### PR TITLE
Change LED color and device name for provisioner

### DIFF
--- a/runners/lpc55/CHANGELOG.md
+++ b/runners/lpc55/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Features
+
+- Change LED color and device name if provisioner app is enabled.
+
 ## Bugfixes
 
 - admin-app: Fix CTAPHID command dispatch ([#8][]).

--- a/runners/lpc55/board/src/trussed.rs
+++ b/runners/lpc55/board/src/trussed.rs
@@ -55,6 +55,7 @@ RGB: RgbLed,
     buttons: Option<BUTTONS>,
     rgb: Option<RGB>,
     wink: Option<core::ops::Range<Duration>>,
+    provisioner: bool,
 }
 
 impl<BUTTONS, RGB> UserInterface<BUTTONS, RGB>
@@ -62,12 +63,17 @@ where
 BUTTONS: Press + Edge,
 RGB: RgbLed,
 {
-    pub fn new(rtc: Rtc<init_state::Enabled>, _buttons: Option<BUTTONS>, rgb: Option<RGB>) -> Self {
+    pub fn new(
+        rtc: Rtc<init_state::Enabled>,
+        _buttons: Option<BUTTONS>,
+        rgb: Option<RGB>,
+        provisioner: bool,
+    ) -> Self {
         let wink = None;
         #[cfg(not(feature = "no-buttons"))]
-        let ui = Self { rtc, buttons: _buttons, rgb, wink };
+        let ui = Self { rtc, buttons: _buttons, rgb, wink, provisioner };
         #[cfg(feature = "no-buttons")]
-        let ui = Self { rtc, buttons: None, rgb, wink };
+        let ui = Self { rtc, buttons: None, rgb, wink, provisioner };
 
         ui
     }
@@ -111,8 +117,13 @@ RGB: RgbLed,
 
             match status {
                 ui::Status::Idle => {
-                    // green
-                    rgb.set(0x00_ff_02.into());
+                    if self.provisioner {
+                        // white
+                        rgb.set(0xff_ff_ff.into());
+                    } else {
+                        // green
+                        rgb.set(0x00_ff_02.into());
+                    }
                 },
                 ui::Status::Processing => {
                     // teal

--- a/runners/lpc55/src/initializer.rs
+++ b/runners/lpc55/src/initializer.rs
@@ -92,7 +92,11 @@ fn get_product_string(pfr: &mut Pfr<hal::typestates::init_state::Enabled>) -> &'
     // Use a default string
     // NB: If this were to be re-used as card issuer's data in CCID ATR,
     // it would need to be limited or truncated to 13 bytes.
-    "Nitrokey 3"
+    if cfg!(feature = "provisioner-app") {
+        "Nitrokey 3 (provisioner)"
+    } else {
+        "Nitrokey 3"
+    }
 }
 
 #[cfg(feature = "write-undefined-flash")]
@@ -733,7 +737,9 @@ impl Initializer {
 
         let three_buttons = basic_stage.three_buttons.take();
 
-        let mut solobee_interface = board::trussed::UserInterface::new(rtc, three_buttons, rgb);
+        let provisioner = cfg!(feature = "provisioner-app");
+        let mut solobee_interface =
+            board::trussed::UserInterface::new(rtc, three_buttons, rgb, provisioner);
         solobee_interface.set_status(trussed::platform::ui::Status::Idle);
 
         let rng = flash_stage.rng.take().unwrap();


### PR DESCRIPTION
With this patch, we change the idle LED color from green to white and
append a " (provisioner)" suffix to the device name returned in the USB
descriptor if the provisioner app is enabled.  This makes it easier to
track the status of the provisioning process both optically and
programatically.