### PR TITLE
usbd-ccid: Support non-static lifetimes

### DIFF
--- a/components/usbd-ccid/src/class.rs
+++ b/components/usbd-ccid/src/class.rs
@@ -17,19 +17,19 @@ use crate::{
 use usb_device::class_prelude::*;
 type Result<T> = core::result::Result<T, UsbError>;
 
-pub struct Ccid<Bus, I, const N: usize>
+pub struct Ccid<'alloc, Bus, I, const N: usize>
 where
     Bus: 'static + UsbBus,
     I: 'static + Interchange<REQUEST = Vec<u8, N>, RESPONSE = Vec<u8, N>>,
 {
     interface_number: InterfaceNumber,
     string_index: StringIndex,
-    read: EndpointOut<'static, Bus>,
+    read: EndpointOut<'alloc, Bus>,
     // interrupt: EndpointIn<'static, Bus>,
-    pipe: Pipe<Bus, I, N>,
+    pipe: Pipe<'alloc, Bus, I, N>,
 }
 
-impl<Bus, I, const N: usize> Ccid<Bus, I, N>
+impl<'alloc, Bus, I, const N: usize> Ccid<'alloc, Bus, I, N>
 where
     Bus: 'static + UsbBus,
     I: 'static + Interchange<REQUEST = Vec<u8, N>, RESPONSE = Vec<u8, N>>,
@@ -40,7 +40,7 @@ where
     /// and allows personalizing the Answer-to-Reset, for instance by
     /// ASCII-encoding vendor or model information.
     pub fn new(
-        allocator: &'static UsbBusAllocator<Bus>,
+        allocator: &'alloc UsbBusAllocator<Bus>,
         request_pipe: Requester<I>,
         card_issuers_data: Option<&[u8]>,
     ) -> Self {
@@ -83,7 +83,7 @@ where
     }
 }
 
-impl<Bus, I, const N: usize> UsbClass<Bus> for Ccid<Bus, I, N>
+impl<'alloc, Bus, I, const N: usize> UsbClass<Bus> for Ccid<'alloc, Bus, I, N>
 where
     Bus: 'static + UsbBus,
     I: 'static + Interchange<REQUEST = Vec<u8, N>, RESPONSE = Vec<u8, N>>,

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -40,12 +40,12 @@ enum Error {
     CommandNotSupported = 0x00,
 }
 
-pub struct Pipe<Bus, I, const N: usize>
+pub struct Pipe<'alloc, Bus, I, const N: usize>
 where
     Bus: 'static + UsbBus,
     I: 'static + Interchange<REQUEST = Vec<u8, N>, RESPONSE = Vec<u8, N>>,
 {
-    pub(crate) write: EndpointIn<'static, Bus>,
+    pub(crate) write: EndpointIn<'alloc, Bus>,
     // pub(crate) rpc: TransportEndpoint<'rpc>,
     seq: u8,
     state: State,
@@ -63,13 +63,13 @@ where
     atr: Vec<u8, 32>,
 }
 
-impl<Bus, I, const N: usize> Pipe<Bus, I, N>
+impl<'alloc, Bus, I, const N: usize> Pipe<'alloc, Bus, I, N>
 where
     Bus: 'static + UsbBus,
     I: 'static + Interchange<REQUEST = Vec<u8, N>, RESPONSE = Vec<u8, N>>,
 {
     pub(crate) fn new(
-        write: EndpointIn<'static, Bus>,
+        write: EndpointIn<'alloc, Bus>,
         request_pipe: Requester<I>,
         card_issuers_data: Option<&[u8]>,
     ) -> Self {
@@ -137,7 +137,7 @@ where
 }
 
 
-impl<Bus, I, const N: usize> Pipe<Bus, I, N>
+impl<'alloc, Bus, I, const N: usize> Pipe<'alloc, Bus, I, N>
 where
     Bus: 'static + UsbBus,
     I: 'static + Interchange<REQUEST = Vec<u8, N>, RESPONSE = Vec<u8, N>>,

--- a/runners/embedded/src/types/usbnfc.rs
+++ b/runners/embedded/src/types/usbnfc.rs
@@ -2,6 +2,7 @@ use crate::soc::types::Soc as SocT;
 use crate::types::Soc;
 
 pub type CcidClass = usbd_ccid::Ccid<
+    'static,
     <SocT as Soc>::UsbBus,
     apdu_dispatch::interchanges::Contact,
     { apdu_dispatch::interchanges::SIZE },

--- a/runners/lpc55/src/types/usb.rs
+++ b/runners/lpc55/src/types/usb.rs
@@ -7,6 +7,7 @@ pub type EnabledUsbPeripheral = hal::peripherals::usbhs::EnabledUsbhsDevice;
 pub type EnabledUsbPeripheral = hal::peripherals::usbfs::EnabledUsbfsDevice;
 
 pub type CcidClass = usbd_ccid::Ccid<
+    'static,
     UsbBus<EnabledUsbPeripheral>,
     apdu_dispatch::interchanges::Contact,
     {apdu_dispatch::interchanges::SIZE},


### PR DESCRIPTION
Similar to the usb-ctaphid implementation, we don’t need to require a
static lifetime for usb-ccid.  This makes it easier to use it e. g. in
a usbip runner.