### PR TITLE
Document that OpenSSH key retrieval is working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - Change the LED patterns so that the LED is off by default, blinks white during a user confirmation request and blinks blue when winking ([#34][])
 - Add a single white LED blink for 0.5 seconds after startup ([#34][])
+- Support retrieval of OpenSSH resident keys ([#48][])
 
 [#34]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/34
+[#48]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/48
 
 # v1.0.3 (2022-04-11)
 


### PR DESCRIPTION
According to our tests, retrieval of OpenSSH resident keys is now
working, see #48, so this patch adds this improvement to the changelog.