### PR TITLE
fix incorrect version for fido-authenticator

### DIFF
--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -30,7 +30,7 @@ ctap-types = "0.1"
 
 ### client apps
 admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }
-fido-authenticator = { version = "0.1", features = ["dispatch"], optional = true }
+fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../../components/ndef-app", optional = true }
 oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", features = ["apdu-dispatch"], optional = true }
 provisioner-app = { path = "../../components/provisioner-app", optional = true }

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -36,7 +36,7 @@ admin-app = { version = "0.1", optional = true }
 apdu-dispatch = "0.1"
 ctaphid-dispatch = "0.1"
 ctap-types = "0.1"
-fido-authenticator = { version = "0.1", features = ["dispatch"], optional = true }
+fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 oath-authenticator = { version = "0.1", features = ["apdu-dispatch"], optional = true }
 trussed = "0.1"
 


### PR DESCRIPTION
* it was `0.1` should be `0.1.1` after removing the patch from the Nitrokey github repository
* `ssh-keygen` (output) errors occur w/o this and probably other issues