### PR TITLE
Enable locked-state (APPROTECT) read-out for nRF52

### DIFF
--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-runner-lib"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "admin-app",
  "apdu-dispatch",

--- a/runners/embedded/src/soc_nrf52840/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/mod.rs
@@ -70,6 +70,12 @@ pub fn init_bootup(
     if !uicr.regout0.read().vout().is_3v3() {
         error!("REGOUT0 is not at 3.3V - external flash will fail!");
     }
+
+    if uicr.approtect.read().pall().is_enabled() {
+        info!("UICR APPROTECT is ENABLED!");
+    } else {
+        info!("UICR APPROTECT is DISABLED!");
+    };
 }
 
 pub fn init_internal_flash(nvmc: nrf52840_pac::NVMC) -> flash::FlashStorage {

--- a/runners/embedded/src/soc_nrf52840/types.rs
+++ b/runners/embedded/src/soc_nrf52840/types.rs
@@ -96,7 +96,8 @@ impl admin_app::Reboot for Reboot {
         SCB::sys_reset()
     }
     fn locked() -> bool {
-        false
+        let pac = unsafe { nrf52840_pac::Peripherals::steal() };
+        pac.UICR.approtect.read().pall().is_enabled()
     }
 }
 

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -149,7 +149,6 @@ impl TrussedApp for OathApp {
     }
 }
 
-
 #[cfg(feature = "admin-app")]
 impl TrussedApp for AdminApp {
     const CLIENT_ID: &'static [u8] = b"admin\0";


### PR DESCRIPTION
... and tiny newline cargo fmt fix