### PR TITLE
Add alpha feature to embedded runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,12 +46,16 @@ build-lpc55-nk3xn:
     - docker
   stage: build
   script:
+    - rustup target add thumbv8m.main-none-eabi
+    - rustup +nightly-2022-11-13 target add thumbv8m.main-none-eabi
     - mkdir -p artifacts
     - export VERSION=`git describe --always`
     - apt-get install -y python3 python3-toml
     - make commands.bd
     - make -C runners/embedded build-nk3xn FEATURES=provisioner
     - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/firmware-nk3xn-lpc55-$VERSION.bin
+    - make -C runners/embedded build-nk3xn FEATURES=alpha
+    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/alpha-nk3xn-lpc55-$VERSION.bin
     - make -C runners/embedded build-nk3xn
     - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/provisioner-nk3xn-lpc55-$VERSION.bin
   after_script:
@@ -73,11 +77,16 @@ build-nrf52-nk3mini:
   script:
     - apt-get install -y python3 python3-toml
     - rustup target add thumbv7em-none-eabihf
+    - rustup +nightly-2022-11-13 target add thumbv7em-none-eabihf
     - mkdir -p artifacts
     - make -C runners/embedded build-nk3am.bl FEATURES=provisioner
     - cp runners/embedded/artifacts/*.bin artifacts/provisioner-nk3am-nrf52.bin
     - cp runners/embedded/artifacts/*.ihex artifacts/provisioner-nk3am-nrf52.ihex
     - make -C runners/embedded clean-nk3am.bl FEATURES=provisioner
+    - make -C runners/embedded build-nk3am.bl FEATURES=alpha
+    - cp runners/embedded/artifacts/*.bin artifacts/alpha-nk3am-nrf52.bin
+    - cp runners/embedded/artifacts/*.ihex artifacts/alpha-nk3am-nrf52.ihex
+    - make -C runners/embedded clean-nk3am.bl FEATURES=alpha
     - make -C runners/embedded build-nk3am.bl FEATURES=develop
     - cp runners/embedded/artifacts/*.bin artifacts/develop-nk3am-nrf52.bin
     - cp runners/embedded/artifacts/*.ihex artifacts/develop-nk3am-nrf52.ihex

--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -48,8 +48,7 @@ dependencies = [
 [[package]]
 name = "apdu-dispatch"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bee13295997ab0b4809e5bf25bfd27844c93cf901220d643f7c0c53f288258"
+source = "git+https://github.com/robin-nitrokey/apdu-dispatch?branch=max-response-len#47c65f20f93e9215ad0afd6d960487f58676c2ea"
 dependencies = [
  "delog",
  "heapless 0.7.16",
@@ -273,6 +272,7 @@ checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -622,6 +622,7 @@ dependencies = [
  "nrf52840-hal",
  "nrf52840-pac",
  "oath-authenticator",
+ "opcard",
  "provisioner-app",
  "rand_core",
  "rtt-target",
@@ -928,8 +929,7 @@ dependencies = [
 [[package]]
 name = "interchange"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310d743c23f798f10d5ba2f77fdd3eff06aaf2d8f8b9d78beba7fb1167f4ccbf"
+source = "git+https://github.com/trussed-dev/interchange.git?rev=fe5633466640e1e9a8c06d9b5dd1d0af08c272af#fe5633466640e1e9a8c06d9b5dd1d0af08c272af"
 
 [[package]]
 name = "iso7816"
@@ -960,6 +960,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "littlefs2"
 version = "0.3.2"
 source = "git+https://github.com/Nitrokey/littlefs2#23b9e5028ce0b2ff77c78545c44ac75da9a79acb"
@@ -977,8 +987,7 @@ dependencies = [
 [[package]]
 name = "littlefs2-sys"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac150caec8a056e1248754f738c2330e578469093a522cf1afe30bbe545b90b"
+source = "git+https://github.com/sosthene-nitrokey/littlefs2-sys.git?branch=bindgen-runtime-feature#8ebb88edc59c0cf9503a9b9377065a0f74440448"
 dependencies = [
  "bindgen",
  "cc",
@@ -1284,6 +1293,24 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opcard"
+version = "0.1.0"
+source = "git+https://github.com/Nitrokey/opcard-rs?tag=v0.1.0#59f1e968b1a76915f3a6c0ebbab43bf3a09b07f8"
+dependencies = [
+ "apdu-dispatch",
+ "delog",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "hex-literal",
+ "iso7816",
+ "log",
+ "serde",
+ "serde_repr",
+ "subtle",
+ "trussed",
+]
 
 [[package]]
 name = "p256"
@@ -1777,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed?branch=main#3da56d8e41b9de64b852ed2bdcfd623118b09c3d"
+source = "git+https://github.com/trussed-dev/trussed?rev=6de826f3bcbef247e55fd890d80d9ed6ce9f0abc#6de826f3bcbef247e55fd890d80d9ed6ce9f0abc"
 dependencies = [
  "aes",
  "bitflags",
@@ -1941,6 +1968,28 @@ checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -34,6 +34,7 @@ admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../../components/ndef-app", optional = true }
 oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", features = ["apdu-dispatch"], optional = true }
+opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v0.1.0", features = ["apdu-dispatch", "delog"], optional = true }
 provisioner-app = { path = "../../components/provisioner-app", optional = true }
 
 ### trussed core
@@ -71,13 +72,13 @@ default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
 
 release = []
 
-alpha = []
+alpha = ["opcard", "trussed/clients-3"]
 
 complete = ["oath-authenticator", # "provisioner-app",
 			"fido-authenticator/disable-reset-time-window",
 			"trussed/clients-3", "log-traceP", "log-rtt"]
 
-develop = ["default", "no-encrypted-storage", "oath-authenticator", "trussed/clients-3",
+develop = ["default", "no-encrypted-storage", "oath-authenticator", "trussed/clients-4",
 			"fido-authenticator/disable-reset-time-window",
 			"log-traceP"]
 
@@ -141,7 +142,9 @@ path = "src/bin/app-lpc.rs"
 required-features = ["soc-lpc55"]
 
 [patch.crates-io]
+apdu-dispatch = { git = "https://github.com/robin-nitrokey/apdu-dispatch", branch = "max-response-len" }
+interchange = { git = "https://github.com/trussed-dev/interchange.git", rev = "fe5633466640e1e9a8c06d9b5dd1d0af08c272af" }
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2" }
+littlefs2-sys = { git = "https://github.com/sosthene-nitrokey/littlefs2-sys.git", branch = "bindgen-runtime-feature" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", branch = "rtc-match" }
-trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
-#trussed = { path = "../../trussed" }
+trussed = { git = "https://github.com/trussed-dev/trussed" , rev = "6de826f3bcbef247e55fd890d80d9ed6ce9f0abc" }

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -71,6 +71,8 @@ default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
 
 release = []
 
+alpha = []
+
 complete = ["oath-authenticator", # "provisioner-app",
 			"fido-authenticator/disable-reset-time-window",
 			"trussed/clients-3", "log-traceP", "log-rtt"]

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -11,6 +11,11 @@ else
   SOC = nrf52
 endif
 
+ifneq ($(findstring alpha,$(FEATURES)),)
+  RUSTUP_TOOLCHAIN = nightly-2022-11-13
+  export RUSTUP_TOOLCHAIN
+endif
+
 # rust triplet
 TARGET = $(shell python3 -c 'import toml; print(toml.load("$(CFG_PATH)")["platform"]["target"])')
 # gnu binutils-prefix
@@ -93,10 +98,11 @@ check-var-%:
 
 %-banner:
 	@echo "******************************************************************************************"
-	@echo "**** TARGET:   $(shell printf %18s $(GET_TARGET)) | BINARY:   $(OUT_BIN)(.ihex)"
-	@echo "**** BOARD:    $(shell printf %18s $(BOARD)) | SOC:      $(SOC)"
-	@echo "**** PROFILE:  $(shell printf %18s $(BUILD_PROFILE)) | BUILD_ID: $(BUILD_ID)"
-	@echo "**** FEATURES: $(BUILD_FEATURES)"
+	@echo "**** TARGET:    $(shell printf %18s $(GET_TARGET)) | BINARY:   $(OUT_BIN)(.ihex)"
+	@echo "**** BOARD:     $(shell printf %18s $(BOARD)) | SOC:      $(SOC)"
+	@echo "**** PROFILE:   $(shell printf %18s $(BUILD_PROFILE)) | BUILD_ID: $(BUILD_ID)"
+	@echo "**** FEATURES:  $(BUILD_FEATURES)"
+	@echo "**** TOOLCHAIN: $(RUSTUP_TOOLCHAIN)"
 	@echo "******************************************************************************************"
 
 list:
@@ -119,6 +125,8 @@ clean-all:
 ###############################################################################
 
 build: build-banner $(SRCS) check-var-BOARD check-var-BUILD_PROFILE check-var-SOC
+
+	cargo --version
 
 	cp -f $(CFG_PATH) cfg.toml
 	echo '' >> cfg.toml

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -104,6 +104,11 @@ impl Stage0 {
     pub fn next(mut self, iocon: hal::Iocon<Unknown>, gpio: hal::Gpio<Unknown>) -> Stage1 {
         unsafe {
             super::types::DEVICE_UUID.copy_from_slice(&hal::uuid());
+            #[cfg(feature = "alpha")]
+            {
+                super::types::DEVICE_UUID[14] = 0xa1;
+                super::types::DEVICE_UUID[15] = 0xfa;
+            }
         };
 
         let mut iocon = iocon.enabled(&mut self.peripherals.syscon);

--- a/runners/embedded/src/soc_nrf52840/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/mod.rs
@@ -34,6 +34,11 @@ pub fn init_bootup(
     unsafe {
         types::DEVICE_UUID[0..4].copy_from_slice(&deviceid0.to_be_bytes());
         types::DEVICE_UUID[4..8].copy_from_slice(&deviceid1.to_be_bytes());
+        #[cfg(feature = "alpha")]
+        {
+            types::DEVICE_UUID[14] = 0xa1;
+            types::DEVICE_UUID[15] = 0xfa;
+        }
     }
 
     info!("RESET Reason: {:x}", power.resetreas.read().bits());

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -111,6 +111,8 @@ pub type OathApp = oath_authenticator::Authenticator<TrussedClient>;
 pub type FidoApp = fido_authenticator::Authenticator<fido_authenticator::Conforming, TrussedClient>;
 #[cfg(feature = "ndef-app")]
 pub type NdefApp = ndef_app::App<'static>;
+#[cfg(feature = "opcard")]
+pub type OpcardApp = opcard::Card<TrussedClient>;
 #[cfg(feature = "provisioner-app")]
 pub type ProvisionerApp =
     provisioner_app::Provisioner<RunnerStore, <SocT as Soc>::InternalFlashStorage, TrussedClient>;
@@ -179,6 +181,21 @@ impl TrussedApp for FidoApp {
     }
 }
 
+#[cfg(feature = "opcard")]
+impl TrussedApp for OpcardApp {
+    const CLIENT_ID: &'static [u8] = b"opcard\0";
+
+    type NonPortable = ();
+    fn with_client(trussed: TrussedClient, _: ()) -> Self {
+        let uuid = <SocT as Soc>::device_uuid();
+        let mut options = opcard::Options::default();
+        options.serial = [0xa0, 0x10, uuid[0], uuid[1]];
+        // TODO: set manufacturer to Nitrokey
+        Self::new(trussed, options)
+    }
+}
+
+
 pub struct ProvisionerNonPortable {
     pub store: RunnerStore,
     pub stolen_filesystem: &'static mut <SocT as Soc>::InternalFlashStorage,
@@ -220,6 +237,8 @@ pub struct Apps {
     pub fido: FidoApp,
     #[cfg(feature = "oath-authenticator")]
     pub oath: OathApp,
+    #[cfg(feature = "opcard")]
+    pub opcard: OpcardApp,
     #[cfg(feature = "ndef-app")]
     pub ndef: NdefApp,
     #[cfg(feature = "provisioner-app")]
@@ -237,6 +256,8 @@ impl Apps {
         let fido = FidoApp::with(trussed, ());
         #[cfg(feature = "oath-authenticator")]
         let oath = OathApp::with(trussed, ());
+        #[cfg(feature = "opcard")]
+        let opcard = OpcardApp::with(trussed, ());
         #[cfg(feature = "ndef-app")]
         let ndef = NdefApp::new();
         #[cfg(feature = "provisioner-app")]
@@ -249,6 +270,8 @@ impl Apps {
             fido,
             #[cfg(feature = "oath-authenticator")]
             oath,
+            #[cfg(feature = "opcard")]
+            opcard,
             #[cfg(feature = "ndef-app")]
             ndef,
             #[cfg(feature = "provisioner-app")]
@@ -265,6 +288,8 @@ impl Apps {
             &mut self.ndef,
             #[cfg(feature = "oath-authenticator")]
             &mut self.oath,
+            #[cfg(feature = "opcard")]
+            &mut self.opcard,
             #[cfg(feature = "fido-authenticator")]
             &mut self.fido,
             #[cfg(feature = "admin-app")]


### PR DESCRIPTION
This is the first step in the alpha release setup.  It adds a `alpha` feature that triggers the nightly compiler and is also built in the CI.  For easier integration, it only includes `opcard` v0.1.0.  I will open a separate PR for the `opcard` integration.