### PR TITLE
Release v1.2.2-alpha.20221125

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,16 +48,19 @@ build-lpc55-nk3xn:
   script:
     - rustup target add thumbv8m.main-none-eabi
     - rustup +nightly-2022-11-13 target add thumbv8m.main-none-eabi
-    - mkdir -p artifacts
+    - mkdir -p artifacts nk3xn
     - export VERSION=`git describe --always`
-    - apt-get install -y python3 python3-toml
+    - apt-get install -y python3 python3-toml zip
     - make commands.bd
+    - cp commands.bd nk3xn
     - make -C runners/embedded build-nk3xn FEATURES=provisioner
-    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/firmware-nk3xn-lpc55-$VERSION.bin
+    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin nk3xn/firmware-nk3xn-lpc55-$VERSION.bin
     - make -C runners/embedded build-nk3xn FEATURES=alpha
-    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/alpha-nk3xn-lpc55-$VERSION.bin
+    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin nk3xn/alpha-nk3xn-lpc55-$VERSION.bin
     - make -C runners/embedded build-nk3xn
-    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/provisioner-nk3xn-lpc55-$VERSION.bin
+    - cp ./runners/embedded/artifacts/runner-lpc55-nk3xn.bin nk3xn/provisioner-nk3xn-lpc55-$VERSION.bin
+    - zip nk3xn-raw.zip nk3xn/*
+    - cp nk3xn-raw.zip artifacts
   after_script:
     - git archive --format zip --output artifacts/nitrokey-3-firmware.zip --prefix nitrokey-3-firmware/ HEAD
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
@@ -75,24 +78,26 @@ build-nrf52-nk3mini:
     - docker
   stage: build
   script:
-    - apt-get install -y python3 python3-toml
+    - apt-get install -y python3 python3-toml zip
     - rustup target add thumbv7em-none-eabihf
     - rustup +nightly-2022-11-13 target add thumbv7em-none-eabihf
     - export VERSION=`git describe --always`
-    - mkdir -p artifacts
+    - mkdir -p artifacts nk3am
     - make -C runners/embedded build-nk3am.bl FEATURES=provisioner
-    - cp runners/embedded/artifacts/*.bin artifacts/provisioner-nk3am-nrf52-$VERSION.bin
-    - cp runners/embedded/artifacts/*.ihex artifacts/provisioner-nk3am-nrf52-$VERSION.ihex
+    - cp runners/embedded/artifacts/*.bin nk3am/provisioner-nk3am-nrf52-$VERSION.bin
+    - cp runners/embedded/artifacts/*.ihex nk3am/provisioner-nk3am-nrf52-$VERSION.ihex
     - make -C runners/embedded clean-nk3am.bl FEATURES=provisioner
     - make -C runners/embedded build-nk3am.bl FEATURES=alpha
-    - cp runners/embedded/artifacts/*.bin artifacts/alpha-nk3am-nrf52-$VERSION.bin
-    - cp runners/embedded/artifacts/*.ihex artifacts/alpha-nk3am-nrf52-$VERSION.ihex
+    - cp runners/embedded/artifacts/*.bin nk3am/alpha-nk3am-nrf52-$VERSION.bin
+    - cp runners/embedded/artifacts/*.ihex nk3am/alpha-nk3am-nrf52-$VERSION.ihex
     - make -C runners/embedded clean-nk3am.bl FEATURES=alpha
     - make -C runners/embedded build-nk3am.bl FEATURES=develop
     - make -C runners/embedded clean-nk3am.bl FEATURES=develop
     - make -C runners/embedded build-nk3am.bl FEATURES=release
-    - cp runners/embedded/artifacts/*.bin artifacts/firmware-nk3am-nrf52-$VERSION.bin
-    - cp runners/embedded/artifacts/*.ihex artifacts/firmware-nk3am-nrf52-$VERSION.ihex
+    - cp runners/embedded/artifacts/*.bin nk3am/firmware-nk3am-nrf52-$VERSION.bin
+    - cp runners/embedded/artifacts/*.ihex nk3am/firmware-nk3am-nrf52-$VERSION.ihex
+    - zip nk3am-raw.zip nk3am/*
+    - cp nk3am-raw.zip artifacts
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
   artifacts:

--- a/runners/embedded/ld/lpc55-memory-template.x
+++ b/runners/embedded/ld/lpc55-memory-template.x
@@ -6,7 +6,7 @@ MEMORY
     FILESYSTEM : ORIGIN = 0x##FS_BASE##, LENGTH = ##FS_LENGTH##K
 
     /* for use with standard link.x */
-    RAM : ORIGIN = 0x20000000, LENGTH = 256K
+    RAM : ORIGIN = 0x20000000, LENGTH = 272K
 
     /* would be used with proper link.x */
     /* needs changes to r0 (initialization code) */

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -101,6 +101,7 @@ impl Stage0 {
             .expect("Clock configuration failed")
     }
 
+    #[inline(never)]
     pub fn next(mut self, iocon: hal::Iocon<Unknown>, gpio: hal::Gpio<Unknown>) -> Stage1 {
         unsafe {
             super::types::DEVICE_UUID.copy_from_slice(&hal::uuid());
@@ -223,6 +224,7 @@ impl Stage1 {
         }
     }
 
+    #[inline(never)]
     pub fn next(
         mut self,
         adc: hal::Adc<Unknown>,
@@ -450,6 +452,7 @@ impl Stage2 {
         info_now!("hardware checks successful");
     }
 
+    #[inline(never)]
     pub fn next(
         mut self,
         flexcomm0: hal::peripherals::flexcomm::Flexcomm0<Unknown>,
@@ -495,6 +498,7 @@ pub struct Stage3 {
 }
 
 impl Stage3 {
+    #[inline(never)]
     pub fn next(
         mut self,
         rng: hal::peripherals::rng::Rng<Unknown>,
@@ -536,6 +540,7 @@ pub struct Stage4 {
 }
 
 impl Stage4 {
+    #[inline(never)]
     pub fn next(mut self) -> Stage5 {
         let syscon = &mut self.peripherals.syscon;
         let pmc = &mut self.peripherals.pmc;
@@ -649,6 +654,7 @@ pub struct Stage5 {
 }
 
 impl Stage5 {
+    #[inline(never)]
     pub fn next(mut self, rtc: hal::peripherals::rtc::Rtc<Unknown>) -> Stage6 {
         let syscon = &mut self.peripherals.syscon;
         let pmc = &mut self.peripherals.pmc;
@@ -710,6 +716,7 @@ impl Stage6 {
         }
     }
 
+    #[inline(never)]
     pub fn next(mut self) -> All {
         self.perform_data_migrations();
         let apps = crate::init_apps(&mut self.trussed, &self.store, self.clocks.is_nfc_passive);
@@ -752,6 +759,7 @@ pub struct All {
     pub clock_controller: Option<DynamicClockController>,
 }
 
+#[inline(never)]
 pub fn start(syscon: hal::Syscon, pmc: hal::Pmc, anactrl: hal::Anactrl) -> Stage0 {
     let peripherals = Peripherals {
         syscon,


### PR DESCRIPTION
* includes #113
* avoid inlining init stages for lpc55
* zip resulting raw binaries to reduce clutter in release