### PR TITLE
ExtFlash: update layout properties & reduce heavy logging 

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -10,6 +10,12 @@ The Nitrokey 3 has three storage types: internal, external and volatile.  The in
 | Internal (nrf52) | 80 KiB |
 | External         | 2 MiB  |
 
+### External Flash
+
+The external flash is not entirely under littlefs2's control. At the end
+128KiB are left free for any potential future use-cases. This leaves 
+1920KiB for littlefs2 usage. 
+
 ## Usage
 
 This section describes how the storage is used in the current stable firmware.

--- a/runners/embedded/src/soc_nrf52840/flash.rs
+++ b/runners/embedded/src/soc_nrf52840/flash.rs
@@ -36,7 +36,7 @@ impl littlefs2::driver::Storage for FlashStorage {
     }
 
     fn erase(&mut self, off: usize, len: usize) -> Result<usize, littlefs2::io::Error> {
-        trace!("EE {:x} {:x}", off, len);
+        trace!("IFe {:x} {:x}", off, len);
 
         const REAL_BLOCK_SIZE: usize = 4 * 1024;
 

--- a/runners/embedded/src/soc_nrf52840/qspiflash.rs
+++ b/runners/embedded/src/soc_nrf52840/qspiflash.rs
@@ -3,6 +3,8 @@ use nrf52840_hal::gpio::{Floating, Input, Output, Pin, PushPull};
 use nrf52840_hal::prelude::OutputPin;
 use nrf52840_hal::spim::Pins as SpimPins;
 
+use crate::flash::SPARE_LEN;
+
 pub struct QspiFlash {
     qspi: nrf52840_pac::QSPI,
     clk_pin: Pin<Output<PushPull>>,
@@ -127,10 +129,11 @@ impl QspiFlash {
 }
 
 impl littlefs2::driver::Storage for QspiFlash {
-    const BLOCK_SIZE: usize = 0x1000;
+    const BLOCK_SIZE: usize = 4096;
     const READ_SIZE: usize = 4;
     const WRITE_SIZE: usize = 256;
-    const BLOCK_COUNT: usize = Self::FLASH_SIZE / Self::BLOCK_SIZE;
+    const BLOCK_COUNT: usize =
+        (Self::FLASH_SIZE / Self::BLOCK_SIZE) - (SPARE_LEN / Self::BLOCK_SIZE);
     type CACHE_SIZE = generic_array::typenum::U256;
     type LOOKAHEADWORDS_SIZE = generic_array::typenum::U2;
 


### PR DESCRIPTION
The external flash now has a reserved portion at the end of the flash. 128kb (32 blocks) are left out at the end. 

This is done by using a reduced `BLOCK_COUNT`, which will restrict littlefs2 to the given `BLOCK_COUNT`, but the low-level `read`/`write`/`erase` methods for `ExtFlashStorage` will still accept operations on this region.