### PR TITLE
embedded: Fix provisioner hardware checks for lpc55

### DIFF
--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -67,7 +67,7 @@ default = []
 alpha = ["apps/alpha", "alloc"]
 develop = ["no-encrypted-storage", "apps/no-reset-time-window", "log-traceP"]
 develop-no-press = ["develop", "no-buttons"]
-provisioner = ["apps/provisioner", "write-undefined-flash", "no-buttons", "apps/no-reset-time-window"]
+provisioner = ["apps/provisioner", "write-undefined-flash", "no-buttons", "apps/no-reset-time-window", "lpc55-hardware-checks"]
 
 # Do not use encryption for the filesystem
 no-encrypted-storage = []

--- a/runners/embedded/src/soc_lpc55/spi.rs
+++ b/runners/embedded/src/soc_lpc55/spi.rs
@@ -5,8 +5,11 @@ use lpc55_hal::{
         SpiMaster,
     },
     peripherals::flexcomm::Spi0,
-    time::RateExtensions,
-    traits::wg::{blocking::spi::Transfer, spi},
+    time::{Hertz, RateExtensions},
+    traits::wg::{
+        blocking::spi::Transfer,
+        spi::{Mode, Phase, Polarity},
+    },
     typestates::pin::{
         self,
         flexcomm::{NoCs, NoPio},
@@ -18,44 +21,48 @@ pub type SckPin = pins::Pio0_28;
 pub type MosiPin = pins::Pio0_24;
 pub type MisoPin = pins::Pio0_25;
 
-pub type Spi = SpiMaster<
-    SckPin,
-    MosiPin,
-    MisoPin,
-    NoPio,
-    Spi0,
-    (
-        Pin<SckPin, pin::state::Special<pin::function::FC0_SCK>>,
-        Pin<MosiPin, pin::state::Special<pin::function::FC0_RXD_SDA_MOSI_DATA>>,
-        Pin<MisoPin, pin::state::Special<pin::function::FC0_TXD_SCL_MISO_WS>>,
-        pin::flexcomm::NoCs,
-    ),
->;
+pub type Sck = Pin<SckPin, pin::state::Special<pin::function::FC0_SCK>>;
+pub type Mosi = Pin<MosiPin, pin::state::Special<pin::function::FC0_RXD_SDA_MOSI_DATA>>;
+pub type Miso = Pin<MisoPin, pin::state::Special<pin::function::FC0_TXD_SCL_MISO_WS>>;
+
+pub type Spi = SpiMaster<SckPin, MosiPin, MisoPin, NoPio, Spi0, (Sck, Mosi, Miso, NoCs)>;
+
+pub enum SpiConfig {
+    ExternalFlash,
+    Nfc,
+}
+
+impl SpiConfig {
+    pub fn speed(&self) -> Hertz {
+        match self {
+            Self::ExternalFlash => 1_000_000u32.Hz(),
+            Self::Nfc => 2_000_000u32.Hz(),
+        }
+    }
+
+    pub fn mode(&self) -> Mode {
+        let (polarity, phase) = match self {
+            Self::ExternalFlash => (Polarity::IdleLow, Phase::CaptureOnFirstTransition),
+            Self::Nfc => (Polarity::IdleLow, Phase::CaptureOnSecondTransition),
+        };
+        Mode { polarity, phase }
+    }
+}
 
 pub fn init(spi: Spi0<Enabled>, iocon: &mut Iocon<Enabled>) -> Spi {
     let sck = SckPin::take().unwrap().into_spi0_sck_pin(iocon);
     let mosi = MosiPin::take().unwrap().into_spi0_mosi_pin(iocon);
     let miso = MisoPin::take().unwrap().into_spi0_miso_pin(iocon);
-    let spi_mode = spi::Mode {
-        polarity: spi::Polarity::IdleLow,
-        phase: spi::Phase::CaptureOnFirstTransition,
-    };
-    SpiMaster::new(
-        spi,
-        (sck, mosi, miso, NoCs),
-        // 2_000_000u32.Hz(),
-        1_000_000u32.Hz(),
-        spi_mode,
-    )
+    configure(spi, (sck, mosi, miso, NoCs), SpiConfig::ExternalFlash)
 }
 
 pub fn reconfigure(spi: Spi) -> Spi {
     let (spi, pins) = spi.release();
-    let spi_mode = spi::Mode {
-        polarity: spi::Polarity::IdleLow,
-        phase: spi::Phase::CaptureOnSecondTransition,
-    };
-    SpiMaster::new(spi, pins, 2_000_000u32.Hz(), spi_mode)
+    configure(spi, pins, SpiConfig::Nfc)
+}
+
+pub fn configure(spi: Spi0<Enabled>, pins: (Sck, Mosi, Miso, NoCs), config: SpiConfig) -> Spi {
+    SpiMaster::new(spi, pins, config.speed(), config.mode())
 }
 
 pub struct SpiMut<'a, SPI: Transfer<u8>>(pub &'a mut SPI);

--- a/runners/embedded/src/soc_lpc55/spi.rs
+++ b/runners/embedded/src/soc_lpc55/spi.rs
@@ -49,16 +49,11 @@ impl SpiConfig {
     }
 }
 
-pub fn init(spi: Spi0<Enabled>, iocon: &mut Iocon<Enabled>) -> Spi {
+pub fn init(spi: Spi0<Enabled>, iocon: &mut Iocon<Enabled>, config: SpiConfig) -> Spi {
     let sck = SckPin::take().unwrap().into_spi0_sck_pin(iocon);
     let mosi = MosiPin::take().unwrap().into_spi0_mosi_pin(iocon);
     let miso = MisoPin::take().unwrap().into_spi0_miso_pin(iocon);
-    configure(spi, (sck, mosi, miso, NoCs), SpiConfig::ExternalFlash)
-}
-
-pub fn reconfigure(spi: Spi) -> Spi {
-    let (spi, pins) = spi.release();
-    configure(spi, pins, SpiConfig::Nfc)
+    configure(spi, (sck, mosi, miso, NoCs), config)
 }
 
 pub fn configure(spi: Spi0<Enabled>, pins: (Sck, Mosi, Miso, NoCs), config: SpiConfig) -> Spi {


### PR DESCRIPTION
This patch re-enables the lpc55 hardware checks in the provisioner and disables NFC if the hardware checks are executed to avoid communication issues linked to different SPI configurations for the external flash and the NFC chip.