### PR TITLE
Fix CTAPHID command dispatch for admin app

### DIFF
--- a/components/admin-app/src/admin.rs
+++ b/components/admin-app/src/admin.rs
@@ -87,6 +87,9 @@ where T: TrussedClient,
 
     fn call(&mut self, command: HidCommand, input_data: &Message, response: &mut Message) -> hid::AppResult {
         match command {
+            HidCommand::Wink => {
+                self.got_wink = true;
+            }
             HidCommand::Vendor(REBOOT) => {
                 R::reboot();
             }
@@ -111,8 +114,12 @@ where T: TrussedClient,
                 // GET VERSION
                 response.extend_from_slice(&self.version.to_be_bytes()).ok();
             }
+            HidCommand::Vendor(UUID) => {
+                // Get UUID
+                response.extend_from_slice(&self.uuid).ok();
+            }
             _ => {
-                self.got_wink = true;
+                return Err(hid::Error::InvalidCommand);
             }
         }
         Ok(())

--- a/runners/lpc55/CHANGELOG.md
+++ b/runners/lpc55/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix CTAPHID command dispatch for the admin application (#8).
+
 # v1.0.0 (2021-10-16)
 
 First stable firmware release with FIDO authenticator.


### PR DESCRIPTION
Previously, the CTAPHID interface of the admin app did not handle the
UUID command and interpreted all unknown commands as Wink commands.
With this patch, we explicitly handle both the Wink and the UUID command
and return an error if any other command is received.

Fixes #8.