### PR TITLE
usb-ccid: Implement abort handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### Bugfixes
 
 - fido-authenticator: Return an error instead of panicking if the credential ID is too long ([#49][])
+- Implement CCID abort handling, fixing an issue where GnuPG would stall for up to a minute on the first operation if a Nitrokey 3 is connected and recognized as a CCID device ([#22][])
 
+[#22]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/22
 [#49]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/49
 
 # v1.1.0 (2022-08-02)


### PR DESCRIPTION
Previously, we just panicked when receiving an abort request.  This
caused a long delay in scdaemon/gnupg when the NK3 was connected.  With
this patch, we add abort handling to usb-ccid to fix this issue.

The implementation is based on Section 5.3.1 of the CCID specification
[0].  The device is expected to send two abort messages, one over the
bulk endpoint and one over the control pipe.  We perform the abort once
we have received both messages.  In the time between receiving the first
and the second message, we reject all incoming messages on the bulk
endpoint.

Fixes https://github.com/Nitrokey/nitrokey-3-firmware/issues/22

[0] https://www.usb.org/sites/default/files/DWG_Smart-Card_CCID_Rev110.pdf