### PR TITLE
Update LPC55 CI builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,13 +74,7 @@ build-lpc55-nk3am:
     - make -C runners/lpc55 ci BOARD=nk3am
     - make -C runners/lpc55 ci BOARD=nk3am PROVISIONER=1
   after_script:
-    - mkdir -p artifacts
-    - cp ./runners/lpc55/firmware-*.bin artifacts
-    - cp ./runners/lpc55/provisioner-*.bin artifacts
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
-  artifacts:
-    paths:
-      - artifacts
 
 build-nrf52-nk3mini:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ build-lpc55-nk3xn:
     - cp ./runners/lpc55/firmware-nk3xn.bin artifacts/firmware-nk3xn-lpc55-$VERSION.bin
     - cp ./runners/lpc55/provisioner-nk3xn.bin artifacts/provisioner-nk3xn-lpc55-$VERSION.bin
     - cp ./commands.bd artifacts
-    - sha256sum artifacts/* | tee artifacts/sha256sum
+    - cd artifacts ; sha256sum * | tee sha256sum ; cd ..
     - git archive --format zip --output artifacts/nitrokey-3-firmware.zip --prefix nitrokey-3-firmware/ HEAD
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,8 +51,9 @@ build-lpc55-nk3xn:
     - make -C runners/lpc55 ci BOARD=nk3xn PROVISIONER=1
   after_script:
     - mkdir -p artifacts
-    - cp ./runners/lpc55/firmware-*.bin artifacts
-    - cp ./runners/lpc55/provisioner-*.bin artifacts
+    - export VERSION=`git describe --always`
+    - cp ./runners/lpc55/firmware-nk3xn.bin artifacts/firmware-nk3xn-lpc55-$VERSION.bin
+    - cp ./runners/lpc55/provisioner-nk3xn.bin artifacts/provisioner-nk3xn-lpc55-$VERSION.bin
     - cp ./commands.bd artifacts
     - sha256sum artifacts/* | tee artifacts/sha256sum
     - git archive --format zip --output artifacts/nitrokey-3-firmware.zip --prefix nitrokey-3-firmware/ HEAD


### PR DESCRIPTION
This PR updates the LPC55 CI builds:
- remove binaries for NK3AM as not used at the moment
- rename binaries to include the version number
- remove `artifacts` prefix from `sha256sum` as all files are placed in the same directory