### PR TITLE
embedded: Bump lpc55 RAM length to 272K

### DIFF
--- a/runners/embedded/ld/lpc55-memory-template.x
+++ b/runners/embedded/ld/lpc55-memory-template.x
@@ -6,7 +6,7 @@ MEMORY
     FILESYSTEM : ORIGIN = 0x##FS_BASE##, LENGTH = ##FS_LENGTH##K
 
     /* for use with standard link.x */
-    RAM : ORIGIN = 0x20000000, LENGTH = 256K
+    RAM : ORIGIN = 0x20000000, LENGTH = 272K
 
     /* would be used with proper link.x */
     /* needs changes to r0 (initialization code) */


### PR DESCRIPTION
According to the memory layout described in sections 2.1.5 and 2.1.8 of the LPC55 user manual ([UM11126](https://www.mouser.com/pdfDocs/NXP_LPC55S6x_UM.pdf)), we have access to 272 kB RAM at 0x2000_0000, not only 256 kB.  This fixes an issue with unresponsive devices experienced with the latest alpha release.