### PR TITLE
Add white LED blink after startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Features
 
-- Change the LED patterns so that the LED is off by default, blinks white during a user confirmation request and blinks blue when winking([#34][])
+- Change the LED patterns so that the LED is off by default, blinks white during a user confirmation request and blinks blue when winking ([#34][])
+- Add a single white LED blink for 0.5 seconds after startup ([#34][])
 
 [#34]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/34
 

--- a/runners/lpc55/board/src/trussed.rs
+++ b/runners/lpc55/board/src/trussed.rs
@@ -49,12 +49,13 @@ RGB: RgbLed,
         rgb: Option<RGB>,
         provisioner: bool,
     ) -> Self {
-        let status = Default::default();
+        let uptime = rtc.uptime();
+        let status = Status::Startup(uptime);
         #[cfg(not(feature = "no-buttons"))]
-        let ui = Self { rtc, buttons: _buttons, status, rgb, provisioner };
+        let mut ui = Self { rtc, buttons: _buttons, status, rgb, provisioner };
         #[cfg(feature = "no-buttons")]
-        let ui = Self { rtc, buttons: None, status, rgb, provisioner };
-
+        let mut ui = Self { rtc, buttons: None, status, rgb, provisioner };
+        ui.refresh_ui(uptime);
         ui
     }
 


### PR DESCRIPTION
Previously, we removed the constant LED light.  To make it clearer when
the NK3 is powered, this patch adds a single white LED blink for 0.5
seconds after startup.  This is consistent with the FIDO2 behavior.