### PR TITLE
Merge c8ceea9f37a7a820ab2e180d1b3530e102922b60 from solo2

### DIFF
--- a/runners/lpc55/CHANGELOG.md
+++ b/runners/lpc55/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v1.0.0 (2021-10-16)
+
+First stable firmware release with FIDO authenticator.

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "admin-app",
  "apdu-dispatch",

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "admin-app",
  "apdu-dispatch",

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "runner"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Nicolas Stalder <n@stalder.io>", "Conor Patrick <conor@solokeys.com>"]
 edition = "2018"
 resolver = "2"

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "runner"
-version = "0.4.0"
+version = "1.0.0"
 authors = ["Nicolas Stalder <n@stalder.io>", "Conor Patrick <conor@solokeys.com>"]
 edition = "2018"
 resolver = "2"

--- a/runners/lpc55/config/cmpa.toml
+++ b/runners/lpc55/config/cmpa.toml
@@ -7,7 +7,6 @@ vid = 0x20a0
 pid = 0x42dd
 
 [factory-settings.secure-boot-configuration]
-puf-enrollment-disabled = true
 puf-keycode-generation-disabled = true
 dice-computation-disabled = true
 secure-boot-enabled = true

--- a/runners/lpc55/config/commands.bd
+++ b/runners/lpc55/config/commands.bd
@@ -1,8 +1,8 @@
 options {
 	flags = 0x8;
 	buildNumber = 0x1;
-	productVersion = "0.3.1";
-	componentVersion = "0.3.1";
+	productVersion = "0.4.0";
+	componentVersion = "0.4.0";
 	secureBinaryVersion = "2.1";
 }
 
@@ -11,8 +11,8 @@ sources {
 }
 
 section (0) {
-	version_check sec 193;
-	version_check nsec 193;
+	version_check sec 256;
+	version_check nsec 256;
 	erase 0x0..0x93000;
 	load inputFile > 0x0;
 }

--- a/runners/lpc55/config/commands.bd
+++ b/runners/lpc55/config/commands.bd
@@ -1,8 +1,8 @@
 options {
 	flags = 0x8;
 	buildNumber = 0x1;
-	productVersion = "0.4.0";
-	componentVersion = "0.4.0";
+	productVersion = "1.0.0";
+	componentVersion = "1.0.0";
 	secureBinaryVersion = "2.1";
 }
 
@@ -11,8 +11,8 @@ sources {
 }
 
 section (0) {
-	version_check sec 256;
-	version_check nsec 256;
+	version_check sec 4194304;
+	version_check nsec 4194304;
 	erase 0x0..0x93000;
 	load inputFile > 0x0;
 }


### PR DESCRIPTION
This merge pulls in c8ceea9f37a7a820ab2e180d1b3530e102922b60 from solo2 that includes our fix for the admin app CTAPHID dispatch and uses a published version for the `salty` dependency.