### PR TITLE
Update documentation after nrf52 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,9 @@ The Nitrokey 3 firmware is written in [Rust][].  It uses the [Trussed][] firmwar
 
 ## Documentation
 
-Documentation for users is available in the [Nitrokey 3 section on docs.nitrokey.com][docs.nitrokey.com].
+Documentation for users is available in the [Nitrokey 3 section on docs.nitrokey.com][docs.nitrokey.com].  For developer documentation, see the [`docs`](./docs/index.md) directory.
 
 [docs.nitrokey.com]: https://docs.nitrokey.com/nitrokey3/index.html
-
-This documentation is available for developers and testers:
-- [Quickstart Guide](./docs/quickstart.md): Compiling and flashing the firmware
-- [Troubleshooting Guide](./docs/troubleshooting.md): Solving common development issues
-- [Contributing Guide](./docs/contributing.md): Contributing to this repository
-- [Maintenance Guide](./docs/maintenance.md): Maintaining this repository
-- [Testing Guide](./docs/testing.md): Testing beta firmware versions
-- [Identifiers List](./docs/identifiers.md): List of identifiers used by firmware
 
 ## Dependencies
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Nitrokey 3 Developer Documentation
+
+This documentation is available for developers and testers:
+- [LPC55 Quickstart Guide](./lpc55-quickstart.md): Compiling and flashing the firmware with an LPC55 prototype
+- [Troubleshooting Guide](./troubleshooting.md): Solving common development issues
+- [Contributing Guide](./contributing.md): Contributing to this repository
+- [Maintenance Guide](./maintenance.md): Maintaining this repository
+- [Testing Guide](./testing.md): Testing beta firmware versions
+- [Identifiers List](./identifiers.md): List of identifiers used by firmware

--- a/docs/lpc55-quickstart.md
+++ b/docs/lpc55-quickstart.md
@@ -1,6 +1,6 @@
-# Quickstart Guide
+# LPC55 Quickstart Guide
 
-This guide explains how to compile and flash the firmware on a prototype device.
+This guide explains how to compile and flash the firmware on a LPC55 prototype device.
 
 *See also: [Solo 2 Getting Started](https://hackmd.io/@solokeys/solo2-getting-started)*
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -17,8 +17,8 @@ As we have a `Cargo.lock` file with fixed dependency versions, we don’t automa
 ### Creating Releases
 
 To release a new version of the firmware, perform the following steps:
-1. Update the version counter in `runners/lpc55/Cargo.toml`.
-2. Run the firmware build.
+1. Update the version counter in `runners/lpc55/Cargo.toml` and `runners/embedded/Cargo.toml`.
+2. Run the firmware build for both runners and add the updated `Cargo.lock`.
 3. Update the changelog.
 4. Update the `runners/lpc55/config/commands.bd` file:
    - The `productVersion` and `componentVersion` should be set to the current firmware version.
@@ -26,7 +26,7 @@ To release a new version of the firmware, perform the following steps:
 5. Commit all changed files and create a signed tag with a `v` prefix and the version number, for example `v1.0.0`.
 6. Create a release on GitHub and copy the relevant section from the changelog to the release description.
 
-### Signing Releases
+### Signing Releases (lpc55)
 
 1. Download the `firmware-nk3xn.bin` as built by the CI from the release tag.
 2. Download the [`runners/lpc55/commands.bd`][] for the release tag.


### PR DESCRIPTION
This patch updates the documentation because we now support two chips,
LPC55 and NRF52.