### PR TITLE
fido-authenticator: Update to 4022d6c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+### Bugfixes
+
+- fido-authenticator: Return an error instead of panicking if the credential ID is too long ([#49][])
+
+[#49]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/49
+
 # v1.1.0 (2022-08-02)
 
 This release adds support for the NRF52 MCU, changes the LED color to red on

--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.0"
-source = "git+https://github.com/nitrokey/fido-authenticator?branch=skip-up-timeout#3a3329443562244e97040eefff99bd7566412d2c"
+source = "git+https://github.com/nitrokey/fido-authenticator?branch=main#4022d6ce568c309150248b6ba14b493a8e82a743"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -145,6 +145,6 @@ required-features = ["soc-lpc55"]
 [patch.crates-io]
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal" }
-fido-authenticator = { git = "https://github.com/nitrokey/fido-authenticator", branch = "skip-up-timeout" }
+fido-authenticator = { git = "https://github.com/nitrokey/fido-authenticator", branch = "main" }
 trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
 #trussed = { path = "../../trussed" }

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.0"
-source = "git+https://github.com/nitrokey/fido-authenticator?branch=skip-up-timeout#3a3329443562244e97040eefff99bd7566412d2c"
+source = "git+https://github.com/nitrokey/fido-authenticator?branch=main#4022d6ce568c309150248b6ba14b493a8e82a743"
 dependencies = [
  "apdu-dispatch 0.1.0",
  "ctap-types",

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -106,7 +106,7 @@ log-warn = []
 log-error = []
 
 [patch.crates-io]
-fido-authenticator = { git = "https://github.com/nitrokey/fido-authenticator", branch = "skip-up-timeout" }
+fido-authenticator = { git = "https://github.com/nitrokey/fido-authenticator", branch = "main" }
 trussed = { git = "https://github.com/nitrokey/trussed", branch = "no-ui-status-reset" }
 
 [profile.release]


### PR DESCRIPTION
This patch updates fido-authenticator to 4022d6c from our fork.  This
version returns an error instead of panicking if the credential ID is
too long.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/49