### PR TITLE
embedded: Update trussed and revert postcard

### DIFF
--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -323,12 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cobs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
 name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,14 +1551,20 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
+checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
- "cobs",
  "heapless 0.7.16",
+ "postcard-cobs",
  "serde",
 ]
+
+[[package]]
+name = "postcard-cobs"
+version = "0.1.5-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 
 [[package]]
 name = "ppv-lite86"
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed?tag=v0.1.0-nitrokey-1#67b9b43aedd4ea66422a228a2c18f0ea8e4e5682"
+source = "git+https://github.com/Nitrokey/trussed?tag=v0.1.0-nitrokey-2#65a83bc353579c7d01f11191798ef94178697499"
 dependencies = [
  "aes",
  "bitflags",

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -153,7 +153,7 @@ interchange = { git = "https://github.com/trussed-dev/interchange", rev = "fe563
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
 littlefs2-sys = { git = "https://github.com/Nitrokey/littlefs2-sys", tag = "v0.1.6-nitrokey-1" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey-1" }
-trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-1" }
+trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-2" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
This patch updates trussed to revert postcard to 0.7.3.  This fixes an issue with decoding existing FIDO2 credentials.