### PR TITLE
Release v1.2.2 alpha - opcard 0.2.0 oath 0.3.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,22 +78,21 @@ build-nrf52-nk3mini:
     - apt-get install -y python3 python3-toml
     - rustup target add thumbv7em-none-eabihf
     - rustup +nightly-2022-11-13 target add thumbv7em-none-eabihf
+    - export VERSION=`git describe --always`
     - mkdir -p artifacts
     - make -C runners/embedded build-nk3am.bl FEATURES=provisioner
-    - cp runners/embedded/artifacts/*.bin artifacts/provisioner-nk3am-nrf52.bin
-    - cp runners/embedded/artifacts/*.ihex artifacts/provisioner-nk3am-nrf52.ihex
+    - cp runners/embedded/artifacts/*.bin artifacts/provisioner-nk3am-nrf52-$VERSION.bin
+    - cp runners/embedded/artifacts/*.ihex artifacts/provisioner-nk3am-nrf52-$VERSION.ihex
     - make -C runners/embedded clean-nk3am.bl FEATURES=provisioner
     - make -C runners/embedded build-nk3am.bl FEATURES=alpha
-    - cp runners/embedded/artifacts/*.bin artifacts/alpha-nk3am-nrf52.bin
-    - cp runners/embedded/artifacts/*.ihex artifacts/alpha-nk3am-nrf52.ihex
+    - cp runners/embedded/artifacts/*.bin artifacts/alpha-nk3am-nrf52-$VERSION.bin
+    - cp runners/embedded/artifacts/*.ihex artifacts/alpha-nk3am-nrf52-$VERSION.ihex
     - make -C runners/embedded clean-nk3am.bl FEATURES=alpha
     - make -C runners/embedded build-nk3am.bl FEATURES=develop
-    - cp runners/embedded/artifacts/*.bin artifacts/develop-nk3am-nrf52.bin
-    - cp runners/embedded/artifacts/*.ihex artifacts/develop-nk3am-nrf52.ihex
     - make -C runners/embedded clean-nk3am.bl FEATURES=develop
     - make -C runners/embedded build-nk3am.bl FEATURES=release
-    - cp runners/embedded/artifacts/*.bin artifacts/firmware-nk3am-nrf52.bin
-    - cp runners/embedded/artifacts/*.ihex artifacts/firmware-nk3am-nrf52.ihex
+    - cp runners/embedded/artifacts/*.bin artifacts/firmware-nk3am-nrf52-$VERSION.bin
+    - cp runners/embedded/artifacts/*.ihex artifacts/firmware-nk3am-nrf52-$VERSION.ihex
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
   artifacts:

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -189,7 +189,7 @@ impl TrussedApp for OpcardApp {
     fn with_client(trussed: TrussedClient, _: ()) -> Self {
         let uuid = <SocT as Soc>::device_uuid();
         let mut options = opcard::Options::default();
-        options.serial = [0xa0, 0x10, uuid[0], uuid[1]];
+        options.serial = [0xa0, 0x20, uuid[0], uuid[1]];
         // TODO: set manufacturer to Nitrokey
         Self::new(trussed, options)
     }


### PR DESCRIPTION
* bumped opcard version (inside its init options)
* remove develop builds from the ci artifacts
* add version string to nrf build-artifacts