### PR TITLE
Add custom panic handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Change the LED color to red on panics ([#52][])
+
+[#52]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/52
+
 # v1.0.4 (2022-07-14)
 
 This release improves compatibility with Windows 10 and with OpenSSH and changes the LED patterns.

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1136,12 +1136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "panic-halt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,7 +1317,6 @@ dependencies = [
  "ndef-app",
  "nfc-device",
  "oath-authenticator",
- "panic-halt",
  "piv-authenticator",
  "provisioner-app",
  "rtt-target",

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -55,11 +55,6 @@ nfc-device = {path = "../../components/nfc-device"}
 usbd-ccid = { path = "../../components/usbd-ccid" }
 usbd-ctaphid = { path = "../../components/usbd-ctaphid" }
 
-
-# panic
-panic-halt = "0.2.0"
-# panic-semihosting = "0.5.6"
-
 # storage
 littlefs2 = { version = "0.3.2", features = ["c-stubs"] }
 

--- a/runners/lpc55/board/src/lib.rs
+++ b/runners/lpc55/board/src/lib.rs
@@ -30,7 +30,7 @@ pub use nk3xn as specifics;
 
 pub use specifics::{
     button::ThreeButtons,
-    led::RgbLed,
+    led::{RgbLed, set_panic_led},
 };
 
 pub mod clock_controller;

--- a/runners/lpc55/board/src/lpcxpresso55/led.rs
+++ b/runners/lpc55/board/src/lpcxpresso55/led.rs
@@ -88,3 +88,5 @@ impl rgb_led::RgbLed for RgbLed {
         self.pwm.set_duty(BlueLed::CHANNEL, intensity.into());
     }
 }
+
+pub fn set_panic_led() {}

--- a/runners/lpc55/board/src/nk3xn/led.rs
+++ b/runners/lpc55/board/src/nk3xn/led.rs
@@ -16,7 +16,6 @@ use crate::hal::{
 
 use crate::traits::rgb_led;
 
-
 pub enum Color {
     Red,
     Green,
@@ -90,3 +89,20 @@ impl rgb_led::RgbLed for RgbLed {
     }
 }
 
+pub fn set_panic_led() {
+    unsafe {
+        let mut syscon = hal::Syscon::steal();
+        let mut iocon = hal::Iocon::steal().enabled(&mut syscon);
+        let mut gpio = hal::Gpio::steal().enabled(&mut syscon);
+
+        RedLedPin::steal()
+            .into_gpio_pin(&mut iocon, &mut gpio)
+            .into_output_low();
+        GreenLedPin::steal()
+            .into_gpio_pin(&mut iocon, &mut gpio)
+            .into_output_high();
+        BlueLedPin::steal()
+            .into_gpio_pin(&mut iocon, &mut gpio)
+            .into_output_high();
+    }
+}

--- a/runners/lpc55/board/src/solo2/led.rs
+++ b/runners/lpc55/board/src/solo2/led.rs
@@ -90,3 +90,4 @@ impl rgb_led::RgbLed for RgbLed {
     }
 }
 
+pub fn set_panic_led() {}

--- a/runners/lpc55/src/lib.rs
+++ b/runners/lpc55/src/lib.rs
@@ -1,11 +1,6 @@
 #![no_std]
 include!(concat!(env!("OUT_DIR"), "/build_constants.rs"));
 
-// panic handler, depending on debug/release build
-// BUT: need to run in release anyway, to have USB work
-use panic_halt as _;
-// use panic_semihosting as _;
-
 use usb_device::device::UsbVidPid;
 use board::clock_controller;
 pub use board::hal; // re-export for convenience
@@ -22,6 +17,15 @@ generate_macros!();
 pub mod types;
 pub mod initializer;
 
+#[inline(never)]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    error_now!("{}", _info);
+    board::set_panic_led();
+    loop {
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    }
+}
 
 // Logging
 #[derive(Debug)]


### PR DESCRIPTION
This patch replaces panic-halt with a custom panic handler that shows a
log message (if logging is enabled) and sets the LED to red.

For simplicity, I’m always resetting the LED pins to regular output pins (instead of PWM) and just set them to low or high.  This works in my test cases both before and after PWM is initialized, so I think this should be fine.

@szszszsz Can you re-run the test suite from https://github.com/Nitrokey/nitrokey-3-firmware/issues/49 with this patch and see if the indicator is working as expected?  I was only able to test this with panics that I caused artificially.
@daringer I think it should be possible to integrate this quite easily into the embedded runner and adapt it for nrf52.  Might also make sense to have this in place for the beta tests.  What do you think?