### PR TITLE
embedded/lpc55: Use external flash in USB mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ dependencies = [
  "usbd-ccid 0.1.0",
  "usbd-ctaphid 0.1.0",
  "usbd-serial",
+ "utils",
 ]
 
 [[package]]
@@ -1453,7 +1454,7 @@ checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
 [[package]]
 name = "littlefs2"
 version = "0.3.2"
-source = "git+https://github.com/Nitrokey/littlefs2?tag=v0.3.2-nitrokey-1#23b9e5028ce0b2ff77c78545c44ac75da9a79acb"
+source = "git+https://github.com/Nitrokey/littlefs2?tag=v0.3.2-nitrokey-2#c2d2605baa1bbe9341dba349e4bc3ef42299b5fa"
 dependencies = [
  "bitflags",
  "cstr_core",
@@ -2764,6 +2765,14 @@ dependencies = [
  "rand_core",
  "trussed",
  "trussed-usbip",
+]
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "delog",
+ "littlefs2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,11 +2760,13 @@ dependencies = [
  "clap 3.2.23",
  "clap-num",
  "delog",
+ "littlefs2",
  "log",
  "pretty_env_logger",
  "rand_core",
  "trussed",
  "trussed-usbip",
+ "utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "1.2.2"
 [patch.crates-io]
 # forked
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.1-nitrokey-1" }
-littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
+littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey-1" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
 

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+delog = "0.1"
+littlefs2 = "0.3"
+
+[features]
+log-all = []
+log-none = []
+log-info = []
+log-debug = []
+log-warn = []
+log-error = []

--- a/components/utils/src/lib.rs
+++ b/components/utils/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+extern crate delog;
+delog::generate_macros!();
+
+mod storage;
+
+pub use storage::{OptionalStorage, RamStorage};

--- a/components/utils/src/storage.rs
+++ b/components/utils/src/storage.rs
@@ -1,0 +1,125 @@
+use core::marker::PhantomData;
+
+use littlefs2::{driver::Storage, io::Error};
+
+// Chosen so that the littlefs2 header fits.  Note that using this size will cause a `NoSpace`
+// error during formatting.  The filesystem will still be mountable though.
+const DEFAULT_RAM_SIZE: usize = 256;
+const ERASED: u8 = 0xff;
+
+pub struct RamStorage<S, const SIZE: usize> {
+    buf: [u8; SIZE],
+    _marker: PhantomData<S>,
+}
+
+impl<S: Storage, const SIZE: usize> Storage for RamStorage<S, SIZE> {
+    const BLOCK_SIZE: usize = S::BLOCK_SIZE;
+    const READ_SIZE: usize = S::READ_SIZE;
+    const WRITE_SIZE: usize = S::WRITE_SIZE;
+    const BLOCK_COUNT: usize = S::BLOCK_COUNT;
+
+    type CACHE_SIZE = S::CACHE_SIZE;
+    type LOOKAHEADWORDS_SIZE = S::LOOKAHEADWORDS_SIZE;
+
+    fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, Error> {
+        let read_size: usize = Self::READ_SIZE;
+        debug_assert!(off % read_size == 0);
+        debug_assert!(buf.len() % read_size == 0);
+        for (from, to) in self.buf.iter().skip(off).zip(buf.iter_mut()) {
+            *to = *from;
+        }
+        // Data outside of the RAM part is always erased
+        for to in buf.iter_mut().skip(self.buf.len().saturating_sub(off)) {
+            *to = ERASED;
+        }
+        Ok(buf.len())
+    }
+
+    fn write(&mut self, off: usize, data: &[u8]) -> Result<usize, Error> {
+        // TODO: return error if out of range?
+        let write_size: usize = Self::WRITE_SIZE;
+        debug_assert!(off % write_size == 0);
+        debug_assert!(data.len() % write_size == 0);
+        for (from, to) in data.iter().zip(self.buf.iter_mut().skip(off)) {
+            *to = *from;
+        }
+        Ok(data.len())
+    }
+
+    fn erase(&mut self, off: usize, len: usize) -> Result<usize, Error> {
+        let block_size: usize = Self::BLOCK_SIZE;
+        debug_assert!(off % block_size == 0);
+        debug_assert!(len % block_size == 0);
+        for byte in self.buf.iter_mut().skip(off).take(len) {
+            *byte = ERASED;
+        }
+        Ok(len)
+    }
+}
+
+impl<S, const SIZE: usize> Default for RamStorage<S, SIZE> {
+    fn default() -> Self {
+        Self {
+            buf: [0xff; SIZE],
+            _marker: Default::default(),
+        }
+    }
+}
+
+pub enum OptionalStorage<S, const RAM_SIZE: usize = DEFAULT_RAM_SIZE> {
+    Storage(S),
+    Ram(RamStorage<S, RAM_SIZE>),
+}
+
+impl<S: Storage, const RAM_SIZE: usize> OptionalStorage<S, RAM_SIZE> {
+    pub fn is_ram(&self) -> bool {
+        matches!(self, Self::Ram(_))
+    }
+}
+
+impl<S: Storage, const RAM_SIZE: usize> Storage for OptionalStorage<S, RAM_SIZE> {
+    const BLOCK_SIZE: usize = S::BLOCK_SIZE;
+    const READ_SIZE: usize = S::READ_SIZE;
+    const WRITE_SIZE: usize = S::WRITE_SIZE;
+    const BLOCK_COUNT: usize = S::BLOCK_COUNT;
+
+    type CACHE_SIZE = S::CACHE_SIZE;
+    type LOOKAHEADWORDS_SIZE = S::LOOKAHEADWORDS_SIZE;
+
+    fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, Error> {
+        info_now!("EFr {:x} {:x}", off, buf.len());
+        match self {
+            Self::Storage(s) => s.read(off, buf),
+            Self::Ram(s) => s.read(off, buf),
+        }
+    }
+
+    fn write(&mut self, off: usize, data: &[u8]) -> Result<usize, Error> {
+        info_now!("EFw {:x} {:x}", off, data.len());
+        match self {
+            Self::Storage(s) => s.write(off, data),
+            Self::Ram(s) => s.write(off, data),
+        }
+    }
+
+    fn erase(&mut self, off: usize, len: usize) -> Result<usize, Error> {
+        info_now!("EFe {:x} {:x}", off, len);
+        match self {
+            Self::Storage(s) => s.erase(off, len),
+            Self::Ram(s) => s.erase(off, len),
+        }
+    }
+}
+
+impl<S, const RAM_SIZE: usize> Default for OptionalStorage<S, RAM_SIZE> {
+    fn default() -> Self {
+        Self::Ram(Default::default())
+    }
+}
+
+impl<S, const RAM_SIZE: usize> From<S> for OptionalStorage<S, RAM_SIZE> {
+    fn from(storage: S) -> Self {
+        Self::Storage(storage)
+    }
+}
+

--- a/components/utils/src/storage.rs
+++ b/components/utils/src/storage.rs
@@ -32,17 +32,21 @@ impl<S: Storage, const SIZE: usize> Storage for RamStorage<S, SIZE> {
         for to in buf.iter_mut().skip(self.buf.len().saturating_sub(off)) {
             *to = ERASED;
         }
+        info!("{}: {:?}", buf.len(), buf);
         Ok(buf.len())
     }
 
     fn write(&mut self, off: usize, data: &[u8]) -> Result<usize, Error> {
-        // TODO: return error if out of range?
+        if off + data.len() > SIZE {
+            return Err(Error::NoSpace);
+        }
         let write_size: usize = Self::WRITE_SIZE;
         debug_assert!(off % write_size == 0);
         debug_assert!(data.len() % write_size == 0);
         for (from, to) in data.iter().zip(self.buf.iter_mut().skip(off)) {
             *to = *from;
         }
+        info!("{}: {:?}", data.len(), data);
         Ok(data.len())
     }
 

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -23,6 +23,7 @@ nfc-device = { path = "../../components/nfc-device" }
 rand_core = "0.6"
 rtt-target = { version = "0.3", features = ["cortex-m"], optional = true }
 spi-memory = "0.2.0"
+utils = { path = "../../components/utils" }
 
 ### protocols and dispatchers
 apdu-dispatch = "0.1"

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -116,7 +116,7 @@ mod app {
         #[cfg(not(feature = "extflash_qspi"))]
         let extflash = ERL::soc::types::ExternalStorage::new();
 
-        let store: ERL::types::RunnerStore = ERL::init_store(internal_flash, extflash);
+        let store: ERL::types::RunnerStore = ERL::init_store(internal_flash, extflash, false);
 
         let usbnfcinit = ERL::init_usb_nfc(usbd_ref, None);
         /* TODO: set up fingerprint device */

--- a/runners/embedded/src/soc_lpc55/spi.rs
+++ b/runners/embedded/src/soc_lpc55/spi.rs
@@ -20,10 +20,12 @@ use lpc55_hal::{
 pub type SckPin = pins::Pio0_28;
 pub type MosiPin = pins::Pio0_24;
 pub type MisoPin = pins::Pio0_25;
+pub type FlashCsPin = pins::Pio0_13;
 
 pub type Sck = Pin<SckPin, pin::state::Special<pin::function::FC0_SCK>>;
 pub type Mosi = Pin<MosiPin, pin::state::Special<pin::function::FC0_RXD_SDA_MOSI_DATA>>;
 pub type Miso = Pin<MisoPin, pin::state::Special<pin::function::FC0_TXD_SCL_MISO_WS>>;
+pub type FlashCs = Pin<FlashCsPin, pin::state::Gpio<pin::gpio::direction::Output>>;
 
 pub type Spi = SpiMaster<SckPin, MosiPin, MisoPin, NoPio, Spi0, (Sck, Mosi, Miso, NoCs)>;
 

--- a/runners/embedded/src/soc_lpc55/types.rs
+++ b/runners/embedded/src/soc_lpc55/types.rs
@@ -1,22 +1,21 @@
 use super::board::{button::ThreeButtons, led::RgbLed};
+use super::spi::{FlashCs, Spi};
 use super::trussed::UserInterface;
-use crate::types::build_constants;
+use crate::{flash::ExtFlashStorage, types::build_constants};
 use embedded_time::duration::Milliseconds;
-use littlefs2::const_ram_storage;
 use lpc55_hal::{
     drivers::timer,
     peripherals::{ctimer, flash, rng, syscon},
     raw,
     traits::flash::WriteErase,
 };
-use trussed::types::{LfsResult, LfsStorage};
+use trussed::types::LfsResult;
+use utils::OptionalStorage;
 
 //////////////////////////////////////////////////////////////////////////////
 // Upper Interface (definitions towards ERL Core)
 
 pub static mut DEVICE_UUID: [u8; 16] = [0u8; 16];
-
-const_ram_storage!(ExternalRAMStorage, 1024);
 
 #[cfg(feature = "no-encrypted-storage")]
 use lpc55_hal::littlefs2_filesystem;
@@ -42,7 +41,7 @@ const INTERFACE_CONFIG: crate::types::Config = crate::types::Config {
 pub struct Soc {}
 impl crate::types::Soc for Soc {
     type InternalFlashStorage = InternalFilesystem;
-    type ExternalFlashStorage = ExternalRAMStorage;
+    type ExternalFlashStorage = OptionalStorage<ExtFlashStorage<Spi, FlashCs>>;
     type UsbBus = lpc55_hal::drivers::UsbBus<UsbPeripheral>;
     type NfcDevice = super::nfc::NfcChip;
     type Rng = rng::Rng<lpc55_hal::Enabled>;

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -9,11 +9,13 @@ cfg-if = { version = "1.0.0" }
 clap = { version = "3.0.0", features = ["cargo", "derive"] }
 clap-num = "1.0.0"
 delog = { version = "0.1.6", features = ["std-log"] }
+littlefs2 = { version = "0.3" }
 log = { version = "0.4.14", default-features = false }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 pretty_env_logger = "0.4.0"
 trussed = { version = "0.1", features = ["clients-3"] }
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ctaphid", "ccid"] }
+utils = { path = "../../components/utils", features = ["log-all"] }
 
 [features]
 alpha = ["apps/alpha"]

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -1,3 +1,5 @@
+mod store;
+
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -9,6 +11,8 @@ use trussed::{
     virt::{self, StoreProvider},
     Platform,
 };
+
+use store::Ram;
 
 const MANUFACTURER: &str = "Nitrokey";
 const PRODUCT: &str = "Nitrokey 3";
@@ -160,7 +164,7 @@ fn main() {
     if let Some(ifs) = args.ifs {
         exec(virt::Filesystem::new(ifs), options, args.serial);
     } else {
-        exec(virt::Ram::default(), options, args.serial);
+        exec(Ram::default(), options, args.serial);
     }
 }
 

--- a/runners/usbip/src/store.rs
+++ b/runners/usbip/src/store.rs
@@ -1,0 +1,95 @@
+// for store!
+#![allow(clippy::too_many_arguments)]
+
+use std::marker::PhantomData;
+
+use littlefs2::{const_ram_storage, fs::Allocation};
+use trussed::{
+    store,
+    types::{LfsResult, LfsStorage},
+    virt::StoreProvider,
+};
+use utils::OptionalStorage;
+
+const STORAGE_SIZE: usize = 512 * 128;
+
+static mut INTERNAL_RAM_STORAGE: Option<InternalStorage> = None;
+static mut INTERNAL_RAM_FS_ALLOC: Option<Allocation<InternalStorage>> = None;
+
+static mut EXTERNAL_STORAGE: Option<ExternalStorage> = None;
+static mut EXTERNAL_FS_ALLOC: Option<Allocation<ExternalStorage>> = None;
+
+static mut VOLATILE_STORAGE: Option<VolatileStorage> = None;
+static mut VOLATILE_FS_ALLOC: Option<Allocation<VolatileStorage>> = None;
+
+const_ram_storage!(InternalStorage, STORAGE_SIZE);
+// Modelled after the actual external RAM, see src/flash.rs in the embedded runner
+const_ram_storage!(
+    name=ExternalRamStorage,
+    trait=LfsStorage,
+    erase_value=0xff,
+    read_size=4,
+    write_size=256,
+    cache_size_ty=littlefs2::consts::U512,
+    block_size=4096,
+    block_count=0x2_0000 / 4096,
+    lookaheadwords_size_ty=littlefs2::consts::U2,
+    filename_max_plus_one_ty=littlefs2::consts::U256,
+    path_max_plus_one_ty=littlefs2::consts::U256,
+    result=LfsResult,
+);
+const_ram_storage!(VolatileStorage, STORAGE_SIZE);
+
+// TODO: use 256 -- would cause a panic because formatting fails
+type ExternalStorage = OptionalStorage<ExternalRamStorage, 4356>;
+
+store!(
+    RamStore,
+    Internal: InternalStorage,
+    External: ExternalStorage,
+    Volatile: VolatileStorage
+);
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Ram;
+
+impl StoreProvider for Ram {
+    type Store = RamStore;
+
+    unsafe fn ifs() -> &'static mut InternalStorage {
+        INTERNAL_RAM_STORAGE.as_mut().expect("ifs not initialized")
+    }
+
+    unsafe fn store() -> Self::Store {
+        Self::Store { __: PhantomData }
+    }
+
+    unsafe fn reset(&self) {
+        INTERNAL_RAM_STORAGE.replace(InternalStorage::new());
+        INTERNAL_RAM_FS_ALLOC.replace(littlefs2::fs::Filesystem::allocate());
+        reset_external();
+        reset_volatile();
+
+        Self::store()
+            .mount(
+                INTERNAL_RAM_FS_ALLOC.as_mut().unwrap(),
+                INTERNAL_RAM_STORAGE.as_mut().unwrap(),
+                EXTERNAL_FS_ALLOC.as_mut().unwrap(),
+                EXTERNAL_STORAGE.as_mut().unwrap(),
+                VOLATILE_FS_ALLOC.as_mut().unwrap(),
+                VOLATILE_STORAGE.as_mut().unwrap(),
+                true,
+            )
+            .expect("failed to mount filesystem");
+    }
+}
+
+unsafe fn reset_external() {
+    EXTERNAL_STORAGE.replace(ExternalStorage::default());
+    EXTERNAL_FS_ALLOC.replace(littlefs2::fs::Filesystem::allocate());
+}
+
+unsafe fn reset_volatile() {
+    VOLATILE_STORAGE.replace(VolatileStorage::new());
+    VOLATILE_FS_ALLOC.replace(littlefs2::fs::Filesystem::allocate());
+}


### PR DESCRIPTION
This patch changes the external storage for the lpc55 SoC in the embedded runner to the external flash unless the device is in passive NFC mode.  In this case, 1024 bytes of RAM are used to simulate the external flash.

TODO:
- [x] investigate RamStorage formatting
- [x] investigate RamStorage size
- [x] investigate RamStorage bounds
- [x] ensure NFC is configured