### PR TITLE
Update opcard to v0.2.0, oath-authenticator to v0.3.0 in alpha

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,12 +46,16 @@ build-lpc55-nk3xn:
     - docker
   stage: build
   script:
+    - rustup target add thumbv8m.main-none-eabi
+    - rustup +nightly-2022-11-13 target add thumbv8m.main-none-eabi
     - mkdir -p artifacts
     - export VERSION=`git describe --always`
     - apt-get install -y python3 python3-toml
     - make commands.bd
     - make -C runners/embedded build-nk3xn FEATURES=provisioner
     - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/firmware-nk3xn-lpc55-$VERSION.bin
+    - make -C runners/embedded build-nk3xn FEATURES=alpha
+    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/alpha-nk3xn-lpc55-$VERSION.bin
     - make -C runners/embedded build-nk3xn
     - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/provisioner-nk3xn-lpc55-$VERSION.bin
   after_script:
@@ -73,11 +77,16 @@ build-nrf52-nk3mini:
   script:
     - apt-get install -y python3 python3-toml
     - rustup target add thumbv7em-none-eabihf
+    - rustup +nightly-2022-11-13 target add thumbv7em-none-eabihf
     - mkdir -p artifacts
     - make -C runners/embedded build-nk3am.bl FEATURES=provisioner
     - cp runners/embedded/artifacts/*.bin artifacts/provisioner-nk3am-nrf52.bin
     - cp runners/embedded/artifacts/*.ihex artifacts/provisioner-nk3am-nrf52.ihex
     - make -C runners/embedded clean-nk3am.bl FEATURES=provisioner
+    - make -C runners/embedded build-nk3am.bl FEATURES=alpha
+    - cp runners/embedded/artifacts/*.bin artifacts/alpha-nk3am-nrf52.bin
+    - cp runners/embedded/artifacts/*.ihex artifacts/alpha-nk3am-nrf52.ihex
+    - make -C runners/embedded clean-nk3am.bl FEATURES=alpha
     - make -C runners/embedded build-nk3am.bl FEATURES=develop
     - cp runners/embedded/artifacts/*.bin artifacts/develop-nk3am-nrf52.bin
     - cp runners/embedded/artifacts/*.ihex artifacts/develop-nk3am-nrf52.ihex

--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
  "trussed",
  "usb-device",
  "usbd-ccid",
- "usbd-ctaphid",
+ "usbd-ctaphid 0.0.0-unreleased",
  "usbd-serial",
 ]
 
@@ -1424,10 +1424,11 @@ dependencies = [
 
 [[package]]
 name = "oath-authenticator"
-version = "0.1.0"
-source = "git+https://github.com/trussed-dev/oath-authenticator#4b680a3805aa9af31c24415fe39e1765638ee99a"
+version = "0.3.0"
+source = "git+https://github.com/nitrokey/oath-authenticator?rev=0.3.0#2cbcfb54eec8dfe24920054c3cdc64d5d27c2021"
 dependencies = [
  "apdu-dispatch",
+ "ctaphid-dispatch",
  "delog",
  "flexiber",
  "heapless 0.7.16",
@@ -1437,6 +1438,7 @@ dependencies = [
  "iso7816",
  "serde",
  "trussed",
+ "usbd-ctaphid 0.0.0-unreleased (git+https://github.com/Nitrokey/nitrokey-3-firmware)",
 ]
 
 [[package]]
@@ -2166,6 +2168,22 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.0.0-unreleased"
+dependencies = [
+ "ctap-types",
+ "ctaphid-dispatch",
+ "delog",
+ "embedded-time",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "interchange",
+ "serde",
+ "usb-device",
+]
+
+[[package]]
+name = "usbd-ctaphid"
+version = "0.0.0-unreleased"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#06238fd8538417b3cf1080924247f51c9a575298"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -16,24 +16,24 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
 dependencies = [
+ "crypto-common",
  "generic-array 0.14.6",
  "heapless 0.7.16",
 ]
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.3",
  "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
@@ -43,6 +43,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-cortex-m"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b309e7a89884824cb3c8e5f882024269c95e90b2f746344f2914423ac33c452"
+dependencies = [
+ "cortex-m",
+ "linked_list_allocator",
 ]
 
 [[package]]
@@ -105,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
 name = "bindgen"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,20 +167,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-modes"
-version = "0.8.1"
+name = "block-buffer"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "block-padding",
- "cipher",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+dependencies = [
+ "generic-array 0.14.6",
+]
 
 [[package]]
 name = "bytemuck"
@@ -195,6 +213,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.3",
+]
 
 [[package]]
 name = "cbor-smol"
@@ -236,21 +263,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
 dependencies = [
  "cfg-if",
- "cipher",
  "cpufeatures",
  "rand_core",
- "zeroize",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6547abe025f4027edacd9edaa357aded014eecec42a5070d9b885c3c334aba2"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
- "cipher",
+ "chacha20 0.9.0",
+ "cipher 0.4.3",
  "poly1305",
  "zeroize",
 ]
@@ -265,6 +301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +321,18 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "cortex-m"
@@ -396,14 +455,34 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
  "generic-array 0.14.6",
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array 0.14.6",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.6",
+ "typenum",
 ]
 
 [[package]]
@@ -488,8 +567,18 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.2.5",
  "der_derive 0.4.1",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
+ "crypto-bigint 0.3.2",
 ]
 
 [[package]]
@@ -518,13 +607,11 @@ dependencies = [
 
 [[package]]
 name = "des"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac41dd49fb554432020d52c875fc290e110113f864c6b1b525cd62c7e7747a5d"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "byteorder",
- "cipher",
- "opaque-debug",
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -537,6 +624,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,7 +642,7 @@ checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der 0.4.5",
  "elliptic-curve",
- "hmac",
+ "hmac 0.11.0",
  "signature",
 ]
 
@@ -559,11 +657,11 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.2.5",
  "ff",
  "generic-array 0.14.6",
  "group",
@@ -596,10 +694,11 @@ name = "embedded-runner-lib"
 version = "1.2.2"
 dependencies = [
  "admin-app",
+ "alloc-cortex-m",
  "apdu-dispatch",
  "cargo-lock",
  "cfg-if",
- "chacha20",
+ "chacha20 0.7.3",
  "cortex-m",
  "cortex-m-rtic",
  "cortex-m-semihosting",
@@ -862,7 +961,7 @@ dependencies = [
  "hash32 0.2.1",
  "rustc_version 0.4.0",
  "serde",
- "spin",
+ "spin 0.9.4",
  "stable_deref_trait",
 ]
 
@@ -902,7 +1001,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -927,6 +1035,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array 0.14.6",
+]
+
+[[package]]
 name = "interchange"
 version = "0.2.2"
 source = "git+https://github.com/trussed-dev/interchange.git?rev=fe5633466640e1e9a8c06d9b5dd1d0af08c272af#fe5633466640e1e9a8c06d9b5dd1d0af08c272af"
@@ -946,6 +1064,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -968,6 +1089,18 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
 
 [[package]]
 name = "littlefs2"
@@ -1016,12 +1149,12 @@ dependencies = [
 [[package]]
 name = "lpc55-hal"
 version = "0.3.0"
-source = "git+https://github.com/Nitrokey/lpc55-hal?branch=rtc-match#a7d1ebe260dd65dd854559aa221256a445d46d36"
+source = "git+https://github.com/nitrokey/lpc55-hal#6ae4070f5a06cfa20f256a262f4ada1cb1bc64fa"
 dependencies = [
- "block-buffer",
- "cipher",
+ "block-buffer 0.9.0",
+ "cipher 0.3.0",
  "cortex-m",
- "digest",
+ "digest 0.9.0",
  "embedded-hal",
  "embedded-time",
  "generic-array 0.14.6",
@@ -1142,7 +1275,7 @@ dependencies = [
  "der 0.2.10",
  "heapless-bytes 0.2.0",
  "micro-ecc-sys",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -1222,6 +1355,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1297,7 +1448,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "opcard"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/opcard-rs?tag=v0.1.0#59f1e968b1a76915f3a6c0ebbab43bf3a09b07f8"
+source = "git+https://github.com/Nitrokey/opcard-rs?rev=v0.2.0#0de848d39364d2784a3b8153ffe5dd1e1a3f49a6"
 dependencies = [
  "apdu-dispatch",
  "delog",
@@ -1320,7 +1471,7 @@ checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -1335,7 +1486,7 @@ dependencies = [
  "p256",
  "p256-cortex-m4-sys",
  "rand_core",
- "sha2",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -1368,10 +1519,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "poly1305"
-version = "0.7.2"
+name = "pkcs1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+dependencies = [
+ "der 0.5.1",
+ "pkcs8",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der 0.5.1",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -1380,20 +1553,20 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "0.7.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
+checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
 dependencies = [
+ "cobs",
  "heapless 0.7.16",
- "postcard-cobs",
  "serde",
 ]
 
 [[package]]
-name = "postcard-cobs"
-version = "0.1.5-pre"
+name = "ppv-lite86"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
@@ -1458,6 +1631,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1692,26 @@ checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
 dependencies = [
  "lazy_static",
  "regex",
+]
+
+[[package]]
+name = "rsa"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+dependencies = [
+ "byteorder",
+ "digest 0.10.6",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "smallvec",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1672,15 +1885,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "block-buffer",
  "cfg-if",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1689,11 +1900,22 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1708,9 +1930,15 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
- "digest",
+ "digest 0.9.0",
  "rand_core",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spi-memory"
@@ -1724,11 +1952,27 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der 0.5.1",
 ]
 
 [[package]]
@@ -1804,14 +2048,14 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed?rev=6de826f3bcbef247e55fd890d80d9ed6ce9f0abc#6de826f3bcbef247e55fd890d80d9ed6ce9f0abc"
+source = "git+https://github.com/nitrokey/trussed?branch=rsa-import#67b9b43aedd4ea66422a228a2c18f0ea8e4e5682"
 dependencies = [
  "aes",
  "bitflags",
- "block-modes",
+ "cbc",
  "cbor-smol",
  "cfg-if",
- "chacha20",
+ "chacha20 0.9.0",
  "chacha20poly1305",
  "cosey 0.3.0",
  "delog",
@@ -1822,18 +2066,21 @@ dependencies = [
  "heapless 0.7.16",
  "heapless-bytes 0.3.0",
  "hex-literal",
- "hmac",
+ "hmac 0.12.1",
  "interchange",
  "littlefs2",
  "nb 1.0.0",
+ "num-bigint-dig",
  "p256-cortex-m4",
  "postcard",
+ "rand_chacha",
  "rand_core",
+ "rsa",
  "salty",
  "serde",
  "serde-indexed",
  "sha-1",
- "sha2",
+ "sha2 0.10.6",
  "zeroize",
 ]
 
@@ -1878,11 +2125,11 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
- "generic-array 0.14.6",
+ "crypto-common",
  "subtle",
 ]
 
@@ -1993,9 +2240,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]

--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -48,8 +48,7 @@ dependencies = [
 [[package]]
 name = "apdu-dispatch"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bee13295997ab0b4809e5bf25bfd27844c93cf901220d643f7c0c53f288258"
+source = "git+https://github.com/robin-nitrokey/apdu-dispatch?branch=max-response-len#47c65f20f93e9215ad0afd6d960487f58676c2ea"
 dependencies = [
  "delog",
  "heapless 0.7.16",
@@ -273,6 +272,7 @@ checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -622,6 +622,7 @@ dependencies = [
  "nrf52840-hal",
  "nrf52840-pac",
  "oath-authenticator",
+ "opcard",
  "provisioner-app",
  "rand_core",
  "rtt-target",
@@ -928,8 +929,7 @@ dependencies = [
 [[package]]
 name = "interchange"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310d743c23f798f10d5ba2f77fdd3eff06aaf2d8f8b9d78beba7fb1167f4ccbf"
+source = "git+https://github.com/trussed-dev/interchange.git?rev=fe5633466640e1e9a8c06d9b5dd1d0af08c272af#fe5633466640e1e9a8c06d9b5dd1d0af08c272af"
 
 [[package]]
 name = "iso7816"
@@ -960,6 +960,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "littlefs2"
 version = "0.3.2"
 source = "git+https://github.com/Nitrokey/littlefs2#23b9e5028ce0b2ff77c78545c44ac75da9a79acb"
@@ -977,8 +987,7 @@ dependencies = [
 [[package]]
 name = "littlefs2-sys"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac150caec8a056e1248754f738c2330e578469093a522cf1afe30bbe545b90b"
+source = "git+https://github.com/sosthene-nitrokey/littlefs2-sys.git?branch=bindgen-runtime-feature#8ebb88edc59c0cf9503a9b9377065a0f74440448"
 dependencies = [
  "bindgen",
  "cc",
@@ -1284,6 +1293,24 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opcard"
+version = "0.1.0"
+source = "git+https://github.com/Nitrokey/opcard-rs?tag=v0.1.0#59f1e968b1a76915f3a6c0ebbab43bf3a09b07f8"
+dependencies = [
+ "apdu-dispatch",
+ "delog",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "hex-literal",
+ "iso7816",
+ "log",
+ "serde",
+ "serde_repr",
+ "subtle",
+ "trussed",
+]
 
 [[package]]
 name = "p256"
@@ -1777,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed?branch=main#3da56d8e41b9de64b852ed2bdcfd623118b09c3d"
+source = "git+https://github.com/trussed-dev/trussed?rev=6de826f3bcbef247e55fd890d80d9ed6ce9f0abc#6de826f3bcbef247e55fd890d80d9ed6ce9f0abc"
 dependencies = [
  "aes",
  "bitflags",
@@ -1941,6 +1968,28 @@ checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -33,7 +33,7 @@ ctap-types = "0.1"
 admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../../components/ndef-app", optional = true }
-oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", features = ["apdu-dispatch"], optional = true }
+oath-authenticator = { git = "https://github.com/nitrokey/oath-authenticator", rev = "0.3.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "v0.2.0", features = ["apdu-dispatch", "delog"], optional = true }
 provisioner-app = { path = "../../components/provisioner-app", optional = true }
 
@@ -75,7 +75,7 @@ default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
 
 release = []
 
-alpha = ["opcard", "rsa2048", "rsa4096", "trussed/clients-3"]
+alpha = ["oath-authenticator", "opcard", "rsa2048", "rsa4096", "trussed/clients-4"]
 
 complete = ["oath-authenticator", # "provisioner-app",
 			"fido-authenticator/disable-reset-time-window",

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -34,6 +34,7 @@ admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../../components/ndef-app", optional = true }
 oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", features = ["apdu-dispatch"], optional = true }
+opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v0.1.0", features = ["apdu-dispatch", "delog"], optional = true }
 provisioner-app = { path = "../../components/provisioner-app", optional = true }
 
 ### trussed core
@@ -71,13 +72,13 @@ default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
 
 release = []
 
-alpha = []
+alpha = ["opcard", "trussed/clients-3"]
 
 complete = ["oath-authenticator", # "provisioner-app",
 			"fido-authenticator/disable-reset-time-window",
 			"trussed/clients-3", "log-traceP", "log-rtt"]
 
-develop = ["default", "no-encrypted-storage", "oath-authenticator", "trussed/clients-3",
+develop = ["default", "no-encrypted-storage", "oath-authenticator", "trussed/clients-4",
 			"fido-authenticator/disable-reset-time-window",
 			"log-traceP"]
 
@@ -141,7 +142,9 @@ path = "src/bin/app-lpc.rs"
 required-features = ["soc-lpc55"]
 
 [patch.crates-io]
+apdu-dispatch = { git = "https://github.com/robin-nitrokey/apdu-dispatch", branch = "max-response-len" }
+interchange = { git = "https://github.com/trussed-dev/interchange.git", rev = "fe5633466640e1e9a8c06d9b5dd1d0af08c272af" }
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2" }
+littlefs2-sys = { git = "https://github.com/sosthene-nitrokey/littlefs2-sys.git", branch = "bindgen-runtime-feature" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", branch = "rtc-match" }
-trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
-#trussed = { path = "../../trussed" }
+trussed = { git = "https://github.com/trussed-dev/trussed" , rev = "6de826f3bcbef247e55fd890d80d9ed6ce9f0abc" }

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -34,7 +34,7 @@ admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../../components/ndef-app", optional = true }
 oath-authenticator = { git = "https://github.com/trussed-dev/oath-authenticator", features = ["apdu-dispatch"], optional = true }
-opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v0.1.0", features = ["apdu-dispatch", "delog"], optional = true }
+opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "v0.2.0", features = ["apdu-dispatch", "delog"], optional = true }
 provisioner-app = { path = "../../components/provisioner-app", optional = true }
 
 ### trussed core
@@ -61,6 +61,9 @@ fm11nc08 = { path = "../../components/fm11nc08", optional = true }
 nb = "1"
 systick-monotonic = { version = "1.0.0", optional = true }
 
+### Allocator
+alloc-cortex-m = { version = "0.4.3", optional = true }
+
 [build-dependencies]
 cargo-lock = "7"
 serde = { version = "1", features = ["derive"] }
@@ -72,7 +75,7 @@ default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
 
 release = []
 
-alpha = ["opcard", "trussed/clients-3"]
+alpha = ["opcard", "rsa2048", "rsa4096", "trussed/clients-3"]
 
 complete = ["oath-authenticator", # "provisioner-app",
 			"fido-authenticator/disable-reset-time-window",
@@ -103,6 +106,9 @@ no-reset-time-window = ["fido-authenticator/disable-reset-time-window"]
 # Format filesystem anyway
 format-filesystem = []
 
+alloc = ["alloc-cortex-m"]
+rsa2048 = ["alloc", "opcard/rsa2048"]
+rsa4096 = ["rsa2048", "opcard/rsa4096"]
 
 board-nrfdk = ["soc-nrf52840", "extflash_qspi"]
 board-proto1 = ["soc-nrf52840"]
@@ -146,5 +152,5 @@ apdu-dispatch = { git = "https://github.com/robin-nitrokey/apdu-dispatch", branc
 interchange = { git = "https://github.com/trussed-dev/interchange.git", rev = "fe5633466640e1e9a8c06d9b5dd1d0af08c272af" }
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2" }
 littlefs2-sys = { git = "https://github.com/sosthene-nitrokey/littlefs2-sys.git", branch = "bindgen-runtime-feature" }
-lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", branch = "rtc-match" }
-trussed = { git = "https://github.com/trussed-dev/trussed" , rev = "6de826f3bcbef247e55fd890d80d9ed6ce9f0abc" }
+lpc55-hal = { git = "https://github.com/nitrokey/lpc55-hal" }
+trussed = { git = "https://github.com/nitrokey/trussed" , branch = "rsa-import" }

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -154,3 +154,13 @@ littlefs2 = { git = "https://github.com/Nitrokey/littlefs2" }
 littlefs2-sys = { git = "https://github.com/sosthene-nitrokey/littlefs2-sys.git", branch = "bindgen-runtime-feature" }
 lpc55-hal = { git = "https://github.com/nitrokey/lpc55-hal" }
 trussed = { git = "https://github.com/nitrokey/trussed" , branch = "rsa-import" }
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "z"
+incremental = false
+debug = true
+
+[profile.release.package.salty]
+opt-level = 2

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -71,6 +71,8 @@ default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
 
 release = []
 
+alpha = []
+
 complete = ["oath-authenticator", # "provisioner-app",
 			"fido-authenticator/disable-reset-time-window",
 			"trussed/clients-3", "log-traceP", "log-rtt"]

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -11,6 +11,11 @@ else
   SOC = nrf52
 endif
 
+ifneq ($(findstring alpha,$(FEATURES)),)
+  RUSTUP_TOOLCHAIN = nightly-2022-11-13
+  export RUSTUP_TOOLCHAIN
+endif
+
 # rust triplet
 TARGET = $(shell python3 -c 'import toml; print(toml.load("$(CFG_PATH)")["platform"]["target"])')
 # gnu binutils-prefix
@@ -93,10 +98,11 @@ check-var-%:
 
 %-banner:
 	@echo "******************************************************************************************"
-	@echo "**** TARGET:   $(shell printf %18s $(GET_TARGET)) | BINARY:   $(OUT_BIN)(.ihex)"
-	@echo "**** BOARD:    $(shell printf %18s $(BOARD)) | SOC:      $(SOC)"
-	@echo "**** PROFILE:  $(shell printf %18s $(BUILD_PROFILE)) | BUILD_ID: $(BUILD_ID)"
-	@echo "**** FEATURES: $(BUILD_FEATURES)"
+	@echo "**** TARGET:    $(shell printf %18s $(GET_TARGET)) | BINARY:   $(OUT_BIN)(.ihex)"
+	@echo "**** BOARD:     $(shell printf %18s $(BOARD)) | SOC:      $(SOC)"
+	@echo "**** PROFILE:   $(shell printf %18s $(BUILD_PROFILE)) | BUILD_ID: $(BUILD_ID)"
+	@echo "**** FEATURES:  $(BUILD_FEATURES)"
+	@echo "**** TOOLCHAIN: $(RUSTUP_TOOLCHAIN)"
 	@echo "******************************************************************************************"
 
 list:
@@ -119,6 +125,8 @@ clean-all:
 ###############################################################################
 
 build: build-banner $(SRCS) check-var-BOARD check-var-BUILD_PROFILE check-var-SOC
+
+	cargo --version
 
 	cp -f $(CFG_PATH) cfg.toml
 	echo '' >> cfg.toml

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -88,6 +88,9 @@ mod app {
 
     #[init()]
     fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
+        #[cfg(feature = "alloc")]
+        embedded_runner_lib::init_alloc();
+
         let soc::init::All {
             basic,
             usb_nfc,

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -51,6 +51,9 @@ mod app {
 
     #[init()]
     fn init(mut ctx: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
+        #[cfg(feature = "alloc")]
+        embedded_runner_lib::init_alloc();
+
         ctx.core.DCB.enable_trace();
         ctx.core.DWT.enable_cycle_counter();
 

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -104,6 +104,11 @@ impl Stage0 {
     pub fn next(mut self, iocon: hal::Iocon<Unknown>, gpio: hal::Gpio<Unknown>) -> Stage1 {
         unsafe {
             super::types::DEVICE_UUID.copy_from_slice(&hal::uuid());
+            #[cfg(feature = "alpha")]
+            {
+                super::types::DEVICE_UUID[14] = 0xa1;
+                super::types::DEVICE_UUID[15] = 0xfa;
+            }
         };
 
         let mut iocon = iocon.enabled(&mut self.peripherals.syscon);

--- a/runners/embedded/src/soc_lpc55/monotonic.rs
+++ b/runners/embedded/src/soc_lpc55/monotonic.rs
@@ -84,7 +84,7 @@ impl rtic::Monotonic for Monotonic {
     fn set_compare(&mut self, instant: Self::Instant) {
         debug_now!("set_compare: {}, {}", instant, self.now());
         let timeout = instant.0.saturating_sub(self.now().0);
-        self.rtc.set_wake(Duration::from_millis(timeout.into()));
+        // self.rtc.set_wake(Duration::from_millis(timeout.into()));
     }
 
     fn clear_compare_flag(&mut self) {

--- a/runners/embedded/src/soc_nrf52840/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/mod.rs
@@ -34,6 +34,11 @@ pub fn init_bootup(
     unsafe {
         types::DEVICE_UUID[0..4].copy_from_slice(&deviceid0.to_be_bytes());
         types::DEVICE_UUID[4..8].copy_from_slice(&deviceid1.to_be_bytes());
+        #[cfg(feature = "alpha")]
+        {
+            types::DEVICE_UUID[14] = 0xa1;
+            types::DEVICE_UUID[15] = 0xfa;
+        }
     }
 
     info!("RESET Reason: {:x}", power.resetreas.read().bits());

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -308,6 +308,8 @@ impl Apps {
             &mut self.fido,
             #[cfg(feature = "admin-app")]
             &mut self.admin,
+            #[cfg(feature = "oath-authenticator")]
+            &mut self.oath,
         ])
     }
 }

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -111,6 +111,8 @@ pub type OathApp = oath_authenticator::Authenticator<TrussedClient>;
 pub type FidoApp = fido_authenticator::Authenticator<fido_authenticator::Conforming, TrussedClient>;
 #[cfg(feature = "ndef-app")]
 pub type NdefApp = ndef_app::App<'static>;
+#[cfg(feature = "opcard")]
+pub type OpcardApp = opcard::Card<TrussedClient>;
 #[cfg(feature = "provisioner-app")]
 pub type ProvisionerApp =
     provisioner_app::Provisioner<RunnerStore, <SocT as Soc>::InternalFlashStorage, TrussedClient>;
@@ -179,6 +181,21 @@ impl TrussedApp for FidoApp {
     }
 }
 
+#[cfg(feature = "opcard")]
+impl TrussedApp for OpcardApp {
+    const CLIENT_ID: &'static [u8] = b"opcard\0";
+
+    type NonPortable = ();
+    fn with_client(trussed: TrussedClient, _: ()) -> Self {
+        let uuid = <SocT as Soc>::device_uuid();
+        let mut options = opcard::Options::default();
+        options.serial = [0xa0, 0x10, uuid[0], uuid[1]];
+        // TODO: set manufacturer to Nitrokey
+        Self::new(trussed, options)
+    }
+}
+
+
 pub struct ProvisionerNonPortable {
     pub store: RunnerStore,
     pub stolen_filesystem: &'static mut <SocT as Soc>::InternalFlashStorage,
@@ -220,6 +237,8 @@ pub struct Apps {
     pub fido: FidoApp,
     #[cfg(feature = "oath-authenticator")]
     pub oath: OathApp,
+    #[cfg(feature = "opcard")]
+    pub opcard: OpcardApp,
     #[cfg(feature = "ndef-app")]
     pub ndef: NdefApp,
     #[cfg(feature = "provisioner-app")]
@@ -237,6 +256,8 @@ impl Apps {
         let fido = FidoApp::with(trussed, ());
         #[cfg(feature = "oath-authenticator")]
         let oath = OathApp::with(trussed, ());
+        #[cfg(feature = "opcard")]
+        let opcard = OpcardApp::with(trussed, ());
         #[cfg(feature = "ndef-app")]
         let ndef = NdefApp::new();
         #[cfg(feature = "provisioner-app")]
@@ -249,6 +270,8 @@ impl Apps {
             fido,
             #[cfg(feature = "oath-authenticator")]
             oath,
+            #[cfg(feature = "opcard")]
+            opcard,
             #[cfg(feature = "ndef-app")]
             ndef,
             #[cfg(feature = "provisioner-app")]
@@ -265,6 +288,8 @@ impl Apps {
             &mut self.ndef,
             #[cfg(feature = "oath-authenticator")]
             &mut self.oath,
+            #[cfg(feature = "opcard")]
+            &mut self.opcard,
             #[cfg(feature = "fido-authenticator")]
             &mut self.fido,
             #[cfg(feature = "admin-app")]

--- a/utils/nrf-builder/Makefile
+++ b/utils/nrf-builder/Makefile
@@ -60,6 +60,9 @@ SRCS = $(shell find $(FW_RUNNER)/src -name "*.rs" )
 
 TTY := $(shell ls -1rt /dev/ttyACM* | tail -n 1 | xargs)
 
+EXTRA_FEATURES :=
+
+
 ######
 
 .PHONY: build clean flash-provisioner flash-fw flash-bootloader provision-keys full-deploy
@@ -160,17 +163,17 @@ $(BL_SIGNED_NAME): bootloader.hex $(PRIV_SIGN_KEY)
 	$(SH_SIGN) $(SIGN_VERSION) $@ $< $(PRIV_SIGN_KEY)
 
 $(FW_NAME_PROVISIONER_HEX) $(FW_NAME_PROVISIONER_BIN): $(NK3_FW_DIR) $(SRCS)
-	$(MAKE) -C $(FW_RUNNER) build-nk3am.bl FEATURES=provisioner
+	$(MAKE) -C $(FW_RUNNER) build-nk3am.bl FEATURES=provisioner,$(EXTRA_FEATURES)
 	cp $(FW_IHEX) $(FW_NAME_PROVISIONER_HEX)
 	cp $(FW_BIN) $(FW_NAME_PROVISIONER_BIN)
 
 $(FW_NAME_DEVELOP_HEX) $(FW_NAME_DEVELOP_BIN): $(NK3_FW_DIR) $(SRCS)
-	$(MAKE) -C $(FW_RUNNER) build-nk3am.bl FEATURES=develop
+	$(MAKE) -C $(FW_RUNNER) build-nk3am.bl FEATURES=develop,$(EXTRA_FEATURES)
 	cp $(FW_IHEX) $(FW_NAME_DEVELOP_HEX)
 	cp $(FW_BIN) $(FW_NAME_DEVELOP_BIN)
 
 $(FW_NAME_RELEASE_HEX) $(FW_NAME_RELEASE_BIN): $(NK3_FW_DIR) $(SRCS)
-	$(MAKE) -C $(FW_RUNNER) build-nk3am.bl FEATURES=release
+	$(MAKE) -C $(FW_RUNNER) build-nk3am.bl FEATURES=release,$(EXTRA_FEATURES)
 	cp $(FW_IHEX) $(FW_NAME_RELEASE_HEX)
 	cp $(FW_BIN) $(FW_NAME_RELEASE_BIN)
 


### PR DESCRIPTION
Open points:
- [x] really update to v0.2.0 once it is released
- [x] fix lpc55 linking issues
- [ ] discuss patched dependencies for stable