### PR TITLE
embedded: Update trussed to fix hmac-secret in fido-authenticator

### DIFF
--- a/runners/embedded/Cargo.lock
+++ b/runners/embedded/Cargo.lock
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed?tag=v0.1.0-nitrokey-2#65a83bc353579c7d01f11191798ef94178697499"
+source = "git+https://github.com/Nitrokey/trussed?tag=v0.1.0-nitrokey-3#ccdbf9929a538ebb6c48a785a76ea91a1b17b707"
 dependencies = [
  "aes",
  "bitflags",

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -153,7 +153,7 @@ interchange = { git = "https://github.com/trussed-dev/interchange", rev = "fe563
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
 littlefs2-sys = { git = "https://github.com/Nitrokey/littlefs2-sys", tag = "v0.1.6-nitrokey-1" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey-1" }
-trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-2" }
+trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-3" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
This patch bumps the trussed dependency to fix a compatibility issue that caused a panic in fido-authenticator when executing an assertion with the hmac-secret extension.

Fixes https://github.com/Nitrokey/nitrokey-3-firmware/issues/94