### PR TITLE
Update toolchain to Rust 1.62.1

### DIFF
--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -11,7 +11,6 @@ authors = [
     "Szczepan Zalega <szczepan@nitrokey.com>",
 ]
 edition = "2021"
-rust-version = "1.59.0"
 license = "Apache-2.0 OR MIT"
 
 [lib]

--- a/runners/lpc55/rust-toolchain.toml
+++ b/runners/lpc55/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.59.0"
-components = ["rustfmt", "llvm-tools-preview"]
-targets = ["thumbv8m.main-none-eabi"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.62.1"
+components = ["rustfmt", "llvm-tools-preview"]
+targets = ["thumbv7em-none-eabihf", "thumbv8m.main-none-eabi"]


### PR DESCRIPTION
This PR removes the MSRV from `Cargo.toml` (as we always use latest stable), moves the `rust-toolchain.toml` to the root (so that it applies for all components and runners) and updates the specified Rust toolchain version to the latest stable, 1.62.1.