### PR TITLE
Add lint target and CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,3 +123,17 @@ build-usbip:
   artifacts:
     paths:
       - artifacts
+
+lint:
+  image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+  tags:
+    - docker
+  stage: build
+  script:
+    - make lint
+  after_script:
+    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,11 @@
-RUNNER := runners/lpc55
+.PHONY: check
+check:
+	$(MAKE) -C runners/embedded check-all
+	$(MAKE) -C runners/usbip check
 
-build:
-	make -C $(RUNNER) build
-
-bacon:
-	make -C $(RUNNER) bacon
-
-run:
-	make -C $(RUNNER) run
-
-jlink:
-	scripts/bump-jlink
-	JLinkGDBServer -strict -device LPC55S69 -if SWD -vd
-
-mount-fs:
-	scripts/fuse-bee
-
-umount-fs:
-	scripts/defuse-bee
+.PHONY: lint
+lint:
+	cargo fmt -- --check
 
 license.txt:
 	cargo run --release --manifest-path utils/collect-license-info/Cargo.toml -- runners/embedded/Cargo.toml > license.txt

--- a/runners/usbip/Makefile
+++ b/runners/usbip/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all
+all: check lint
+
+.PHONY: check
+check:
+	cargo check
+	cargo check --features alpha
+	cargo check --features provisioner
+
+.PHONY: lint
+lint:
+	cargo clippy --no-deps
+	cargo fmt -- --check


### PR DESCRIPTION
This PR cleans up some Makefiles, adds a `lint` target to run `rustfmt` and a CI job to execute `make lint`.  The target name is based on our discussion in https://github.com/Nitrokey/nitrokey-3-firmware/pull/144.