### PR TITLE
Change LED color for winking to white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.0.4 (unreleased)
 
+### Features
+
+- Use white instead of blue as the LED color for winking ([#34][])
+
 ## v1.0.4-rc.3 (2022-07-05)
 
 ### Features

--- a/runners/lpc55/board/src/ui.rs
+++ b/runners/lpc55/board/src/ui.rs
@@ -6,7 +6,6 @@ use crate::traits::rgb_led::Intensities;
 
 const BLACK: Intensities = Intensities { red: 0, green: 0, blue: 0 };
 const RED: Intensities = Intensities { red: u8::MAX, green: 0, blue: 0 };
-const BLUE: Intensities = Intensities { red: 0, green: 0, blue: u8::MAX };
 const TEAL: Intensities = Intensities { red: 0, green: u8::MAX, blue: 0x5a };
 const WHITE: Intensities = Intensities { red: u8::MAX, green: u8::MAX, blue: u8::MAX };
 
@@ -53,7 +52,7 @@ impl Status {
             Self::Processing => LedMode::constant(TEAL),
             Self::WaitingForUserPresence(start) => LedMode::simple_blinking(WHITE, *start),
             Self::Error => LedMode::constant(RED),
-            Self::Winking(range) => LedMode::simple_blinking(BLUE, range.start),
+            Self::Winking(range) => LedMode::simple_blinking(WHITE, range.start),
         }
     }
 }


### PR DESCRIPTION
For consistency with the Nitrokey FIDO2 behavior, we change the LED
color for winking to white (instead of blue).