### PR TITLE
admin-app: Fix wink command

### DIFF
--- a/runners/lpc55/CHANGELOG.md
+++ b/runners/lpc55/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## Bugfixes
 
 - admin-app: Fix CTAPHID command dispatch ([#8][]).
+- admin-app: Fix CTAPHID wink command ([#9][]).
 - fido-authenticator: Handle pin protocol field in hmac-secret extension data
   to fix the authenticatorGetAssertion command for newer clients ([#14][],
   [fido-authenticator#1][]).
 - fido-authenticator: Signal credential protetection ([fido-authenticator#5][]).
 
 [#8]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/8
+[#9]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/9
 [#14]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/14
 [fido-authenticator#1]: https://github.com/solokeys/fido-authenticator/pull/1
 [fido-authenticator#5]: https://github.com/solokeys/fido-authenticator/pull/5


### PR DESCRIPTION
Previously, the wink command did not have any effect.  With this patch,
we toggle the LED between blue and green if the wink command has been
executed.  The LED blinks until the specified duration (currently 10
seconds) is over or the UI status is changed.

This requires a patched trussed version for this change:
	https://github.com/trussed-dev/trussed/pull/15

Fix #9.