### PR TITLE
embedded: Use nrf52840-hal 0.15.1

### DIFF
--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -1291,7 +1291,8 @@ dependencies = [
 [[package]]
 name = "nrf-hal-common"
 version = "0.15.1"
-source = "git+https://github.com/nrf-rs/nrf-hal#663008c033ad67263e4ac0c561d5d1fac28d7170"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089242b8b729622099054dcb5518e9eac80bcf6a7e30091c7cfa043383e9998c"
 dependencies = [
  "cast",
  "cfg-if",
@@ -1323,7 +1324,8 @@ dependencies = [
 [[package]]
 name = "nrf52840-hal"
 version = "0.15.1"
-source = "git+https://github.com/nrf-rs/nrf-hal#663008c033ad67263e4ac0c561d5d1fac28d7170"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c090616930ef132c1f7e9f9a964f6c8c5aa8962e402cc5abbbde7ce16ce9a0"
 dependencies = [
  "embedded-hal",
  "nrf-hal-common",

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -50,7 +50,7 @@ usbd-ctaphid = { path = "../../components/usbd-ctaphid" }
 
 ### NRF52 specific dependencies
 chacha20 = { version = "0.7", default-features = false, features = ["rng"], optional = true }
-nrf52840-hal = { git = "https://github.com/nrf-rs/nrf-hal", optional = true }
+nrf52840-hal = { version = "0.15.1", optional = true }
 nrf52840-pac = { version = "0.11", optional = true }
 
 ### LPC55 specific dependencies


### PR DESCRIPTION
Instead of using nrf52840-hal as a Git dependency, use the published 0.15.1 version.

Fixes #103