### PR TITLE
lpc55: Add external flash check

### DIFF
--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1252,6 +1252,7 @@ dependencies = [
  "delog",
  "fido-authenticator",
  "fm11nc08",
+ "generic-array 0.14.6",
  "heapless 0.6.1",
  "interchange",
  "littlefs2",
@@ -1262,6 +1263,7 @@ dependencies = [
  "oath-authenticator",
  "provisioner-app",
  "rtt-target",
+ "spi-memory",
  "trussed",
  "usb-device",
  "usbd-ccid",
@@ -1424,6 +1426,16 @@ checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest",
  "rand_core",
+]
+
+[[package]]
+name = "spi-memory"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94caf9e6bd5673e05be1a3f4113b85cdc7976a1ac8bc2763731ae5a4acee4a9"
+dependencies = [
+ "bitflags",
+ "embedded-hal",
 ]
 
 [[package]]

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -31,6 +31,8 @@ rtt-target = { version = "0.3", optional = true, features = ["cortex-m"] }
 usb-device = "0.2.3"
 # usbd-hid = { version = "0.4.5", optional = true }
 usbd-serial = "0.1.0"
+spi-memory = "0.2.0"
+generic-array = "0.14"
 
 admin-app = { version = "0.1", optional = true }
 apdu-dispatch = "0.1"

--- a/runners/lpc55/board/src/lib.rs
+++ b/runners/lpc55/board/src/lib.rs
@@ -35,6 +35,7 @@ pub use specifics::{
 
 pub mod clock_controller;
 pub mod nfc;
+pub mod spi;
 pub mod trussed;
 pub mod ui;
 

--- a/runners/lpc55/board/src/spi.rs
+++ b/runners/lpc55/board/src/spi.rs
@@ -1,0 +1,69 @@
+use crate::hal::{
+    self,
+    drivers::{
+        pins::{self, Pin},
+        SpiMaster,
+    },
+    Enabled,
+    peripherals::flexcomm::Spi0,
+    time::RateExtensions,
+    typestates::{
+        pin::{
+            self,
+            flexcomm::NoPio,
+        },
+    },
+};
+
+pub type SckPin = pins::Pio0_28;
+pub type MosiPin = pins::Pio0_24;
+pub type MisoPin = pins::Pio0_25;
+
+pub type Spi = SpiMaster<
+    SckPin,
+    MosiPin,
+    MisoPin,
+    NoPio,
+    Spi0,
+    (
+        Pin<SckPin, pin::state::Special<pin::function::FC0_SCK>>,
+        Pin<MosiPin, pin::state::Special<pin::function::FC0_RXD_SDA_MOSI_DATA>>,
+        Pin<MisoPin, pin::state::Special<pin::function::FC0_TXD_SCL_MISO_WS>>,
+        pin::flexcomm::NoCs,
+    ),
+>;
+
+pub fn init(
+    spi: Spi0<Enabled>,
+    iocon: &mut hal::Iocon<Enabled>,
+) -> Spi {
+    let sck = SckPin::take().unwrap().into_spi0_sck_pin(iocon);
+    let mosi = MosiPin::take().unwrap().into_spi0_mosi_pin(iocon);
+    let miso = MisoPin::take().unwrap().into_spi0_miso_pin(iocon);
+    let spi_mode = hal::traits::wg::spi::Mode {
+        polarity: hal::traits::wg::spi::Polarity::IdleLow,
+        // phase: hal::traits::wg::spi::Phase::CaptureOnSecondTransition,
+        phase: hal::traits::wg::spi::Phase::CaptureOnFirstTransition,
+    };
+    SpiMaster::new(
+        spi,
+        (sck, mosi, miso, hal::typestates::pin::flexcomm::NoCs),
+        // 2_000_000u32.Hz(),
+        1_000_000u32.Hz(),
+        spi_mode,
+    )
+}
+
+pub fn reconfigure(spi: Spi) -> Spi {
+    let (spi, pins) = spi.release();
+    let spi_mode = hal::traits::wg::spi::Mode {
+        polarity: hal::traits::wg::spi::Polarity::IdleLow,
+        phase: hal::traits::wg::spi::Phase::CaptureOnSecondTransition,
+    };
+    SpiMaster::new(
+        spi,
+        pins,
+        2_000_000u32.Hz(),
+        spi_mode,
+    )
+}

--- a/runners/lpc55/src/initializer.rs
+++ b/runners/lpc55/src/initializer.rs
@@ -21,6 +21,7 @@ use hal::peripherals::pfr::Pfr;
 use hal::typestates::init_state::Unknown;
 use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
 
+use littlefs2::fs::Filesystem;
 use interchange::Interchange;
 use trussed::platform::UserInterface;
 
@@ -228,19 +229,16 @@ impl Initializer {
 
     fn try_enable_fm11nc08 <T: Ctimer<hal::Enabled>>(
         &mut self,
-        clocks: &Clocks,
         iocon: &mut hal::Iocon<hal::Enabled>,
         gpio: &mut hal::Gpio<hal::Enabled>,
         nfc_irq: hal::Pin<board::nfc::NfcIrqPin, Gpio<direction::Input>>,
         delay_timer: &mut Timer<T>,
 
-        flexcomm0: hal::peripherals::flexcomm::Flexcomm0<Unknown>,
+        spi: board::spi::Spi,
         inputmux: hal::peripherals::inputmux::InputMux<Unknown>,
         pint: hal::peripherals::pint::Pint<Unknown>,
     ) -> Option<board::nfc::NfcChip> {
-        let token = clocks.support_flexcomm_token().unwrap();
         let syscon = &mut self.syscon;
-        let spi = flexcomm0.enabled_as_spi(syscon, &token);
 
         // TODO save these so they can be released later
         let mut mux = inputmux.enabled(syscon);
@@ -411,19 +409,18 @@ impl Initializer {
     pub fn initialize_nfc(&mut self,
         clock_stage: &mut stages::Clock,
         basic_stage: &mut stages::Basic,
-        flexcomm0: hal::peripherals::flexcomm::Flexcomm0<Unknown>,
+        spi: board::spi::Spi,
         mux: hal::peripherals::inputmux::InputMux<Unknown>,
         pint: hal::peripherals::pint::Pint<Unknown>,
     ) -> stages::Nfc {
 
         let nfc_chip = if self.config.nfc_enabled {
             self.try_enable_fm11nc08(
-                &clock_stage.clocks,
                 &mut clock_stage.iocon,
                 &mut clock_stage.gpio,
                 clock_stage.nfc_irq.take().unwrap(),
                 &mut basic_stage.delay_timer,
-                flexcomm0,
+                spi,
                 mux,
                 pint,
             )
@@ -610,7 +607,7 @@ impl Initializer {
         nfc_stage: &mut stages::Nfc,
         flash_stage: &mut stages::Flash,
     ) -> stages::Filesystem {
-        use littlefs2::fs::{Allocation, Filesystem};
+        use littlefs2::fs::Allocation;
         use types::{ExternalStorage, VolatileStorage};
 
         let syscon = &mut self.syscon;
@@ -783,6 +780,7 @@ impl Initializer {
         basic_stage: &mut stages::Basic,
         clock_stage: &mut stages::Clock,
         flexcomm5: hal::peripherals::flexcomm::Flexcomm5<Unknown>,
+        spi: &mut board::spi::Spi,
     ) {
         // SE050 check
         let _enabled = pins::Pio1_26::take()
@@ -821,7 +819,40 @@ impl Initializer {
             panic!("Unexpected RESYNC response: {:?}", response);
         }
 
+        // External Flash checks
+        let spi = types::SpiMut(spi);
+        let flash_cs = pins::Pio0_13::take()
+            .unwrap()
+            .into_gpio_pin(&mut clock_stage.iocon, &mut clock_stage.gpio)
+            .into_output_high();
+        let _power = pins::Pio0_21::take()
+            .unwrap()
+            .into_gpio_pin(&mut clock_stage.iocon, &mut clock_stage.gpio)
+            .into_output_high();
+
+        basic_stage.delay_timer.start(200_000.microseconds());
+        nb::block!(basic_stage.delay_timer.wait()).ok();
+
+        let mut flash = types::ExtFlashStorage::new(spi, flash_cs);
+        if !Filesystem::is_mountable(&mut flash) {
+            debug_now!("external filesystem not mountable, trying to format");
+            Filesystem::format(&mut flash).expect("failed to format external filesystem");
+        }
+        if !Filesystem::is_mountable(&mut flash) {
+            panic!("filesystem not mountable after format");
+        }
+
         info_now!("hardware checks successful");
+    }
+
+    fn setup_spi(
+        &mut self,
+        clock_stage: &mut stages::Clock,
+        flexcomm0: hal::peripherals::flexcomm::Flexcomm0<Unknown>,
+    ) -> board::spi::Spi {
+        let token = clock_stage.clocks.support_flexcomm_token().unwrap();
+        let spi = flexcomm0.enabled_as_spi(&mut self.syscon, &token);
+        board::spi::init(spi, &mut clock_stage.iocon)
     }
 
     #[inline(never)]
@@ -851,7 +882,7 @@ impl Initializer {
 
         rtc: hal::peripherals::rtc::Rtc<Unknown>,
 
-        flexcomm5: hal::peripherals::flexcomm::Flexcomm5<Unknown>,
+        _flexcomm5: hal::peripherals::flexcomm::Flexcomm5<Unknown>,
     ) -> stages::All {
 
         let mut clock_stage = self.initialize_clocks(iocon, gpio,);
@@ -866,10 +897,16 @@ impl Initializer {
             perf_timer,
             pfr,
         );
+        let mut spi = self.setup_spi(&mut clock_stage, flexcomm0);
+
+        #[cfg(feature = "provisioner-app")]
+        self.run_hardware_checks(&mut basic_stage, &mut clock_stage, _flexcomm5, &mut spi);
+
+        let spi = board::spi::reconfigure(spi);
         let mut nfc_stage = self.initialize_nfc(
             &mut clock_stage,
             &mut basic_stage,
-            flexcomm0,
+            spi,
             mux,
             pint
         );
@@ -902,9 +939,6 @@ impl Initializer {
         );
 
         self.perform_data_migrations(&basic_stage, &filesystem_stage);
-
-        #[cfg(feature = "provisioner-app")]
-        self.run_hardware_checks(&mut basic_stage, &mut clock_stage, flexcomm5);
 
         stages::All {
             trussed: trussed,

--- a/runners/lpc55/src/types.rs
+++ b/runners/lpc55/src/types.rs
@@ -1,6 +1,6 @@
 include!(concat!(env!("OUT_DIR"), "/build_constants.rs"));
 
-use core::time::Duration;
+use core::{cell::RefCell, time::Duration};
 
 use crate::hal;
 use hal::drivers::timer;
@@ -9,6 +9,8 @@ use littlefs2::{const_ram_storage, consts};
 use trussed::types::{LfsResult, LfsStorage};
 use trussed::{platform, store};
 use hal::peripherals::ctimer;
+use hal::traits::wg::{blocking::spi::Transfer, digital::v2::OutputPin};
+use spi_memory::{BlockDevice, Read};
 
 #[cfg(feature = "no-encrypted-storage")]
 use hal::littlefs2_filesystem;
@@ -58,6 +60,137 @@ store!(Store,
     External: ExternalStorage,
     Volatile: VolatileStorage
 );
+
+struct FlashProperties {
+	size: usize,
+	jedec: [u8; 3],
+	_cont: u8,
+}
+
+const FLASH_PROPERTIES: FlashProperties = FlashProperties {
+	size: 0x20_0000,
+	jedec: [0xc8, 0x40, 0x15],
+	_cont: 0 /* should be 6, but device doesn't report those */
+};
+
+pub struct ExtFlashStorage<SPI, CS> where SPI: Transfer<u8>, CS: OutputPin {
+	s25flash: RefCell<spi_memory::series25::Flash<SPI, CS>>,
+}
+
+impl<SPI, CS> littlefs2::driver::Storage for ExtFlashStorage<SPI, CS> where SPI: Transfer<u8>, CS: OutputPin {
+
+	const BLOCK_SIZE: usize = 4096;
+	const READ_SIZE: usize = 4;
+	const WRITE_SIZE: usize = 256;
+	const BLOCK_COUNT: usize = FLASH_PROPERTIES.size / Self::BLOCK_SIZE;
+	type CACHE_SIZE = generic_array::typenum::U256;
+	type LOOKAHEADWORDS_SIZE = generic_array::typenum::U1;
+
+	fn read(&self, off: usize, buf: &mut [u8]) -> Result<usize, littlefs2::io::Error> {
+		trace!("EFr {:x} {:x}", off, buf.len());
+		if buf.len() == 0 { return Ok(0); }
+		if buf.len() > FLASH_PROPERTIES.size ||
+			off > FLASH_PROPERTIES.size - buf.len() {
+			return Err(littlefs2::io::Error::Unknown(0x6578_7046));
+		}
+        let mut flash = self.s25flash.borrow_mut();
+		let r = flash.read(off as u32, buf);
+		if r.is_ok() { trace!("r >>> {}", delog::hex_str!(&buf[0..4])); }
+		map_result(r, buf.len())
+	}
+
+	fn write(&mut self, off: usize, data: &[u8]) -> Result<usize, littlefs2::io::Error> {
+		trace!("EFw {:x} {:x}", off, data.len());
+		trace!("w >>> {}", delog::hex_str!(&data[0..4]));
+        const CHUNK_SIZE: usize = 256;
+        let mut buf = [0; CHUNK_SIZE];
+        let mut off = off as u32;
+        let mut flash = self.s25flash.borrow_mut();
+        for chunk in data.chunks(CHUNK_SIZE) {
+            let buf = &mut buf[..chunk.len()];
+            buf.copy_from_slice(chunk);
+            flash
+                .write_bytes(off, buf)
+                .map_err(|_| littlefs2::io::Error::Unknown(0x6565_6565))?;
+            off += CHUNK_SIZE as u32;
+        }
+        Ok(data.len())
+	}
+
+	fn erase(&mut self, off: usize, len: usize) -> Result<usize, littlefs2::io::Error> {
+		trace!("EFe {:x} {:x}", off, len);
+		if len > FLASH_PROPERTIES.size ||
+			off > FLASH_PROPERTIES.size - len {
+			return Err(littlefs2::io::Error::Unknown(0x6578_7046));
+		}
+        let result = self.s25flash.borrow_mut().erase_sectors(off as u32, len / 256);
+		map_result(result, len)
+	}
+}
+
+fn map_result<SPI, CS>(r: Result<(), spi_memory::Error<SPI, CS>>, len: usize)
+			-> Result<usize, littlefs2::io::Error>
+			where SPI: Transfer<u8>, CS: OutputPin {
+	match r {
+		Ok(()) => Ok(len),
+		Err(_) => Err(littlefs2::io::Error::Unknown(0x6565_6565))
+	}
+}
+
+impl<SPI, CS> ExtFlashStorage<SPI, CS> where SPI: Transfer<u8>, CS: OutputPin {
+
+	fn raw_command(spim: &mut SPI, cs: &mut CS, buf: &mut [u8]) {
+		cs.set_low().ok().unwrap();
+		spim.transfer(buf).ok().unwrap();
+		cs.set_high().ok().unwrap();
+	}
+
+	pub fn new(mut spim: SPI, mut cs: CS) -> Self {
+		Self::selftest(&mut spim, &mut cs);
+
+		let mut flash = spi_memory::series25::Flash::init(spim, cs).ok().unwrap();
+		let jedec_id = flash.read_jedec_id().ok().unwrap();
+		info!("Ext. Flash: {:?}", jedec_id);
+		if jedec_id.mfr_code() != FLASH_PROPERTIES.jedec[0] ||
+			jedec_id.device_id() != &FLASH_PROPERTIES.jedec[1..] {
+			panic!("Unknown Ext. Flash!");
+		}
+        let s25flash = RefCell::new(flash);
+
+		Self { s25flash }
+	}
+
+	pub fn selftest(spim: &mut SPI, cs: &mut CS) {
+		macro_rules! doraw {
+			($buf:expr, $len:expr, $str:expr) => {
+			let mut buf: [u8; $len] = $buf;
+			Self::raw_command(spim, cs, &mut buf);
+			trace!($str, delog::hex_str!(&buf[1..]));
+		}}
+
+		doraw!([0x9f, 0, 0, 0], 4, "JEDEC {}");
+		doraw!([0x05, 0], 2, "RDSRl {}");
+		doraw!([0x35, 0], 2, "RDSRh {}");
+	}
+
+	pub fn size(&self) -> usize {
+		FLASH_PROPERTIES.size
+	}
+
+	pub fn erase_chip(&mut self) -> Result<usize, littlefs2::io::Error> {
+		map_result(self.s25flash.borrow_mut().erase_all(), FLASH_PROPERTIES.size)
+	}
+}
+
+pub struct SpiMut<'a, SPI: Transfer<u8>>(pub &'a mut SPI);
+
+impl<'a, SPI: Transfer<u8>> Transfer<u8> for SpiMut<'a, SPI> {
+    type Error = SPI::Error;
+
+    fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+        self.0.transfer(words)
+    }
+}
 
 pub type ThreeButtons = board::ThreeButtons;
 pub type RgbLed = board::RgbLed;


### PR DESCRIPTION
This patch adds a check that verifies that the external flash storage can be accessed and formatted with a littlefs2 filesystem.