### PR TITLE
Release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.0.3 (unreleased)
+# v1.0.3 (2022-04-11)
 
 This release fixes a FIDO authentication issue with Google.
 

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "1.0.3-rc.1"
+version = "1.0.3"
 dependencies = [
  "admin-app",
  "apdu-dispatch",

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "runner"
-version = "1.0.3-rc.1"
+version = "1.0.3"
 authors = ["Nicolas Stalder <n@stalder.io>", "Conor Patrick <conor@solokeys.com>"]
 edition = "2018"
 resolver = "2"


### PR DESCRIPTION
As the tests of the v1.0.3-rc.1 release candidate were successful, this patch releases v1.0.3.