### PR TITLE
Explicitly exclude lpc55 from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "utils/collect-license-info",
     "utils/gen-commands-bd",
 ]
+exclude = ["runners/lpc55"]
 resolver = "2"
 
 [patch.crates-io]


### PR DESCRIPTION
This fixes a compiler error for the lpc55 runner.