### PR TITLE
nRF: journaling IFS for better power loss resistance & migration mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "collect-license-info"
 version = "0.1.0"
 dependencies = [
@@ -787,6 +793,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "delog"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,7 +974,10 @@ dependencies = [
  "embedded-time",
  "fm11nc08",
  "generic-array 0.14.6",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
  "interchange",
+ "lfs-backup",
  "littlefs2",
  "lpc55-hal",
  "lpc55-pac",
@@ -1119,6 +1141,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab17bb279def6720d058cb6c052249938e7f99260ab534879281a95367a87e5"
 dependencies = [
  "gcd",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+
+[[package]]
+name = "futures-task"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-util"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1446,6 +1545,21 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lfs-backup"
+version = "0.1.0"
+dependencies = [
+ "generic-array 0.14.6",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "littlefs2",
+ "postcard 1.0.2",
+ "rand",
+ "serde",
+ "serial_test",
+ "trussed",
+]
 
 [[package]]
 name = "libc"
@@ -1917,6 +2031,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +2064,18 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -1969,6 +2118,17 @@ checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
  "heapless 0.7.16",
  "postcard-cobs",
+ "serde",
+]
+
+[[package]]
+name = "postcard"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
+dependencies = [
+ "cobs",
+ "heapless 0.7.16",
  "serde",
 ]
 
@@ -2080,6 +2240,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha",
  "rand_core",
 ]
@@ -2101,6 +2262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2333,6 +2503,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538c30747ae860d6fb88330addbbd3e0ddbe46d662d032855596d8a8ca260611"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2576,15 @@ checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest 0.9.0",
  "rand_core",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2590,7 +2794,7 @@ dependencies = [
  "nb 1.0.0",
  "num-bigint-dig",
  "p256-cortex-m4",
- "postcard",
+ "postcard 0.7.3",
  "rand_chacha",
  "rand_core",
  "rsa",
@@ -2853,6 +3057,63 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "zeroize"

--- a/components/lfs-backup/Cargo.toml
+++ b/components/lfs-backup/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "lfs-backup"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+
+littlefs2 = "0.3.2"
+generic-array = "0.14.6"
+
+heapless-bytes = "0.3.0"
+heapless = "0.7.16"
+
+serde = { version = "1.0", default-features = false }
+postcard = "1.0"
+
+trussed = "0.1"
+
+[dev-dependencies]
+rand = "0.8.5"
+serial_test = "1.0"

--- a/components/lfs-backup/src/lfs_backup.rs
+++ b/components/lfs-backup/src/lfs_backup.rs
@@ -27,6 +27,7 @@ pub enum FSBackupError {
     PathAssemblyErr,
     BackendWriteErr,
     BackendReadErr,
+    BackendEraseErr,
     SerializeErr,
     DeserializeErr,
     PathStackFullErr,

--- a/components/lfs-backup/src/lfs_backup.rs
+++ b/components/lfs-backup/src/lfs_backup.rs
@@ -1,0 +1,287 @@
+use littlefs2::consts::PATH_MAX;
+use littlefs2::fs::{Attribute, DirEntry, Filesystem};
+
+use littlefs2::path::{Path, PathBuf};
+
+use postcard;
+use serde::{Deserialize, Serialize};
+
+use heapless::Vec;
+use heapless_bytes::Bytes;
+
+use trussed::config::{MAX_MESSAGE_LENGTH, USER_ATTRIBUTE_NUMBER};
+
+use trussed::types::{Message, UserAttribute};
+
+pub const MAX_FS_DEPTH: usize = 8;
+
+pub const MAX_DUMP_BLOB_LENGTH: usize = 256 * 10;
+
+const LEN_PREFIX_SIZE: usize = 4;
+const FS_BACKUP_START_DELIM: &[u8; 4] = b"SB||";
+const FS_BACKUP_END_DELIM: &[u8; 4] = b"||EB";
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum FSBackupError {
+    LittleFs2Err,
+    PathAssemblyErr,
+    BackendWriteErr,
+    BackendReadErr,
+    SerializeErr,
+    DeserializeErr,
+    PathStackFullErr,
+    EndOfBackupBlobs,
+    StartOfBackupBlobs,
+    RestoreErr,
+    UserAttributeErr,
+    DataAssemblyErr,
+}
+
+impl From<littlefs2::io::Error> for FSBackupError {
+    fn from(_error: littlefs2::io::Error) -> Self {
+        Self::LittleFs2Err
+    }
+}
+
+pub type Result<T, E = FSBackupError> = core::result::Result<T, E>;
+
+#[derive(Clone, Debug)]
+pub struct PathCursor {
+    pub path: PathBuf,
+    pub idx: usize,
+    pub attr: Option<UserAttribute>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FSEntryBlob {
+    path: Bytes<PATH_MAX>,
+    is_dir: bool,
+    content: Option<Message>,
+    attr: Option<UserAttribute>,
+}
+
+pub trait BackupBackend {
+    // for simplicity we only have one size for read & write
+    const RW_SIZE: usize;
+
+    fn read<const N: usize>(&mut self, len: usize) -> Result<Bytes<N>>;
+    fn write(&mut self, content: &[u8]) -> Result<usize>;
+    fn erase(&mut self) -> Result<usize>;
+    fn reset(&mut self);
+
+    fn write_start(&mut self) -> Result<usize> {
+        self.write(FS_BACKUP_START_DELIM.as_slice())
+    }
+
+    fn write_end(&mut self) -> Result<usize> {
+        self.write(FS_BACKUP_END_DELIM.as_slice())
+    }
+
+    fn write_entry(
+        &mut self,
+        entry: &DirEntry,
+        content: Option<Message>,
+        attr: Option<UserAttribute>,
+    ) -> Result<usize> {
+        let path_bytes =
+            Bytes::<PATH_MAX>::from_slice(entry.path().as_str_ref_with_trailing_nul().as_bytes())
+                .map_err(|_| FSBackupError::PathAssemblyErr)?;
+
+        let blob = FSEntryBlob {
+            path: path_bytes,
+            is_dir: entry.file_type().is_dir(),
+            content,
+            attr,
+        };
+        // assemble to-be-written blob => <data-len: big-endian u32><data>
+        let raw_blob: Vec<u8, MAX_DUMP_BLOB_LENGTH> =
+            postcard::to_vec(&blob).map_err(|_| FSBackupError::SerializeErr)?;
+        let raw_blob_len: u32 = raw_blob.len() as u32;
+        let raw_blob_len_bin = raw_blob_len.to_be_bytes();
+
+        let mut buf = Bytes::<MAX_DUMP_BLOB_LENGTH>::new();
+        buf.extend_from_slice(&raw_blob_len_bin)
+            .map_err(|_| FSBackupError::DataAssemblyErr)?;
+        buf.extend_from_slice(&raw_blob)
+            .map_err(|_| FSBackupError::DataAssemblyErr)?;
+
+        self.write(buf.as_slice())
+    }
+
+    fn read_next(&mut self) -> Result<FSEntryBlob> {
+        let chunk_one: Bytes<MAX_DUMP_BLOB_LENGTH> = self.read(Self::RW_SIZE)?;
+
+        let mut prefix = [0u8; LEN_PREFIX_SIZE];
+        prefix.copy_from_slice(&chunk_one.as_slice()[..4]);
+
+        if &prefix == FS_BACKUP_START_DELIM {
+            return Err(FSBackupError::StartOfBackupBlobs);
+        } else if &prefix == FS_BACKUP_END_DELIM {
+            return Err(FSBackupError::EndOfBackupBlobs);
+        }
+        let blob_len: u32 = u32::from_be_bytes(prefix);
+
+        // handle blob with length > (RW_SIZE - 4) => more `read` calls
+        let postcard_bytes = if blob_len > (Self::RW_SIZE - 4) as u32 {
+            let mut buf = Bytes::<MAX_DUMP_BLOB_LENGTH>::new();
+            buf.extend_from_slice(&chunk_one.as_slice()[4..])
+                .map_err(|_| FSBackupError::DataAssemblyErr)?;
+            let remaining_chunks: Bytes<MAX_DUMP_BLOB_LENGTH> =
+                self.read(blob_len as usize - (Self::RW_SIZE - 4))?;
+            buf.extend_from_slice(&remaining_chunks)
+                .map_err(|_| FSBackupError::DataAssemblyErr)?;
+            buf
+        // all data for entry already `read` no further `read` calls needed
+        } else {
+            Bytes::from_slice(&chunk_one.as_slice()[4..])
+                .map_err(|_| FSBackupError::BackendReadErr)?
+        };
+
+        postcard::from_bytes(postcard_bytes.as_slice()).map_err(|_| FSBackupError::DeserializeErr)
+    }
+
+    /// return the next filesystem entry inside 'path' after offset 'off'
+    fn get_next_entry<S: littlefs2::driver::Storage>(
+        fs: &Filesystem<S>,
+        path: &PathBuf,
+        off: usize,
+    ) -> Result<Option<DirEntry>> {
+        fs.read_dir_and_then(path, |it| {
+            // skip "." & ".."
+            Ok(it.enumerate().nth(off + 2))
+        })
+        .map_err(|_| FSBackupError::LittleFs2Err)
+        .map(|v| v.map(|iv| iv.1.unwrap()))
+    }
+
+    fn backup<S: littlefs2::driver::Storage>(
+        &mut self,
+        fs: &Filesystem<S>,
+    ) -> Result<(usize, usize)> {
+        let root_dir = PathBuf::from("/");
+
+        let mut path_stack: Vec<PathCursor, MAX_FS_DEPTH> = Vec::new();
+        path_stack
+            .push(PathCursor {
+                path: root_dir,
+                idx: 0,
+                attr: None,
+            })
+            .map_err(|_| FSBackupError::PathStackFullErr)?;
+
+        self.write_start()?;
+
+        let mut d_cnt: usize = 0;
+        let mut f_cnt: usize = 0;
+        while !path_stack.is_empty() {
+            let mut current = path_stack.pop().unwrap();
+            let next_path = Self::get_next_entry(fs, &current.path, current.idx)?;
+
+            // 'None' => no next item inside this directory, continue w/o adding 'current'
+            // back to 'path_stack' implicitly means this subtree is done
+            if next_path == None {
+                continue;
+            }
+
+            let entry = next_path.unwrap();
+
+            // move index "pointer" to next item
+            current.idx += 1;
+
+            let attr = fs
+                .attribute(entry.path(), USER_ATTRIBUTE_NUMBER)?
+                .map(|v| UserAttribute::from_slice(v.data()))
+                .transpose()
+                .map_err(|_| FSBackupError::UserAttributeErr)?;
+
+            if entry.file_type().is_dir() {
+                d_cnt += 1;
+
+                let path = PathBuf::from(entry.path());
+
+                path_stack
+                    .push(current)
+                    .map_err(|_| FSBackupError::PathStackFullErr)?;
+                path_stack
+                    .push(PathCursor {
+                        path,
+                        idx: 0,
+                        attr: attr.clone(),
+                    })
+                    .map_err(|_| FSBackupError::PathStackFullErr)?;
+                self.write_entry(&entry, None, attr)?;
+            } else {
+                f_cnt += 1;
+                path_stack
+                    .push(current)
+                    .map_err(|_| FSBackupError::PathStackFullErr)?;
+
+                let file_contents = entry.file_type().is_file().then(|| {
+                    Message::from_slice(
+                        fs.read::<MAX_MESSAGE_LENGTH>(entry.path())
+                            .unwrap()
+                            .as_slice(),
+                    )
+                    .expect("file contents: bytes creation failed")
+                });
+                self.write_entry(&entry, file_contents, attr)?;
+            }
+        }
+
+        self.write_end()?;
+
+        Ok((d_cnt, f_cnt))
+    }
+
+    fn restore<S: littlefs2::driver::Storage>(
+        &mut self,
+        fs: &Filesystem<S>,
+    ) -> Result<(usize, usize)> {
+        let next_entry = self.read_next();
+        if let Err(err) = next_entry {
+            if err != FSBackupError::StartOfBackupBlobs {
+                return Err(err);
+            }
+        }
+
+        let mut d_cnt: usize = 0;
+        let mut f_cnt: usize = 0;
+        loop {
+            let next_entry = self.read_next();
+            match next_entry {
+                Ok(v) => {
+                    let path = Path::from_bytes_with_nul(v.path.as_slice())
+                        .map_err(|_| FSBackupError::PathAssemblyErr)?;
+                    if v.is_dir {
+                        d_cnt += 1;
+                        fs.create_dir(path)?;
+
+                        if let Some(user_attr) = v.attr {
+                            let mut attr = Attribute::new(USER_ATTRIBUTE_NUMBER);
+                            attr.set_data(user_attr.as_slice());
+                            fs.set_attribute(path, &attr)?
+                        };
+                    } else {
+                        f_cnt += 1;
+                        let content = v.content.unwrap();
+                        fs.write(path, content.as_slice())?;
+
+                        if let Some(user_attr) = v.attr {
+                            let mut attr = Attribute::new(USER_ATTRIBUTE_NUMBER);
+                            attr.set_data(user_attr.as_slice());
+                            fs.set_attribute(path, &attr)?;
+                        };
+                    }
+                }
+                Err(e) => {
+                    if e == FSBackupError::EndOfBackupBlobs {
+                        break;
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+        Ok((d_cnt, f_cnt))
+    }
+}

--- a/components/lfs-backup/src/lib.rs
+++ b/components/lfs-backup/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+mod lfs_backup;
+
+pub use crate::lfs_backup::*;

--- a/components/lfs-backup/src/lib.rs
+++ b/components/lfs-backup/src/lib.rs
@@ -3,3 +3,10 @@
 mod lfs_backup;
 
 pub use crate::lfs_backup::*;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;

--- a/components/lfs-backup/src/lib.rs
+++ b/components/lfs-backup/src/lib.rs
@@ -1,5 +1,38 @@
 #![no_std]
 
+//! LittleFS2 backup and restore mechanism to/from low-level NVM interfaces.
+//!
+//! This component realizes a backup/restore operation using a littlefs2
+//! `Filesystem` as the source resp. target. The counterpart is denoted
+//! a `BackupBackend`, which is a trait that needs to be implemented.
+//!
+//! Low-level flash devices (NVMs) mostly come with intrinsic restrictions
+//! like read/write/erase sizes (i.e., blocks). The `BackupBackend`
+//! implementation has to strictly enforce them and set `RW_SIZE` accordingly.
+//!
+//! # Backup Data Layout
+//! A full backup binary blob consists of:
+//! ```text
+//! FS_BACKUP_START_DELIM | Entry1 | Entry2 | … | FS_BACKUP_END_DELIM
+//! ```
+//! With `EntryX` being:
+//!
+//! | bytes   | content                           |
+//! |---------|-----------------------------------|
+//! |  0 - 3  | Big-Endian length of the blob     |
+//! |  4 - n  | postcard-serialized `FSEntryBlob` |
+//!
+//! # Important Implementation Details
+//! * The `BackupBackend` implementation has to maintain an internal *cursor*
+//!   pointing at the current position inside the backup blob
+//! * `read` & `write` are explicitly *not* responsible to cache or manipulate
+//!   the passed content in any way - this is implemented in `read_next` &
+//!   `write_entry`
+//! * The *cursor* should move forward by multiples of `RW_SIZE` for
+//!   *every* `read` & `write` invocation as by definition the low-level
+//!   interfaces for most flash memories will not allow multiple writes
+//!   within the same block (i.e., within `RW_SIZE` bytes)
+
 mod lfs_backup;
 
 pub use crate::lfs_backup::*;

--- a/components/lfs-backup/src/tests.rs
+++ b/components/lfs-backup/src/tests.rs
@@ -1,0 +1,477 @@
+use littlefs2::fs::Filesystem;
+use littlefs2::path::{Path, PathBuf};
+
+use heapless::Vec;
+use heapless_bytes::Bytes;
+
+use crate::lfs_backup::{BackupBackend, FSBackupError, PathCursor, Result, MAX_FS_DEPTH};
+
+use trussed::config::USER_ATTRIBUTE_NUMBER;
+use trussed::types::UserAttribute;
+
+use std::{
+    fs::{remove_file, File},
+    io::{Read, Seek as _, SeekFrom, Write},
+    path::Path as StdPath,
+    path::PathBuf as StdPathBuf,
+    string::{String, ToString},
+};
+
+pub use generic_array::{
+    typenum::{consts, U128, U16, U2, U256, U4096, U512},
+    GenericArray,
+};
+
+pub struct FileFlash {
+    path: std::path::PathBuf,
+}
+
+#[derive(Clone)]
+struct FileBackend {
+    offset: usize,
+    path: StdPathBuf,
+}
+
+type LfsResult<T> = Result<T, littlefs2::io::Error>;
+
+pub const FS_SIZE: usize = 1920 * 1024; // 2MB - 128kb
+
+const ORIGIN_FS_PATH: &str = "/tmp/test.fs";
+const TARGET_FS_PATH: &str = "/tmp/target.fs";
+const BACKUP_DATA_PATH: &str = "/tmp/backend.test.bin";
+
+impl FileFlash {
+    pub fn new(state_path: impl AsRef<std::path::Path>) -> Self {
+        let path: std::path::PathBuf = state_path.as_ref().into();
+
+        if let Ok(file) = File::open(&path) {
+            assert_eq!(file.metadata().unwrap().len(), FS_SIZE as u64);
+            println!("using existing state file: {path:?}");
+        } else {
+            let file = File::create(&path).unwrap();
+            file.set_len(FS_SIZE as u64).unwrap();
+            println!("Created new state file: {path:?}");
+        }
+        Self { path }
+    }
+}
+
+impl FileBackend {
+    pub fn new(data_path: &StdPath) -> Self {
+        let path: std::path::PathBuf = data_path.into();
+
+        const FILE_SIZE: u64 = FS_SIZE as u64;
+        if let Ok(file) = File::open(&path) {
+            assert_eq!(file.metadata().unwrap().len(), FILE_SIZE);
+            println!("using existing backend file: {:?}", &data_path);
+        } else {
+            let file = File::create(&path).unwrap();
+            file.set_len(FILE_SIZE).unwrap();
+            println!("Created new backend file: {:?}", &data_path);
+        }
+
+        Self { offset: 0, path }
+    }
+}
+
+impl BackupBackend for FileBackend {
+    const RW_SIZE: usize = 256;
+
+    fn write(&mut self, content: &[u8]) -> Result<usize> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&self.path)
+            .map_err(|_| FSBackupError::BackendWriteErr)?;
+
+        file.seek(SeekFrom::Start(self.offset as _))
+            .map_err(|_| FSBackupError::BackendWriteErr)?;
+
+        let bytes_written = file
+            .write(content)
+            .map_err(|_| FSBackupError::BackendWriteErr)?;
+
+        assert_eq!(bytes_written, content.len());
+
+        self.offset +=
+            bytes_written + ((Self::RW_SIZE - (bytes_written % Self::RW_SIZE)) % Self::RW_SIZE);
+
+        assert_eq!(self.offset % Self::RW_SIZE, 0);
+
+        file.flush().unwrap();
+        Ok(bytes_written)
+    }
+
+    fn read<const N: usize>(&mut self, len: usize) -> Result<Bytes<N>> {
+        let mut buffer = [0u8; N];
+        let mut file = File::open(&self.path).map_err(|_| FSBackupError::BackendReadErr)?;
+
+        file.seek(SeekFrom::Start(self.offset as _))
+            .map_err(|_| FSBackupError::BackendReadErr)?;
+
+        file.read_exact(&mut buffer[..len])
+            .map_err(|_| FSBackupError::BackendReadErr)?;
+
+        let output =
+            Bytes::<N>::from_slice(&buffer[..len]).map_err(|_| FSBackupError::BackendReadErr)?;
+
+        assert_eq!(len, output.len());
+
+        self.offset +=
+            output.len() + ((Self::RW_SIZE - (output.len() % Self::RW_SIZE)) % Self::RW_SIZE);
+
+        assert_eq!(self.offset % Self::RW_SIZE, 0);
+
+        //println!("requested: {len} new offset: {}", self.offset);
+        //println!("{:02x?}", output);
+
+        Ok(output)
+    }
+
+    fn erase(&mut self) -> Result<usize> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&self.path)
+            .map_err(|_| FSBackupError::BackendWriteErr)?;
+        let content: [u8; FS_SIZE] = [0x00u8; FS_SIZE];
+        file.write(&content)
+            .map_err(|_| FSBackupError::BackendWriteErr)
+    }
+
+    fn reset(&mut self) {
+        self.offset = 0;
+    }
+}
+
+fn fill_test_file(fs: &Filesystem<FileFlash>, p: &str, data: &str) -> usize {
+    let path = Path::from_bytes_with_nul(p.as_bytes()).expect("path-fail");
+    let data = data.as_bytes();
+    fs.write(path, data).expect("write fail");
+
+    path.to_string().len() + data.len()
+}
+
+fn fill_random_test_file(fs: &Filesystem<FileFlash>, p: &str) -> usize {
+    let path = Path::from_bytes_with_nul(p.as_bytes()).expect("path-fail");
+
+    let data: String = thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(thread_rng().gen_range(0..512))
+        .map(char::from)
+        .collect();
+
+    fs.write(path, &data.as_bytes()).expect("write fail");
+
+    path.to_string().len() + data.len()
+}
+
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+
+fn fill_test_data(
+    fs: &Filesystem<FileFlash>,
+    num_files: u32,
+    deterministic: bool,
+) -> (usize, usize, usize) {
+    let mut d_cnt: usize = 0;
+    let mut f_cnt: usize = 0;
+    let mut data_size = 0;
+
+    let path = PathBuf::from("/was/geht/denn/bluba");
+    let data = "blablblalbalab".as_bytes();
+    fs.create_dir_all(&path.parent().unwrap())
+        .expect("dir create 1 fail");
+    fs.write(&path, data).expect("write 1 fail");
+    f_cnt += 1;
+    d_cnt += 3;
+    data_size += data.len() + path.to_string().len();
+
+    let path = PathBuf::from("/was/geht/denn/hier");
+    let data = "".as_bytes();
+    fs.create_dir_all(&path.parent().unwrap())
+        .expect("dir create 2 fail");
+    fs.write(&path, data).expect("write 2 fail");
+    f_cnt += 1;
+    d_cnt += 0;
+    data_size += data.len() + &path.to_string().len();
+
+    let path = PathBuf::from("/was/dort");
+    let data = "".as_bytes();
+    fs.create_dir_all(&path.parent().unwrap())
+        .expect("dir create 3 fail");
+    fs.write(&path, data).expect("write 3 fail");
+    f_cnt += 1;
+    d_cnt += 0;
+    data_size += data.len() + path.to_string().len();
+
+    let path = PathBuf::from("/testdir/");
+    fs.create_dir_all(&path).expect("dir create fail");
+
+    let data =
+        "sowqxxxxxxxxxxxxxxxxxxxxxxxxxxxxxdwfqefewefwfwefeweffwewdqwdqdwfewefwefxwefxoejfofwe";
+
+    for idx in 0..num_files {
+        if deterministic {
+            let data = if idx % 13 != 0 {
+                format!("{data}{idx:0>4}")
+            } else {
+                String::from("")
+            };
+            data_size += fill_test_file(fs, &format!("/testdir/testfile{idx:0>4}\0"), &data);
+        } else {
+            data_size += fill_random_test_file(fs, &format!("/testdir/testfile{idx:0>4}\0"));
+        }
+    }
+    d_cnt += 1;
+    f_cnt += num_files as usize;
+
+    (d_cnt, f_cnt, data_size)
+}
+
+impl littlefs2::driver::Storage for FileFlash {
+    const READ_SIZE: usize = 4;
+    const WRITE_SIZE: usize = 4;
+    const BLOCK_SIZE: usize = 256;
+
+    const BLOCK_COUNT: usize = (FS_SIZE / Self::BLOCK_SIZE as usize);
+    const BLOCK_CYCLES: isize = -1;
+
+    type CACHE_SIZE = U256;
+    type LOOKAHEADWORDS_SIZE = U2;
+
+    fn read(&mut self, offset: usize, buffer: &mut [u8]) -> LfsResult<usize> {
+        let mut file = File::open(&self.path).unwrap();
+        file.seek(SeekFrom::Start(offset as _)).unwrap();
+        let bytes_read = file.read(buffer).unwrap();
+        assert_eq!(bytes_read, buffer.len());
+        Ok(bytes_read as _)
+    }
+
+    fn write(&mut self, offset: usize, data: &[u8]) -> LfsResult<usize> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&self.path)
+            .unwrap();
+        file.seek(SeekFrom::Start(offset as _)).unwrap();
+        let bytes_written = file.write(data).unwrap();
+        assert_eq!(bytes_written, data.len());
+        file.flush().unwrap();
+        Ok(bytes_written)
+    }
+
+    fn erase(&mut self, offset: usize, len: usize) -> LfsResult<usize> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&self.path)
+            .unwrap();
+        file.seek(SeekFrom::Start(offset as _)).unwrap();
+        let zero_block = [0xFFu8; Self::BLOCK_SIZE];
+        for _ in 0..(len / Self::BLOCK_SIZE) {
+            let bytes_written = file.write(&zero_block).unwrap();
+            assert_eq!(bytes_written, Self::BLOCK_SIZE);
+        }
+        file.flush().unwrap();
+        Ok(len)
+    }
+}
+
+pub fn equal_filesystems(
+    fs1: &Filesystem<FileFlash>,
+    fs2: &Filesystem<FileFlash>,
+) -> (usize, usize) {
+    let root_dir = PathBuf::from("/");
+
+    let mut path_stack: Vec<PathCursor, MAX_FS_DEPTH> = Vec::new();
+    path_stack
+        .push(PathCursor {
+            path: root_dir,
+            idx: 0,
+            attr: None,
+        })
+        .map_err(|_| FSBackupError::PathStackFullErr)
+        .unwrap();
+
+    let mut d_cnt: usize = 0;
+    let mut f_cnt: usize = 0;
+
+    while !path_stack.is_empty() {
+        let mut current = path_stack.pop().unwrap();
+        let next_path = FileBackend::get_next_entry(fs1, &current.path, current.idx).unwrap();
+
+        // 'None' => no next item inside this directory, continue w/o adding 'current'
+        // back to 'path_stack' implicitly means this subtree is done
+        if next_path == None {
+            continue;
+        }
+
+        let entry = next_path.unwrap();
+
+        // move index "pointer" to next item
+        current.idx += 1;
+
+        let info = fs2
+            .metadata(entry.path())
+            .expect("path (metadata) not found");
+
+        assert_eq!(info, entry.metadata());
+
+        let attr1 = fs1
+            .attribute(entry.path(), USER_ATTRIBUTE_NUMBER)
+            .unwrap()
+            .map(|v| UserAttribute::from_slice(v.data()))
+            .transpose()
+            .expect("user attr err");
+
+        let attr2 = fs2
+            .attribute(entry.path(), USER_ATTRIBUTE_NUMBER)
+            .unwrap()
+            .map(|v| UserAttribute::from_slice(v.data()))
+            .transpose()
+            .expect("user attr err");
+
+        assert_eq!(attr1, attr2);
+
+        if entry.metadata().is_file() {
+            f_cnt += 1;
+            let content1 = fs1.read::<1024>(entry.path()).unwrap();
+            let content2 = fs2.read::<1024>(entry.path()).unwrap();
+            assert_eq!(content1, content2);
+
+            path_stack.push(current).expect("path stack full");
+        } else {
+            d_cnt += 1;
+            path_stack.push(current).expect("path stack full");
+
+            let mut path = PathBuf::new();
+            path.push(entry.path());
+
+            path_stack
+                .push(PathCursor {
+                    path,
+                    idx: 0,
+                    attr: attr1,
+                })
+                .expect("path stack full");
+        }
+    }
+    (d_cnt, f_cnt)
+}
+
+fn fsbackup(num_files: u32, deterministic: bool) {
+    // cleanup old paths
+    for del_path in [ORIGIN_FS_PATH, TARGET_FS_PATH, BACKUP_DATA_PATH].iter() {
+        if StdPath::new(del_path).exists() {
+            remove_file(del_path).expect("failed deleting file");
+        }
+    }
+
+    // prepare origin fs (backup target)
+    let mut alloc: littlefs2::fs::Allocation<FileFlash> = Filesystem::allocate();
+    let mut storage = FileFlash::new(ORIGIN_FS_PATH);
+    Filesystem::format(&mut storage).expect("(origin) format failed");
+    let fs = Filesystem::mount(&mut alloc, &mut storage).expect("failed mount");
+
+    // output some fs info
+    let i_blocks = fs.available_blocks().unwrap();
+    let i_space = fs.available_space().unwrap();
+    println!(
+        "initial - fs blocks: {:?} fs space: {:?}",
+        i_blocks, i_space
+    );
+
+    // populate origin fs with test data
+    let (num_dirs, num_files, data_size) = fill_test_data(&fs, num_files, deterministic);
+
+    // output some fs info (after test data population)
+    let f_blocks = fs.available_blocks().unwrap();
+    let f_space = fs.available_space().unwrap();
+    println!(
+        "filled - fs blocks: {:?} fs space: {:?}",
+        f_blocks,
+        fs.available_space().unwrap()
+    );
+    let used_blocks = i_blocks - f_blocks;
+    let used_space = i_space - f_space;
+    let per_file = data_size / num_files;
+    let space_usage = (data_size * 100) / used_space;
+    println!("used blocks: {used_blocks} used space: {used_space} usage ratio: {space_usage}%");
+    println!("wrote dirs/files: {num_dirs}/{num_files} wrote bytes: {data_size} size per file: {per_file}");
+
+    // prepare target fs (restore target)
+    let mut target_alloc: littlefs2::fs::Allocation<FileFlash> = Filesystem::allocate();
+    let mut target_storage = FileFlash::new(TARGET_FS_PATH);
+    Filesystem::format(&mut target_storage).expect("(target) formatting failed");
+    let target_fs =
+        Filesystem::mount(&mut target_alloc, &mut target_storage).expect("failed target mount");
+
+    // prepare intermediate `FSBackup` storage blob
+    let backend_path = StdPath::new(BACKUP_DATA_PATH);
+    let mut backend = FileBackend::new(backend_path);
+
+    // execute backup from origin fs -> `FSBackup` storage blob
+    let res_backup = backend.backup(&fs);
+
+    backend.reset();
+
+    // execute restore from `FSBackup` storage blob -> target fs
+    let res_restore = backend.restore(&target_fs);
+
+    println!("RESULTS: {res_backup:?} {res_restore:?}");
+
+    let count_orig = if let (Ok(b_count), Ok(r_count)) = (res_backup, res_restore) {
+        println!("backup count: {b_count:?} restore count: {r_count:?}");
+        assert_eq!(b_count, r_count);
+        b_count
+    } else {
+        panic!("failed backup/restore");
+    };
+
+    // output some target fs info (restore target)
+    println!(
+        "restored - fs blocks: {:?} fs space: {:?}",
+        target_fs.available_blocks().unwrap(),
+        target_fs.available_space().unwrap()
+    );
+
+    // check pair-wise equivalence of origin fs vs. target fs
+    let count1 = equal_filesystems(&fs, &target_fs);
+    let count2 = equal_filesystems(&target_fs, &fs);
+
+    assert_eq!(count1, count2);
+    assert_eq!(count1, count_orig);
+    assert_eq!((num_dirs, num_files), count_orig);
+
+    println!("filesystems are equal!");
+    println!("checked files for equality: {count1:?}");
+}
+
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn fsbackup_deterministic_small() {
+    fsbackup(100, true);
+}
+
+#[test]
+#[serial]
+fn fsbackup_nondeterministic_small() {
+    fsbackup(100, false);
+}
+
+#[test]
+#[serial]
+fn fsbackup_deterministic_medium() {
+    fsbackup(300, true);
+}
+
+#[test]
+#[serial]
+fn fsbackup_nondeterministic_medium() {
+    fsbackup(300, false);
+}
+
+#[test]
+#[serial]
+fn fsbackup_nondeterministic_big() {
+    fsbackup(750, false);
+}

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -24,6 +24,10 @@ rand_core = "0.6"
 rtt-target = { version = "0.3", features = ["cortex-m"], optional = true }
 spi-memory = "0.2.0"
 utils = { path = "../../components/utils" }
+serde = { version = "1.0", default-features = false }
+heapless = "0.7"
+heapless-bytes = { version = "0.3.0", features = ["cbor"] }
+lfs-backup = { path = "../../components/lfs-backup" }
 
 ### protocols and dispatchers
 apdu-dispatch = "0.1"
@@ -87,7 +91,7 @@ alloc = ["alloc-cortex-m"]
 
 board-nrfdk = ["soc-nrf52840", "extflash_qspi"]
 board-proto1 = ["soc-nrf52840"]
-board-nk3am = ["soc-nrf52840" , "extflash_qspi"]
+board-nk3am = ["soc-nrf52840", "extflash_qspi"]
 
 board-nk3xn = ["soc-lpc55"]
 

--- a/runners/embedded/src/flash.rs
+++ b/runners/embedded/src/flash.rs
@@ -41,10 +41,10 @@ where
     type LOOKAHEADWORDS_SIZE = generic_array::typenum::U2;
 
     fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, Error> {
-        trace!("EFr {:x} {:x}", off, buf.len());
+        /*trace!("EFr {:x} {:x}", off, buf.len());
         if buf.len() == 0 {
             return Ok(0);
-        }
+        }*/
         if buf.len() > FLASH_PROPERTIES.size || off > FLASH_PROPERTIES.size - buf.len() {
             return Err(Error::Unknown(0x6578_7046));
         }

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -73,8 +73,16 @@ pub fn init_store(
 
     /* Step 2: try mounting each FS in turn */
     if !littlefs2::fs::Filesystem::is_mountable(ifs_storage) {
+        #[cfg(feature = "provisioner")]
         let _fmt_ext = littlefs2::fs::Filesystem::format(ifs_storage);
-        error!("IFS Mount Error, Reformat {:?}", _fmt_ext);
+        //error!("IFS Mount Error, Reformat {:?}", _fmt_ext);
+        //panic!("FAILED TRYING TO MOUNT IFS");
+
+        #[cfg(all(feature = "board-nk3am", not(feature = "provisioner")))]
+        {
+            // recover on failed mount
+            ifs_storage.recover_from_journal();
+        }
         status.insert(types::InitStatus::INTERNAL_FLASH_ERROR);
     };
     let ifs = match littlefs2::fs::Filesystem::mount(ifs_alloc, ifs_storage) {

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -7,6 +7,11 @@ use soc::types::Soc as SocT;
 use types::Soc;
 use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
 
+#[cfg(feature = "board-nk3am")]
+use soc::migrations::ftl_journal;
+#[cfg(feature = "board-nk3am")]
+use soc::migrations::ftl_journal::ifs_flash_old::FlashStorage as OldFlashStorage;
+
 extern crate delog;
 delog::generate_macros!();
 
@@ -72,28 +77,65 @@ pub fn init_store(
     let vfs_alloc = transcend!(types::VOLATILE_FS_ALLOC, Filesystem::allocate());
 
     /* Step 2: try mounting each FS in turn */
-    if !littlefs2::fs::Filesystem::is_mountable(ifs_storage) {
-        #[cfg(feature = "provisioner")]
-        let _fmt_ext = littlefs2::fs::Filesystem::format(ifs_storage);
-        //error!("IFS Mount Error, Reformat {:?}", _fmt_ext);
-        //panic!("FAILED TRYING TO MOUNT IFS");
+    if !Filesystem::is_mountable(ifs_storage) {
+        // handle provisioner
+        if cfg!(feature = "provisioner") {
+            info_now!("IFS mount failed - provisioner => formatting");
+            let _fmt_int = Filesystem::format(ifs_storage);
+        } else {
+            status.insert(types::InitStatus::INTERNAL_FLASH_ERROR);
 
-        #[cfg(all(feature = "board-nk3am", not(feature = "provisioner")))]
-        {
-            // recover on failed mount
-            ifs_storage.recover_from_journal();
+            // handle lpc55 boards
+            #[cfg(feature = "board-nk3xn")]
+            {
+                let _fmt_int = Filesystem::format(ifs_storage);
+                error_now!("IFS (lpc55) mount-fail");
+            }
+
+            // handle nRF42 boards
+            #[cfg(feature = "board-nk3am")]
+            {
+                error_now!("IFS (nrf42) mount-fail");
+
+                // regular mount failed, try mounting "old" (pre-journaling) IFS
+                let pac = unsafe { nrf52840_pac::Peripherals::steal() };
+                let mut old_ifs_storage = OldFlashStorage::new(pac.NVMC);
+                let mut old_ifs_alloc: littlefs2::fs::Allocation<OldFlashStorage> =
+                    Filesystem::allocate();
+                let old_mountable = Filesystem::is_mountable(&mut old_ifs_storage);
+
+                // we can mount the old ifs filesystem, thus we need to migrate
+                if old_mountable {
+                    let mounted_ifs = ftl_journal::migrate(
+                        &mut old_ifs_storage,
+                        &mut old_ifs_alloc,
+                        ifs_alloc,
+                        ifs_storage,
+                        efs_storage,
+                    );
+                    // migration went fine => use its resulting IFS
+                    if let Ok(()) = mounted_ifs {
+                        info_now!("migration ok, mounting IFS");
+                    // migration failed => format IFS
+                    } else {
+                        error_now!("failed migration, formatting IFS");
+                        let _fmt_ifs = Filesystem::format(ifs_storage);
+                    }
+                } else {
+                    info_now!("recovering from journal");
+                    // IFS and old-IFS cannot be mounted, try to recover from journal
+                    ifs_storage.recover_from_journal();
+                }
+            }
         }
-        status.insert(types::InitStatus::INTERNAL_FLASH_ERROR);
-    };
-    let ifs = match littlefs2::fs::Filesystem::mount(ifs_alloc, ifs_storage) {
-        Ok(ifs_) => {
-            transcend!(types::INTERNAL_FS, ifs_)
-        }
-        Err(_e) => {
-            error!("IFS Mount Error {:?}", _e);
-            panic!("store");
-        }
-    };
+    }
+
+    #[cfg(feature = "board-nk3am")]
+    ifs_storage.format_journal_blocks();
+
+    let ifs_ = Filesystem::mount(ifs_alloc, ifs_storage).expect("Could not bring up IFS!");
+    let ifs = transcend!(types::INTERNAL_FS, ifs_);
+
     if !littlefs2::fs::Filesystem::is_mountable(efs_storage) {
         let fmt_ext = littlefs2::fs::Filesystem::format(efs_storage);
         if simulated_efs && fmt_ext == Err(littlefs2::io::Error::NoSpace) {

--- a/runners/embedded/src/soc_nrf52840/flash.rs
+++ b/runners/embedded/src/soc_nrf52840/flash.rs
@@ -7,29 +7,229 @@ use crate::types::build_constants::{
 pub const FLASH_BASE: *mut u8 = FS_BASE as *mut u8;
 pub const FLASH_SIZE: usize = FS_CEIL - FS_BASE;
 
+const REAL_BLOCK_SIZE: usize = 4 * 1024;
+
+const FTL_BLOCK_SIZE: usize = 256;
+const FTL_JOURNAL_BLOCKS: usize = 2;
+const FTL_BLOCKS_IN_REAL: usize = REAL_BLOCK_SIZE / FTL_BLOCK_SIZE;
+
+// relative to FLASH_BASE
+const FTL_JOURNAL_START: u32 = 0;
+
+#[derive(Clone)]
+pub struct JournalInfo {
+    pub idx: u32,
+    pub cnt: u32,
+}
+
 pub struct FlashStorage {
-    nvmc: nrf52840_hal::nvmc::Nvmc<nrf52840_pac::NVMC>,
+    pub nvmc: nrf52840_hal::nvmc::Nvmc<nrf52840_pac::NVMC>,
+    next_journal: Option<JournalInfo>,
+}
+
+impl FlashStorage {
+    pub fn format_journal_blocks(&mut self) {
+        // erase entire journal region
+        self.nvmc
+            .erase(
+                FTL_JOURNAL_START,
+                (FTL_JOURNAL_BLOCKS * REAL_BLOCK_SIZE) as u32,
+            )
+            .unwrap();
+
+        // format, for each block:
+        // * write counter, which equals the block idx
+        // * write 0x00 into remaining block
+        let buf: [u8; (FTL_BLOCK_SIZE - 4)] = [0x00; (FTL_BLOCK_SIZE - 4)];
+        for idx in 0..FTL_JOURNAL_BLOCKS as u32 {
+            let addr = FTL_JOURNAL_START + (REAL_BLOCK_SIZE * idx as usize) as u32;
+            self.nvmc.write(addr, &idx.to_be_bytes()).unwrap();
+            self.nvmc.write(addr + 4, &buf).unwrap();
+        }
+    }
+
+    pub fn get_next_journal(&mut self) -> JournalInfo {
+        // search journal blocks for max(cnt)
+        if self.next_journal.is_none() {
+            let (min_idx, min_cnt) = (0..FTL_JOURNAL_BLOCKS as u32)
+                .map(|idx| (idx, self.get_journal_cnt(idx)))
+                .min_by_key(|item| item.1)
+                .unwrap();
+            // ... and set `next_journal` accordingly
+            self.next_journal = Some(JournalInfo {
+                idx: min_idx,
+                cnt: min_cnt,
+            });
+        }
+        // common case: just return `next_journal`
+        trace!("cnt: {}", self.next_journal.clone().unwrap().cnt);
+        self.next_journal.clone().unwrap()
+    }
+
+    pub fn get_last_journal(&mut self) -> JournalInfo {
+        // for recovery the latest written (max counter) block is needed
+        let (max_idx, max_cnt) = (0..FTL_JOURNAL_BLOCKS as u32)
+            .map(|idx| (idx, self.get_journal_cnt(idx)))
+            .max_by_key(|item| item.1)
+            .unwrap();
+
+        JournalInfo {
+            idx: max_idx,
+            cnt: max_cnt,
+        }
+    }
+
+    pub fn get_journal_cnt(&mut self, block_idx: u32) -> u32 {
+        // read counter for given `block_idx` from nvm
+        let mut buf: [u8; 4] = [0x00; 4];
+        let block_addr = FTL_JOURNAL_START + (REAL_BLOCK_SIZE * block_idx as usize) as u32;
+        self.nvmc.read(block_addr, &mut buf).unwrap();
+
+        // construct counter
+        let mut jrnl_cnt_raw: [u8; 4] = [0u8; 4];
+        jrnl_cnt_raw.copy_from_slice(&buf);
+        let jrnl_cnt = u32::from_be_bytes(jrnl_cnt_raw);
+
+        // freshly erased block? 0xff == u32::MAX
+        // if so, format all journal blocks
+        if jrnl_cnt == u32::MAX {
+            self.format_journal_blocks();
+            trace!("FORMATTING JOURNAL BLOCKS ????");
+            // default cnt after formatting == block idx
+            block_idx
+        } else {
+            jrnl_cnt
+        }
+    }
+
+    pub fn write_journal(&mut self, src_addr: usize, data: &[u8], lhs_len: usize, rhs_off: usize) {
+        // Writing the journal, contents
+        // * counter     => overall journal pages written, smallest used for next
+        // * source addr => where to write-back to in case of recovery
+        // * lhs len     => length of left part
+        // * rhs off     => offset of right part (relative to block)
+        // * lhs data    => lhs journal data
+        // * rhs data    => rhs journal data
+
+        // get journal block & calc its address
+        let jinfo = self.get_next_journal();
+        let addr = FTL_JOURNAL_START + (jinfo.idx * REAL_BLOCK_SIZE as u32);
+
+        // erase journal block
+        self.nvmc
+            .erase(addr as u32, addr + REAL_BLOCK_SIZE as u32)
+            .unwrap();
+
+        // write meta-data
+        let write_vals = [jinfo.cnt, src_addr as u32, lhs_len as u32, rhs_off as u32];
+        for (idx, data) in (0..4).zip(write_vals) {
+            self.nvmc
+                .write(addr + idx * 4, &data.to_be_bytes())
+                .unwrap();
+        }
+
+        // write lhs + rhs for journaled block
+        if lhs_len > 0 {
+            self.nvmc
+                .write((addr + 16) as u32, &data[..lhs_len])
+                .unwrap();
+        }
+
+        let rhs_len = (REAL_BLOCK_SIZE - rhs_off) as u32;
+        if rhs_len > 0 {
+            self.nvmc
+                .write(addr + 16 + lhs_len as u32, &data[rhs_off..])
+                .unwrap();
+        }
+
+        trace!(
+            "wrote jrnl {FTL_JOURNAL_START:x} {src_addr:x} {lhs_len:x} {rhs_off:x} {:x}",
+            data.len()
+        );
+
+        // move next journal info to next slot + inc counter
+        self.next_journal = Some(JournalInfo {
+            idx: (jinfo.idx + 1) % (FTL_JOURNAL_BLOCKS as u32),
+            cnt: jinfo.cnt + 1,
+        });
+    }
+
+    pub fn recover_from_journal(&mut self) -> bool {
+        trace!("RECOVERING FROM JOURNAL");
+
+        // get last written journal block & calc its address
+        let jinfo = self.get_last_journal();
+        let addr = FTL_JOURNAL_START + jinfo.idx * REAL_BLOCK_SIZE as u32;
+
+        // read entire block at once
+        let mut buf: [u8; REAL_BLOCK_SIZE] = [0x00; REAL_BLOCK_SIZE];
+        self.nvmc.read(addr, &mut buf).unwrap();
+
+        // read meta-data
+        let mut cnt_raw: [u8; 4] = [0u8; 4];
+        cnt_raw.copy_from_slice(&buf[..4]);
+        let _cnt = u32::from_be_bytes(cnt_raw);
+
+        let mut src_addr_raw: [u8; 4] = [0u8; 4];
+        src_addr_raw.copy_from_slice(&buf[4..8]);
+        let src_addr = u32::from_be_bytes(src_addr_raw);
+
+        let mut lhs_len_raw: [u8; 4] = [0u8; 4];
+        lhs_len_raw.copy_from_slice(&buf[8..12]);
+        let lhs_len = u32::from_be_bytes(lhs_len_raw);
+
+        let mut rhs_off_raw: [u8; 4] = [0u8; 4];
+        rhs_off_raw.copy_from_slice(&buf[12..16]);
+        let rhs_off = u32::from_be_bytes(rhs_off_raw);
+        let rhs_len = REAL_BLOCK_SIZE - rhs_off as usize;
+
+        // erase target block inside littlefs2 space
+        self.nvmc
+            .erase(src_addr as u32, (src_addr + REAL_BLOCK_SIZE as u32) as u32)
+            .unwrap();
+
+        // write back journaled lhs + rhs
+        if lhs_len > 0 {
+            self.nvmc
+                .write(src_addr, &buf[16..((lhs_len + 16) as usize)])
+                .unwrap();
+        }
+        if rhs_len > 0 {
+            self.nvmc
+                .write(
+                    src_addr + rhs_off,
+                    &buf[((lhs_len + 16) as usize)..((rhs_len + 16 + lhs_len as usize) as usize)],
+                )
+                .unwrap();
+        }
+        trace!("RECOVER complete count: {_cnt} idx: {}", jinfo.idx);
+
+        true
+    }
 }
 
 impl littlefs2::driver::Storage for FlashStorage {
-    const BLOCK_SIZE: usize = 256;
+    const BLOCK_SIZE: usize = FTL_BLOCK_SIZE;
     const READ_SIZE: usize = 4;
-    const WRITE_SIZE: usize = 4;
-    const BLOCK_COUNT: usize = FLASH_SIZE / Self::BLOCK_SIZE;
+    const WRITE_SIZE: usize = FTL_BLOCK_SIZE;
+    const BLOCK_COUNT: usize =
+        (FLASH_SIZE / Self::BLOCK_SIZE) - (FTL_BLOCKS_IN_REAL * FTL_JOURNAL_BLOCKS);
 
     type CACHE_SIZE = generic_array::typenum::U256;
     type LOOKAHEADWORDS_SIZE = generic_array::typenum::U2;
 
     fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, littlefs2::io::Error> {
-        // w/o this too much spam is generated, thus writes/deletes traces get lost
-        if buf.len() > 4 {
-            trace!("IFr {:x} {:x}", off, buf.len());
-        }
+        // skip journal blocks
+        let off = off + (REAL_BLOCK_SIZE * FTL_JOURNAL_BLOCKS);
+
         let res = self.nvmc.read(off as u32, buf);
         nvmc_to_lfs_return(res, buf.len())
     }
 
     fn write(&mut self, off: usize, buf: &[u8]) -> Result<usize, littlefs2::io::Error> {
+        // skip journal blocks
+        let off = off + (REAL_BLOCK_SIZE * FTL_JOURNAL_BLOCKS);
+
         trace!("IFw {:x} {:x}", off, buf.len());
         let res = self.nvmc.write(off as u32, buf);
         nvmc_to_lfs_return(res, buf.len())
@@ -38,30 +238,31 @@ impl littlefs2::driver::Storage for FlashStorage {
     fn erase(&mut self, off: usize, len: usize) -> Result<usize, littlefs2::io::Error> {
         trace!("IFe {:x} {:x}", off, len);
 
-        const REAL_BLOCK_SIZE: usize = 4 * 1024;
+        // skip journal blocks
+        let off = off + (REAL_BLOCK_SIZE * FTL_JOURNAL_BLOCKS);
 
         let block_off: usize = off - (off % REAL_BLOCK_SIZE);
+        let left_end: usize = off - block_off;
+        let right_off: usize = left_end + len;
 
         let mut buf: [u8; REAL_BLOCK_SIZE] = [0x00; REAL_BLOCK_SIZE];
-        self.nvmc
-            .read(block_off as u32, &mut buf)
-            .expect("EE - failed read");
+
+        self.nvmc.read(block_off as u32, &mut buf).unwrap();
+
+        self.write_journal(block_off, &buf, left_end, right_off);
+
         let erase_res = self
             .nvmc
             .erase(block_off as u32, (block_off + REAL_BLOCK_SIZE) as u32);
 
-        let left_end: usize = off - block_off;
         if left_end > 0 {
-            self.nvmc
-                .write(block_off as u32, &buf[..left_end])
-                .expect("EE - failed write 1");
+            self.nvmc.write(block_off as u32, &buf[..left_end]).unwrap();
         }
 
-        let right_off: usize = left_end + len;
         if REAL_BLOCK_SIZE - right_off > 0 {
             self.nvmc
                 .write((off + len) as u32, &buf[right_off..])
-                .expect("EE - failed write 2");
+                .unwrap();
         }
 
         nvmc_to_lfs_return(erase_res, len)
@@ -85,6 +286,10 @@ impl FlashStorage {
     pub fn new(nvmc_pac: nrf52840_hal::pac::NVMC) -> Self {
         let buf = unsafe { core::slice::from_raw_parts_mut(FLASH_BASE, FLASH_SIZE) };
         let nvmc = nrf52840_hal::nvmc::Nvmc::new(nvmc_pac, buf);
-        Self { nvmc }
+
+        Self {
+            nvmc,
+            next_journal: None,
+        }
     }
 }

--- a/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/backends.rs
+++ b/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/backends.rs
@@ -1,0 +1,83 @@
+use heapless_bytes::Bytes;
+use littlefs2::driver::Storage;
+
+use lfs_backup::{BackupBackend, FSBackupError, Result, MAX_DUMP_BLOB_LENGTH};
+
+use crate::soc::types::Soc as SocT;
+use crate::types::Soc;
+
+pub struct EFSBackupBackend<'a> {
+    extflash: &'a mut <SocT as Soc>::ExternalFlashStorage,
+    initial_offset: usize,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a> EFSBackupBackend<'a> {
+    pub fn new(
+        extflash: &'a mut <SocT as Soc>::ExternalFlashStorage,
+        offset: usize,
+        len: usize,
+    ) -> Self {
+        Self {
+            extflash,
+            initial_offset: offset.clone(),
+            offset,
+            len,
+        }
+    }
+}
+
+impl<'a> BackupBackend for EFSBackupBackend<'a> {
+    // would be good to get this from ext-flash directly
+    const RW_SIZE: usize = 256;
+
+    fn write(&mut self, content: &[u8]) -> Result<usize> {
+        let len =
+            content.len() + ((Self::RW_SIZE - (content.len() % Self::RW_SIZE)) % Self::RW_SIZE);
+        let mut data: Bytes<MAX_DUMP_BLOB_LENGTH> = Bytes::from_slice(content).unwrap();
+
+        data.resize(len, 0x00)
+            .map_err(|_| FSBackupError::BackendWriteErr)?;
+
+        let count = self
+            .extflash
+            .write(self.offset, &data)
+            .map_err(|_| FSBackupError::BackendWriteErr)?;
+        self.offset += data.len();
+
+        //trace_now!("W-addr: {} len: {} datalen: {}", self.offset, content.len(), data.len());
+        //trace_now!("W-data: {} = {:?}", data);
+
+        Ok(count)
+    }
+
+    fn read<const N: usize>(&mut self, len: usize) -> Result<Bytes<N>> {
+        let mut output = Bytes::<N>::default();
+        output.resize_default(len).expect("assuming: N > len");
+
+        self.extflash
+            .read(self.offset, &mut output)
+            .map_err(|_| FSBackupError::BackendReadErr)?;
+
+        self.offset +=
+            output.len() + ((Self::RW_SIZE - (output.len() % Self::RW_SIZE)) % Self::RW_SIZE);
+
+        //trace_now!("R-addr: {} len {:}", self.offset, output.len());
+        //trace_now!("R-data {:?}", output);
+
+        Ok(output)
+    }
+
+    fn erase(&mut self) -> Result<usize> {
+        self.extflash
+            .erase(self.initial_offset, self.len)
+            .map_err(|_| FSBackupError::BackendEraseErr)?;
+        self.offset = self.initial_offset.clone();
+        Ok(self.len)
+    }
+
+    fn reset(&mut self) {
+        self.offset = self.initial_offset;
+    }
+}

--- a/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/ifs_flash_old.rs
+++ b/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/ifs_flash_old.rs
@@ -1,0 +1,90 @@
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+
+use crate::types::build_constants::{
+    CONFIG_FILESYSTEM_BOUNDARY as FS_BASE, CONFIG_FILESYSTEM_END as FS_CEIL,
+};
+
+pub const FLASH_BASE: *mut u8 = FS_BASE as *mut u8;
+pub const FLASH_SIZE: usize = FS_CEIL - FS_BASE;
+
+pub struct FlashStorage {
+    nvmc: nrf52840_hal::nvmc::Nvmc<nrf52840_pac::NVMC>,
+}
+
+impl littlefs2::driver::Storage for FlashStorage {
+    const BLOCK_SIZE: usize = 256;
+    const READ_SIZE: usize = 4;
+    const WRITE_SIZE: usize = 4;
+    const BLOCK_COUNT: usize = FLASH_SIZE / Self::BLOCK_SIZE;
+
+    type CACHE_SIZE = generic_array::typenum::U256;
+    type LOOKAHEADWORDS_SIZE = generic_array::typenum::U2;
+
+    fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, littlefs2::io::Error> {
+        // w/o this too much spam is generated, thus writes/deletes traces get lost
+        if buf.len() > 4 {
+            trace!("IFr {:x} {:x}", off, buf.len());
+        }
+        let res = self.nvmc.read(off as u32, buf);
+        nvmc_to_lfs_return(res, buf.len())
+    }
+
+    fn write(&mut self, off: usize, buf: &[u8]) -> Result<usize, littlefs2::io::Error> {
+        trace!("IFw {:x} {:x}", off, buf.len());
+        let res = self.nvmc.write(off as u32, buf);
+        nvmc_to_lfs_return(res, buf.len())
+    }
+
+    fn erase(&mut self, off: usize, len: usize) -> Result<usize, littlefs2::io::Error> {
+        trace!("EE {:x} {:x}", off, len);
+
+        const REAL_BLOCK_SIZE: usize = 4 * 1024;
+
+        let block_off: usize = off - (off % REAL_BLOCK_SIZE);
+
+        let mut buf: [u8; REAL_BLOCK_SIZE] = [0x00; REAL_BLOCK_SIZE];
+        self.nvmc
+            .read(block_off as u32, &mut buf)
+            .expect("EE - failed read");
+        let erase_res = self
+            .nvmc
+            .erase(block_off as u32, (block_off + REAL_BLOCK_SIZE) as u32);
+
+        let left_end: usize = off - block_off;
+        if left_end > 0 {
+            self.nvmc
+                .write(block_off as u32, &buf[..left_end])
+                .expect("EE - failed write 1");
+        }
+
+        let right_off: usize = left_end + len;
+        if REAL_BLOCK_SIZE - right_off > 0 {
+            self.nvmc
+                .write((off + len) as u32, &buf[right_off..])
+                .expect("EE - failed write 2");
+        }
+
+        nvmc_to_lfs_return(erase_res, len)
+    }
+}
+
+/**
+ * Source Result type does not provide a useful Ok value, and Destination Result type
+ * does not contain a meaningful low-level error code we could return; so here goes
+ * the most stupid result conversion routine ever
+ */
+fn nvmc_to_lfs_return(
+    r: Result<(), nrf52840_hal::nvmc::NvmcError>,
+    len: usize,
+) -> Result<usize, littlefs2::io::Error> {
+    r.map(|_| len)
+        .map_err(|_| littlefs2::io::Error::Unknown(0x4e56_4d43)) // 'NVMC'
+}
+
+impl FlashStorage {
+    pub fn new(nvmc_pac: nrf52840_hal::pac::NVMC) -> Self {
+        let buf = unsafe { core::slice::from_raw_parts_mut(FLASH_BASE, FLASH_SIZE) };
+        let nvmc = nrf52840_hal::nvmc::Nvmc::new(nvmc_pac, buf);
+        Self { nvmc }
+    }
+}

--- a/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/mod.rs
@@ -1,0 +1,49 @@
+pub mod backends;
+pub mod ifs_flash_old;
+
+use littlefs2;
+
+use backends::EFSBackupBackend;
+use ifs_flash_old::FlashStorage as OldFlashStorage;
+use lfs_backup::{BackupBackend, FSBackupError, Result};
+
+use crate::soc::{flash::FlashStorage, qspiflash::QspiFlash};
+
+pub fn migrate<'a>(
+    old_ifs_storage: &mut OldFlashStorage,
+    old_ifs_alloc: &mut littlefs2::fs::Allocation<OldFlashStorage>,
+    ifs_alloc: &mut littlefs2::fs::Allocation<FlashStorage>,
+    ifs_storage: &mut FlashStorage,
+    efs_storage: &mut QspiFlash,
+) -> Result<()> {
+    let old_mounted = littlefs2::fs::Filesystem::mount(old_ifs_alloc, old_ifs_storage)
+        .map_err(|_| FSBackupError::LittleFs2Err)?;
+
+    trace!("old IFS mount success - migrating");
+
+    // ext.flash = 2MB, spare for e.g., backup operations = 128kb (at end)
+    let spare_len = 4096 * 32;
+    let spare_offset = (2 * 1024 * 1024) - spare_len;
+    let mut backend = EFSBackupBackend::new(efs_storage, spare_offset, spare_len);
+
+    backend.erase()?;
+
+    trace!("backing: old IFS -> backend");
+    backend.backup(&old_mounted)?;
+
+    // only format IFS on failed backup...
+    trace!("backup done, format new IFS");
+    let _fmt_ifs = littlefs2::fs::Filesystem::format(ifs_storage);
+    ifs_storage.format_journal_blocks();
+
+    let new_mounted = littlefs2::fs::Filesystem::mount(ifs_alloc, ifs_storage)
+        .map_err(|_| FSBackupError::LittleFs2Err)?;
+
+    trace!("restore: backend -> new IFS");
+    backend.reset();
+    let _res = backend.restore(&new_mounted)?;
+
+    // any outcome should erase the external flash contents
+    backend.erase()?;
+    Ok(())
+}

--- a/runners/embedded/src/soc_nrf52840/migrations/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod ftl_journal;

--- a/runners/embedded/src/soc_nrf52840/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/mod.rs
@@ -19,10 +19,13 @@ pub mod trussed_ui;
 
 pub mod types;
 
-mod flash;
+pub mod flash;
 #[cfg(feature = "extflash_qspi")]
 pub mod qspiflash;
 pub mod rtic_monotonic;
+
+#[cfg(feature = "board-nk3am")]
+pub mod migrations;
 
 pub fn init_bootup(
     ficr: &nrf52840_pac::FICR,

--- a/utils/nrf-builder/Makefile.test-ftl-migration
+++ b/utils/nrf-builder/Makefile.test-ftl-migration
@@ -1,0 +1,24 @@
+MAIN_REPO_DIR=nk3-fw-main
+
+migrate-nrf-test: $(MAIN_REPO_DIR)-update
+	$(MAKE) -C $(MAIN_REPO_DIR)/utils/nrf-builder full-deploy
+
+	#$(MAKE) flash-develop EXTRA_FEATURES=develop-no-press,log-rtt,log-traceP
+	$(MAKE) flash-release 
+
+	nitropy nk3 test
+
+	@echo "if there is a certificate (and no x5c bug)"
+
+
+$(MAIN_REPO_DIR): 
+	git clone https://github.com/Nitrokey/nitrokey-3-firmware.git $(MAIN_REPO_DIR)
+
+.PHONY: $(MAIN_REPO_DIR)-update
+$(MAIN_REPO_DIR)-update: $(MAIN_REPO_DIR)
+	cd $(MAIN_REPO_DIR) && git checkout main
+	cd $(MAIN_REPO_DIR) && git pull
+	cd $(MAIN_REPO_DIR) && git checkout fa94cac8ccc91b7c88c08dcb14312af6e4675700
+
+
+


### PR DESCRIPTION
Improving the power-loss filesystem-corruption resistance for nRF-based Nitrokey 3 Mini. 

This essentially consists of 3 parts:
* `fsbackup.rs` introduces a generic littlefs2 to blob and back mechanism (backup & restore)
* `soc_nrf52840/flash.rs` introduces the journaling and littlefs2 recovering functionality 
* the actual migration from the old littlefs2 filesystem layout to the new (journaled) layout

Initial draft still WIP, at least the following parts are missing:
* [x] tests for filesystem backup/restore functionality
* [x] actual migration logic before the actual `init_store` calls (trigger: new IFS does not mount, due to moved 1st block)
* [x] improve `Results` handling in new `soc_nrf52840/flash.rs`
* [x] `nrf-builder` (?) updates  to create a device with an old filesystem for on-device test automation (not commited)
* [x] use `postcard` instead of `cbor` for (de)serialization in `fsbackup.rs` ?
* [x] find proper locations for migration-sources & `fsbackup.rs`
* [x] obey `read_size` & `write_size` (from the respective `FlashStorage` impl) in `fsbackup.rs`
* [x] erase backup target (ext-flash) before writing the backup
* [x] erase backup target (ext-flash) after successful restore
* [x] format journals after successful restore
* [x] introduce possibility to use `N` journaling blocks
* [x] auto-cleanup journal cells, if in undefined state
* [x] move journal in front of the filesystem (instead after it)
* [x] provide test script to test migration on real hardware