### PR TITLE
oath-authenticator over CTAPHID

### DIFF
--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
  "trussed",
  "usb-device",
  "usbd-ccid",
- "usbd-ctaphid",
+ "usbd-ctaphid 0.0.0-unreleased",
  "usbd-serial",
 ]
 
@@ -1234,10 +1234,11 @@ dependencies = [
 
 [[package]]
 name = "oath-authenticator"
-version = "0.1.0"
-source = "git+https://github.com/trussed-dev/oath-authenticator#4b680a3805aa9af31c24415fe39e1765638ee99a"
+version = "0.3.0"
+source = "git+https://github.com/Nitrokey/oath-authenticator.git?rev=0.3.0#2cbcfb54eec8dfe24920054c3cdc64d5d27c2021"
 dependencies = [
  "apdu-dispatch",
+ "ctaphid-dispatch",
  "delog",
  "flexiber",
  "heapless 0.7.16",
@@ -1247,6 +1248,7 @@ dependencies = [
  "iso7816",
  "serde",
  "trussed",
+ "usbd-ctaphid 0.0.0-unreleased (git+https://github.com/Nitrokey/nitrokey-3-firmware)",
 ]
 
 [[package]]
@@ -1835,6 +1837,22 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.0.0-unreleased"
+dependencies = [
+ "ctap-types",
+ "ctaphid-dispatch",
+ "delog",
+ "embedded-time",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "interchange",
+ "serde",
+ "usb-device",
+]
+
+[[package]]
+name = "usbd-ctaphid"
+version = "0.0.0-unreleased"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#06238fd8538417b3cf1080924247f51c9a575298"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -32,7 +32,7 @@ ctap-types = "0.1"
 admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../../components/ndef-app", optional = true }
-oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", features = ["apdu-dispatch"], optional = true }
+oath-authenticator = { version = "0.3", features = ["apdu-dispatch", "ctaphid"], optional = true }
 provisioner-app = { path = "../../components/provisioner-app", optional = true }
 
 ### trussed core
@@ -144,3 +144,4 @@ littlefs2 = { git = "https://github.com/Nitrokey/littlefs2" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal" }
 trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
 #trussed = { path = "../../trussed" }
+oath-authenticator = { git = "https://github.com/Nitrokey/oath-authenticator.git",  rev = "0.3.0" }

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -283,6 +283,8 @@ impl Apps {
             &mut self.fido,
             #[cfg(feature = "admin-app")]
             &mut self.admin,
+            #[cfg(feature = "oath-authenticator")]
+            &mut self.oath,
         ])
     }
 }

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1037,11 +1037,11 @@ dependencies = [
 
 [[package]]
 name = "oath-authenticator"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11470bb97635a0d1943211c7b9cd473ecee002342480e8fc7347beba27f38243"
+version = "0.2.0"
+source = "git+https://github.com/Nitrokey/oath-authenticator.git?branch=reverse-hotp#7b7d6e9c537709f51eb2854abad53fd6453cb102"
 dependencies = [
  "apdu-dispatch",
+ "ctaphid-dispatch",
  "delog",
  "flexiber",
  "heapless 0.7.16",
@@ -1051,6 +1051,7 @@ dependencies = [
  "iso7816",
  "serde",
  "trussed",
+ "usbd-ctaphid 0.0.0-unreleased (git+https://github.com/Nitrokey/nitrokey-3-firmware)",
 ]
 
 [[package]]
@@ -1265,7 +1266,7 @@ dependencies = [
  "trussed",
  "usb-device",
  "usbd-ccid",
- "usbd-ctaphid",
+ "usbd-ctaphid 0.0.0-unreleased",
  "usbd-serial",
 ]
 
@@ -1561,6 +1562,22 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.0.0-unreleased"
+dependencies = [
+ "ctap-types",
+ "ctaphid-dispatch",
+ "delog",
+ "embedded-time",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "interchange",
+ "serde",
+ "usb-device",
+]
+
+[[package]]
+name = "usbd-ctaphid"
+version = "0.0.0-unreleased"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#9fa6c1b2af6c468911dcc4f5acc445d8587be6d2"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/runners/lpc55/Cargo.lock
+++ b/runners/lpc55/Cargo.lock
@@ -1037,8 +1037,8 @@ dependencies = [
 
 [[package]]
 name = "oath-authenticator"
-version = "0.2.0"
-source = "git+https://github.com/Nitrokey/oath-authenticator.git?branch=reverse-hotp#7b7d6e9c537709f51eb2854abad53fd6453cb102"
+version = "0.3.0"
+source = "git+https://github.com/Nitrokey/oath-authenticator.git?rev=0.3.0#2cbcfb54eec8dfe24920054c3cdc64d5d27c2021"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.0.0-unreleased"
-source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#9fa6c1b2af6c468911dcc4f5acc445d8587be6d2"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#06238fd8538417b3cf1080924247f51c9a575298"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -37,7 +37,7 @@ apdu-dispatch = "0.1"
 ctaphid-dispatch = "0.1"
 ctap-types = "0.1"
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
-oath-authenticator = { version = "0.1", features = ["apdu-dispatch"], optional = true }
+oath-authenticator = { version = "0.2", features = ["apdu-dispatch", "ctaphid"], optional = true }
 trussed = "0.1"
 
 # board
@@ -56,7 +56,7 @@ usbd-ctaphid = { path = "../../components/usbd-ctaphid" }
 littlefs2 = { version = "0.3.2", features = ["c-stubs"] }
 
 [features]
-default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
+default = ["admin-app", "fido-authenticator", "ndef-app", "oath-authenticator", "trussed/clients-3"]
 
 develop = ["oath-authenticator", "no-encrypted-storage", "no-buttons", "no-reset-time-window", "trussed/clients-3"]
 develop-provisioner = ["oath-authenticator", "no-encrypted-storage", "no-buttons", "no-reset-time-window", "provisioner-app", "trussed/clients-4"]
@@ -105,6 +105,7 @@ log-error = []
 
 [patch.crates-io]
 trussed = { git = "https://github.com/nitrokey/trussed", branch = "no-ui-status-reset" }
+oath-authenticator = { git = "https://github.com/Nitrokey/oath-authenticator.git",  branch = "reverse-hotp" }
 
 [profile.release]
 codegen-units = 1

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -37,7 +37,7 @@ apdu-dispatch = "0.1"
 ctaphid-dispatch = "0.1"
 ctap-types = "0.1"
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
-oath-authenticator = { version = "0.2", features = ["apdu-dispatch", "ctaphid"], optional = true }
+oath-authenticator = { version = "0.3", features = ["apdu-dispatch", "ctaphid"], optional = true }
 trussed = "0.1"
 
 # board
@@ -105,7 +105,7 @@ log-error = []
 
 [patch.crates-io]
 trussed = { git = "https://github.com/nitrokey/trussed", branch = "no-ui-status-reset" }
-oath-authenticator = { git = "https://github.com/Nitrokey/oath-authenticator.git",  branch = "reverse-hotp" }
+oath-authenticator = { git = "https://github.com/Nitrokey/oath-authenticator.git",  rev = "0.3.0" }
 
 [profile.release]
 codegen-units = 1

--- a/runners/lpc55/src/types.rs
+++ b/runners/lpc55/src/types.rs
@@ -274,6 +274,8 @@ impl Apps {
             &mut self.fido,
             #[cfg(feature = "admin-app")]
             &mut self.admin,
+            #[cfg(feature = "oath-authenticator")]
+            &mut self.oath,
         ])
     }
 }


### PR DESCRIPTION
Support oath-authenticator over CTAPHID.

To do:
- [x] rebase on main
- [x] check dependencies, remove branches, use git tags
- [x] builds for lpc55 runner
- [x] builds for the embedded runner
