### PR TITLE
Add ccid apps to the usbip runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
  "humansize",
  "mime",
  "mime_guess",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-traits",
  "percent-encoding",
  "proc-macro2",
@@ -295,9 +295,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "camino"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
+checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
 dependencies = [
  "serde",
 ]
@@ -558,6 +558,7 @@ checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
+ "critical-section 1.1.1",
  "embedded-hal",
  "volatile-register",
 ]
@@ -890,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]
@@ -1039,7 +1040,7 @@ checksum = "f1965703169d4c3581f1d853e6a0bacf2ad9ba5d161f58ac331de95b37584a50"
 dependencies = [
  "az",
  "bytemuck",
- "half 2.2.0",
+ "half 2.2.1",
  "typenum",
 ]
 
@@ -1097,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "gcd"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1b088ad0a967aa29540456b82fc8903f854775d33f71e9709c4efb3dfbfd2"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "gen-commands-bd"
@@ -1162,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -1205,9 +1206,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "half"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c467d36af040b7b2681f5fddd27427f6da8d3d072f575a265e181d2f8e8d157"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
 dependencies = [
  "crunchy",
 ]
@@ -1653,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1993,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -2067,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2479,9 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -2567,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner#47f042642478b9e03bbb34ab14b39bec943c4c28"
+source = "git+https://github.com/trussed-dev/pc-usbip-runner#7e3dfcd327cde008a03dd32f1c6572e1a7d2ba4f"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
@@ -2603,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
 
 [[package]]
 name = "unicode-ident"
@@ -2682,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "usbd-ccid"
 version = "0.0.0-unreleased"
-source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#c02188a6853a93bdaee2e673d282e621db2c1789"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#168011629dbea851fb9433f5b9a06f38f76cb07b"
 dependencies = [
  "delog",
  "embedded-time",
@@ -2710,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.0.0-unreleased"
-source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#24d40b0f1064ad411b6f5e6d37f94407d3067305"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#168011629dbea851fb9433f5b9a06f38f76cb07b"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,18 +38,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "alloc-cortex-m"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b309e7a89884824cb3c8e5f882024269c95e90b2f746344f2914423ac33c452"
+checksum = "483c3bd0f9a7bb982b72988f5f173d29687c432d8013c1d3232635e6c0f0a60c"
 dependencies = [
  "cortex-m",
  "linked_list_allocator",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "apdu-dispatch"
@@ -148,7 +148,7 @@ dependencies = [
  "humansize",
  "mime",
  "mime_guess",
- "nom 7.1.1",
+ "nom 7.1.2",
  "num-traits",
  "percent-encoding",
  "proc-macro2",
@@ -160,11 +160,11 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
- "critical-section",
+ "critical-section 1.1.1",
 ]
 
 [[package]]
@@ -231,12 +231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
 
 [[package]]
 name = "byteorder"
@@ -320,7 +314,7 @@ dependencies = [
  "cargo_metadata",
  "csv",
  "getopts",
- "semver 1.0.13",
+ "semver 1.0.16",
  "serde",
  "serde_derive",
  "serde_json",
@@ -334,7 +328,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c408da54db4c50d4693f7e649c299bc9de9c23ead86249e5368830bb32a734b"
 dependencies = [
- "semver 1.0.13",
+ "semver 1.0.16",
  "serde",
  "toml",
  "url",
@@ -357,7 +351,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.13",
+ "semver 1.0.16",
  "serde",
  "serde_json",
 ]
@@ -391,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cexpr"
@@ -467,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
@@ -558,9 +552,9 @@ checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "cortex-m"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70858629a458fdfd39f9675c4dc309411f2a3f83bede76988d81bf1a0ecee9e0"
+checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -650,24 +644,28 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1079fb8528d9f9c888b1e8aa651e6e079ade467323d58f75faf1d30b1808f540"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "critical-section"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
+checksum = "c1706d332edc22aef4d9f23a6bb1c92360a403013c291af51247a737472dcae6"
 dependencies = [
  "bare-metal 1.0.0",
- "cfg-if",
- "cortex-m",
- "riscv",
+ "critical-section 1.1.1",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crunchy"
@@ -970,7 +968,7 @@ dependencies = [
  "toml",
  "trussed",
  "usb-device",
- "usbd-ccid",
+ "usbd-ccid 0.0.0-unreleased",
  "usbd-ctaphid 0.0.0-unreleased",
  "usbd-serial",
 ]
@@ -1035,13 +1033,13 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.18.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8c4fbf8cd36f2a96740c31320902abbf0acbd733049b758707d842490c98c4"
+checksum = "f1965703169d4c3581f1d853e6a0bacf2ad9ba5d161f58ac331de95b37584a50"
 dependencies = [
  "az",
  "bytemuck",
- "half 2.1.0",
+ "half 2.2.0",
  "typenum",
 ]
 
@@ -1081,11 +1079,10 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1100,12 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "gcd"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37978dab2ca789938a83b2f8bc1ef32db6633af9051a6cd409eff72cbaaa79a"
-dependencies = [
- "paste",
-]
+checksum = "a4b1b088ad0a967aa29540456b82fc8903f854775d33f71e9709c4efb3dfbfd2"
 
 [[package]]
 name = "gen-commands-bd"
@@ -1113,7 +1107,7 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata",
  "gumdrop",
- "semver 1.0.13",
+ "semver 1.0.16",
  "serde",
  "toml",
 ]
@@ -1211,9 +1205,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "half"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+checksum = "6c467d36af040b7b2681f5fddd27427f6da8d3d072f575a265e181d2f8e8d157"
 dependencies = [
  "crunchy",
 ]
@@ -1357,20 +1351,19 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1409,9 +1402,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "lazy_static"
@@ -1430,9 +1423,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -1483,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1558,12 +1551,6 @@ dependencies = [
  "rtic-syntax 0.4.0",
  "syn",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1666,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1702,7 +1689,7 @@ checksum = "640e88d4c108743c667f03320d0c9ab24a20f183a7a1b18bde7891ee13fd92c5"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
- "critical-section",
+ "critical-section 0.2.8",
  "usb-device",
  "vcell",
 ]
@@ -1744,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -1831,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -1903,12 +1890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,9 +1897,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pkcs1"
@@ -2012,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -2042,9 +2023,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2086,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2103,30 +2084,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
-
-[[package]]
-name = "riscv"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "riscv-target",
-]
-
-[[package]]
-name = "riscv-target"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
-dependencies = [
- "lazy_static",
- "regex",
-]
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rsa"
@@ -2220,14 +2180,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.13",
+ "semver 1.0.16",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "salty"
@@ -2258,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 dependencies = [
  "serde",
 ]
@@ -2273,9 +2233,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -2303,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2314,20 +2274,20 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2336,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2485,9 +2445,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2508,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "systick-monotonic"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e71d8e4587d8f434b88b9aef901987f46164df813a3a1d6bdf3a58debf67f0"
+checksum = "67fb822d5c615a0ae3a4795ee5b1d06381c7faf488d861c0a4fa8e6a88d5ff84"
 dependencies = [
  "cortex-m",
  "fugit",
@@ -2558,9 +2518,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -2607,22 +2567,24 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner#8de2f9f3439647cacbdbd4a6e426385846adcd4b"
+source = "git+https://github.com/trussed-dev/pc-usbip-runner#47f042642478b9e03bbb34ab14b39bec943c4c28"
 dependencies = [
+ "apdu-dispatch",
  "ctaphid-dispatch",
  "interchange",
  "log",
  "trussed",
  "usb-device",
+ "usbd-ccid 0.0.0-unreleased (git+https://github.com/Nitrokey/nitrokey-3-firmware)",
  "usbd-ctaphid 0.0.0-unreleased (git+https://github.com/Nitrokey/nitrokey-3-firmware)",
  "usbip-device",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ufmt-write"
@@ -2647,15 +2609,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -2674,9 +2636,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -2690,13 +2652,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -2709,6 +2670,19 @@ checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 [[package]]
 name = "usbd-ccid"
 version = "0.0.0-unreleased"
+dependencies = [
+ "delog",
+ "embedded-time",
+ "heapless 0.7.16",
+ "interchange",
+ "iso7816",
+ "usb-device",
+]
+
+[[package]]
+name = "usbd-ccid"
+version = "0.0.0-unreleased"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#c02188a6853a93bdaee2e673d282e621db2c1789"
 dependencies = [
  "delog",
  "embedded-time",
@@ -2736,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.0.0-unreleased"
-source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#2b499dbe4b68b010d61c657092dbdcf6fc71b308"
+source = "git+https://github.com/Nitrokey/nitrokey-3-firmware#24d40b0f1064ad411b6f5e6d37f94407d3067305"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",
@@ -2868,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 apdu-dispatch = "0.1"
 ctaphid-dispatch = "0.1"
 trussed = "0.1"
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", features = ["ctaphid"], optional = true }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ctaphid", "ccid"], optional = true }
 usbd-ctaphid = { path = "../usbd-ctaphid", optional = true }
 
 # apps

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -169,6 +169,13 @@ impl<R: Runner> trussed_usbip::Apps<Client<R>, (&R, NonPortable<R>)> for Apps<R>
     fn with_ctaphid_apps<T>(&mut self, f: impl FnOnce(&mut [&mut dyn CtaphidApp]) -> T) -> T {
         self.ctaphid_dispatch(f)
     }
+
+    fn with_ccid_apps<T>(
+        &mut self,
+        f: impl FnOnce(&mut [&mut dyn apdu_dispatch::App<7609, 7609>]) -> T,
+    ) -> T {
+        self.apdu_dispatch(f)
+    }
 }
 
 trait App<R: Runner>: Sized {

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -172,7 +172,7 @@ impl<R: Runner> trussed_usbip::Apps<Client<R>, (&R, NonPortable<R>)> for Apps<R>
 
     fn with_ccid_apps<T>(
         &mut self,
-        f: impl FnOnce(&mut [&mut dyn apdu_dispatch::App<7609, 7609>]) -> T,
+        f: impl FnOnce(&mut [&mut dyn apdu_dispatch::App<ApduCommandSize, ApduResponseSize>]) -> T,
     ) -> T {
         self.apdu_dispatch(f)
     }

--- a/components/usbd-ccid/Cargo.toml
+++ b/components/usbd-ccid/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usbd-ccid"
 version = "0.0.0-unreleased"
 authors = ["Nicolas Stalder <n@stalder.io>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/usbd-ccid/src/class.rs
+++ b/components/usbd-ccid/src/class.rs
@@ -66,7 +66,7 @@ where
     }
 
     pub fn did_start_processing(&mut self) -> Status {
-        if self.pipe.did_started_processing() {
+        if self.pipe.did_start_processing() {
             // We should send a wait extension later
             Status::ReceivedData(1_000.milliseconds())
         } else {

--- a/components/usbd-ccid/src/class.rs
+++ b/components/usbd-ccid/src/class.rs
@@ -144,15 +144,17 @@ where
             packet.resize_default(packet.capacity()).unwrap();
             let result = self.read.read(&mut packet);
             result.map(|count| {
-                packet.resize_default(count).unwrap();
+                assert!(count <= packet.capacity());
+                packet.truncate(count);
                 packet
             })
         };
 
-        // should we return an error message
-        // if the raw packet is invalid?
-        if let Ok(packet) = maybe_packet {
-            self.pipe.handle_packet(packet);
+        match maybe_packet {
+            Ok(packet) => self.pipe.handle_packet(packet),
+            Err(_err) => {
+                error!("Failed to read packet: {_err:?}");
+            }
         }
     }
 

--- a/components/usbd-ccid/src/constants.rs
+++ b/components/usbd-ccid/src/constants.rs
@@ -6,6 +6,8 @@ pub const PACKET_SIZE: usize = 64;
 
 pub const CCID_HEADER_LEN: usize = 10;
 
+pub const MAX_CCID_DATA_LEN: usize = PACKET_SIZE - CCID_HEADER_LEN;
+
 pub const CLASS_CCID: u8 = 0x0B;
 pub const SUBCLASS_NONE: u8 = 0x0;
 

--- a/components/usbd-ccid/src/constants.rs
+++ b/components/usbd-ccid/src/constants.rs
@@ -4,6 +4,8 @@ pub const PACKET_SIZE: usize = 512;
 #[cfg(not(feature = "highspeed-usb"))]
 pub const PACKET_SIZE: usize = 64;
 
+pub const CCID_HEADER_LEN: usize = 10;
+
 pub const CLASS_CCID: u8 = 0x0B;
 pub const SUBCLASS_NONE: u8 = 0x0;
 

--- a/components/usbd-ccid/src/constants.rs
+++ b/components/usbd-ccid/src/constants.rs
@@ -39,7 +39,7 @@ pub const MAX_IFSD: [u8; 4] = [0xfe, 0x00, 0x00, 0x00];
 // "The value shall be between 261 + 10 and 65544 + 10
 // dwMaxCCIDMsgLen 3072
 pub const MAX_MSG_LENGTH: usize = 3072;
-pub const MAX_MSG_LENGTH_LE: [u8; 4] = [0x00, 0x0C, 0x00, 0x00];
+pub const MAX_MSG_LENGTH_LE: [u8; 4] = (MAX_MSG_LENGTH as u32).to_le_bytes();
 
 pub const NUM_SLOTS: u8 = 1;
 pub const MAX_BUSY_SLOTS: u8 = 1;

--- a/components/usbd-ccid/src/lib.rs
+++ b/components/usbd-ccid/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
-//! https://www.usb.org/sites/default/files/DWG_Smart-Card_CCID_Rev110.pdf
-//! https://www.usb.org/sites/default/files/DWG_Smart-Card_USB-ICC_ICCD_rev10.pdf
+//! [CCID Specification for Integrated Circuit(s) Cards Interface Devices](https://www.usb.org/sites/default/files/DWG_Smart-Card_CCID_Rev110.pdf)
+//!
+//! [CCID SpecificationUSB Integrated Circuit(s) Card Devices](https://www.usb.org/sites/default/files/DWG_Smart-Card_USB-ICC_ICCD_rev10.pdf)
 
 #[macro_use]
 extern crate delog;

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -160,7 +160,7 @@ where
         // only (can we fix this), so 255B is the maximum)
         if !self.receiving_long {
             if packet.len() < 10 {
-                panic!("unexpected short packet");
+                panic!("unexpected short packet. Len: {}", packet.len());
             }
             self.ext_packet.clear();
             // TODO check
@@ -280,7 +280,7 @@ where
                         self.state = State::Receiving;
                         self.send_empty_datablock(Chain::ExpectingMore);
                     }
-                    _ => panic!("unexpectedly in idle state"),
+                    chain => panic!("unexpectedly in idle state. Got chain: {chain:?}",),
                 }
             }
 
@@ -300,7 +300,7 @@ where
                     self.call_app();
                     self.state = State::Processing;
                 }
-                _ => panic!("unexpectedly in receiving state"),
+                chain => panic!("unexpectedly in receiving state. Got chain: {chain:?}",),
             },
 
             State::Processing => {
@@ -320,7 +320,7 @@ where
                 Chain::ExpectingMore => {
                     self.prime_outbox();
                 }
-                _ => panic!("unexpectedly in receiving state"),
+                chain => panic!("unexpectedly in receiving state. Got chain: {chain:?}"),
             },
         }
     }
@@ -368,12 +368,14 @@ where
 
     #[inline(never)]
     pub fn poll_app(&mut self) {
+        info!("Poll_app");
         if State::Processing == self.state {
             // info!("processing, checking for response, interchange state {:?}",
             //           self.interchange.state()).ok();
-
+            info!("State: processing");
             if interchange::State::Responded == self.interchange.state() {
                 // we should have an open XfrBlock allowance
+                info!("Has response");
                 self.state = State::ReadyToSend;
                 self.sent = 0;
                 self.prime_outbox();
@@ -529,7 +531,7 @@ where
                     info!("waiting to send");
                 }
 
-                Err(_) => panic!("unexpected send error"),
+                Err(err) => panic!("unexpected send error {err:?}"),
             }
         }
     }

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -167,10 +167,10 @@ where
             self.ext_packet.extend_from_slice(&packet).unwrap();
 
             let pl = packet.data_len();
-            if pl > 54 {
+            if pl > MAX_CCID_DATA_LEN {
                 self.receiving_long = true;
                 self.in_chain = 1;
-                self.long_packet_missing = pl - 54;
+                self.long_packet_missing = pl - MAX_CCID_DATA_LEN;
                 self.packet_len = pl;
                 return;
             } else {

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -166,7 +166,7 @@ where
             // TODO check
             self.ext_packet.extend_from_slice(&packet).unwrap();
 
-            let pl = packet.packet_len();
+            let pl = packet.data_len();
             if pl > 54 {
                 self.receiving_long = true;
                 self.in_chain = 1;
@@ -180,7 +180,12 @@ where
             // TODO check
             self.ext_packet.extend_from_slice(&packet).ok();
             self.in_chain += 1;
-            assert!(packet.len() <= self.long_packet_missing);
+            assert!(
+                packet.len() <= self.long_packet_missing,
+                "Got packet of length {}, expected max {}",
+                packet.len(),
+                self.long_packet_missing
+            );
             self.long_packet_missing -= packet.len();
             if self.long_packet_missing > 0 {
                 return;

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -159,7 +159,7 @@ where
         // when certificates are transmitted, because PIV somehow uses short APDUs
         // only (can we fix this), so 255B is the maximum)
         if !self.receiving_long {
-            if packet.len() < 10 {
+            if packet.len() < CCID_HEADER_LEN {
                 panic!("unexpected short packet. Len: {}", packet.len());
             }
             self.ext_packet.clear();
@@ -334,7 +334,7 @@ where
         if self.state == State::Processing {
             // Need to send a wait extension request.
             let mut packet = RawPacket::new();
-            packet.resize_default(10).ok();
+            packet.resize_default(CCID_HEADER_LEN).ok();
             packet[0] = 0x80;
             packet[6] = self.seq;
 
@@ -401,7 +401,7 @@ where
         let message = self.interchange.response().unwrap();
         // let message: &mut Vec<u8, N> = unsafe { (*self.interchange.interchange.get()).rp_mut() };
 
-        let chunk_size = core::cmp::min(PACKET_SIZE - 10, message.len() - self.sent);
+        let chunk_size = core::cmp::min(PACKET_SIZE - CCID_HEADER_LEN, message.len() - self.sent);
         let chunk = &message[self.sent..][..chunk_size];
         self.sent += chunk_size;
         let more = self.sent < message.len();
@@ -442,7 +442,7 @@ where
 
     fn send_slot_status_ok(&mut self) {
         let mut packet = RawPacket::new();
-        packet.resize_default(10).ok();
+        packet.resize_default(CCID_HEADER_LEN).ok();
         packet[0] = 0x81;
         packet[6] = self.seq;
         self.send_packet_assuming_possible(packet);
@@ -450,7 +450,7 @@ where
 
     fn send_slot_status_error(&mut self, error: Error) {
         let mut packet = RawPacket::new();
-        packet.resize_default(10).ok();
+        packet.resize_default(CCID_HEADER_LEN).ok();
         packet[0] = 0x6c;
         packet[6] = self.seq;
         packet[7] = 1 << 6;

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -391,7 +391,8 @@ where
         }
 
         // if let Some(message) = self.interchange.response() {
-        let message: &mut Vec<u8, N> = unsafe { (*self.interchange.interchange.get()).rp_mut() };
+        let message = self.interchange.response().unwrap();
+        // let message: &mut Vec<u8, N> = unsafe { (*self.interchange.interchange.get()).rp_mut() };
 
         let chunk_size = core::cmp::min(PACKET_SIZE - 10, message.len() - self.sent);
         let chunk = &message[self.sent..][..chunk_size];
@@ -532,14 +533,6 @@ where
             }
         }
     }
-
-    // pub fn read_address(&self) -> EndpointAddress {
-    //     self.read.address()
-    // }
-
-    // pub fn write_address(&self) -> EndpointAddress {
-    //     self.write.address()
-    // }
 
     // Called if we receive an ABORT request on the control pipe.
     pub fn expect_abort(&mut self, slot: u8, seq: u8) {

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -397,9 +397,7 @@ where
             panic!("Outbox is already primed");
         }
 
-        // if let Some(message) = self.interchange.response() {
         let message = self.interchange.response().unwrap();
-        // let message: &mut Vec<u8, N> = unsafe { (*self.interchange.interchange.get()).rp_mut() };
 
         let chunk_size = core::cmp::min(PACKET_SIZE - CCID_HEADER_LEN, message.len() - self.sent);
         let chunk = &message[self.sent..][..chunk_size];
@@ -432,7 +430,6 @@ where
 
         // fast-lane response attempt
         self.maybe_send_packet();
-        // }
     }
 
     fn send_empty_datablock(&mut self, chain: Chain) {

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -387,7 +387,7 @@ where
         }
 
         if self.outbox.is_some() {
-            panic!();
+            panic!("Outbox is already primed");
         }
 
         // if let Some(message) = self.interchange.response() {

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -325,7 +325,7 @@ where
                 Chain::ExpectingMore => {
                     self.prime_outbox();
                 }
-                chain => panic!("unexpectedly in receiving state. Got chain: {chain:?}"),
+                chain => panic!("unexpectedly in sending state. Got chain: {chain:?}"),
             },
         }
     }

--- a/components/usbd-ccid/src/pipe.rs
+++ b/components/usbd-ccid/src/pipe.rs
@@ -348,7 +348,7 @@ where
     }
 
     /// Turns false on read.  Intended for checking to see if a wait extension request needs to be started.
-    pub fn did_started_processing(&mut self) -> bool {
+    pub fn did_start_processing(&mut self) -> bool {
         if self.started_processing {
             self.started_processing = false;
             true
@@ -368,7 +368,7 @@ where
 
     #[inline(never)]
     pub fn poll_app(&mut self) {
-        if let State::Processing = self.state {
+        if State::Processing == self.state {
             // info!("processing, checking for response, interchange state {:?}",
             //           self.interchange.state()).ok();
 

--- a/components/usbd-ccid/src/types/packet.rs
+++ b/components/usbd-ccid/src/types/packet.rs
@@ -6,11 +6,11 @@ pub type RawPacket = heapless::Vec<u8, PACKET_SIZE>;
 pub type ExtPacket = heapless::Vec<u8, MAX_MSG_LENGTH>;
 
 pub trait RawPacketExt {
-    fn packet_len(&self) -> usize;
+    fn data_len(&self) -> usize;
 }
 
 impl RawPacketExt for RawPacket {
-    fn packet_len(&self) -> usize {
+    fn data_len(&self) -> usize {
         u32::from_le_bytes(self[1..5].try_into().unwrap()) as usize
     }
 }

--- a/components/usbd-ccid/src/types/packet.rs
+++ b/components/usbd-ccid/src/types/packet.rs
@@ -61,7 +61,7 @@ pub trait ChainedPacket: Packet {
             2 => Chain::Ends,
             3 => Chain::Continues,
             0x10 => Chain::ExpectingMore,
-            _ => panic!("invalid power select parameter"),
+            _ => panic!("invalid power select parameter {level_parameter:x}"),
         }
     }
 }
@@ -294,7 +294,7 @@ impl PowerOn {
             1 => PowerSelection::V5,
             2 => PowerSelection::V3_3,
             3 => PowerSelection::V1_8,
-            _ => panic!("invalid power select parameter"),
+            _ => panic!("invalid power select parameter {:x}", &self[7]),
         }
     }
 }

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 apps = { path = "../../components/apps" }
 cfg-if = "*"
 delog = "0.1"
-cortex-m = "0.7"
+cortex-m = { version = "0.7", features = ["critical-section-single-core"]}
 cortex-m-rtic = "1.0"
 embedded-storage = "0.3"
 embedded-hal = "0.2.3"

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -13,7 +13,7 @@ log = { version = "0.4.14", default-features = false }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 pretty_env_logger = "0.4.0"
 trussed = { version = "0.1", features = ["clients-3"] }
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", features = ["ctaphid"] }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ctaphid", "ccid"] }
 
 [features]
 alpha = ["apps/alpha"]


### PR DESCRIPTION
This PR cleans up `usbd-ccid` a bit and adds the CCID apps (opcard) to the usbip runner.

Closes #140, #150 and #151

On my machine I enconter 2 bugs:

- `pcscd` and this somehow manage to trigger a kernel bug:
  1. `cargo run --release --features alpha
  2.  `usbip attach -r localhost -b 1-1` (enough times for it to not return immediately)
  3. `opgpcard status` 
  4. now `lsusb`  hangs and `dmesg` shows an error: `kernel BUG at mm/usercopy.c:101!`

- `gpg` still fails to detect this as an openpgp smartcard for some reason