### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
-# Unreleased
+# v1.1.0 (2022-08-02)
 
-- include the embedded runner, currently only confirmed working for nRF52
-- Change the LED color to red on panics ([#52][])
-- Skip the additional user presence check for the first Get Assertion or Authenticate request within two seconds after boot ([#61][])
+This release adds support for the NRF52 MCU, changes the LED color to red on
+panics and allows the user to skip the additional user presence check for the
+first FIDO2 operation within two seconds after boot.
 
-[#52]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/52
-[#61]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/61
-
-# v1.1.0-rc.1 (2022-07-27)
+## v1.1.0-rc.1 (2022-07-27)
 
 This is the first official nRF52 release(candidate) for the Nitrokey 3A Mini.
 

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "admin-app",
  "apdu-dispatch 0.1.0",

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "runner"
-version = "1.0.4"
+version = "1.1.0"
 authors = [
     "Conor Patrick <conor@solokeys.com>",
     "Nicolas Stalder <n@stalder.io>",

--- a/runners/lpc55/config/commands.bd
+++ b/runners/lpc55/config/commands.bd
@@ -1,8 +1,8 @@
 options {
 	flags = 0x8;
 	buildNumber = 0x1;
-	productVersion = "1.0.4";
-	componentVersion = "1.0.4";
+	productVersion = "1.1.0";
+	componentVersion = "1.1.0";
 	secureBinaryVersion = "2.1";
 }
 
@@ -11,8 +11,8 @@ sources {
 }
 
 section (0) {
-	version_check sec 4194308;
-	version_check nsec 4194308;
+	version_check sec 4194368;
+	version_check nsec 4194368;
 	erase 0x0..0x93000;
 	load inputFile > 0x0;
 }


### PR DESCRIPTION
This release adds support for the NRF52 MCU, changes the LED color to
red on panics and allows the user to skip the additional user presence
check for the first FIDO2 operation within two seconds after boot.