### PR TITLE
nrf / ext-flash: adapt to new lfs2 lookahead calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
 [[package]]
 name = "littlefs2"
 version = "0.3.2"
-source = "git+https://github.com/Nitrokey/littlefs2?tag=v0.3.2-nitrokey-1#23b9e5028ce0b2ff77c78545c44ac75da9a79acb"
+source = "git+https://github.com/Nitrokey/littlefs2?branch=lookahead#650e8aeb5e76c9ad0976341029b2c0f39ca9b9b8"
 dependencies = [
  "bitflags",
  "cstr_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ dependencies = [
 [[package]]
 name = "lpc55-hal"
 version = "0.3.0"
-source = "git+https://github.com/Nitrokey/lpc55-hal?tag=v0.3.0-nitrokey-1#6ae4070f5a06cfa20f256a262f4ada1cb1bc64fa"
+source = "git+https://github.com/Nitrokey/lpc55-hal?branch=lfs2-lookahead#6e2d57e3df9eddf561bbb331a03a792b526abede"
 dependencies = [
  "block-buffer 0.9.0",
  "cipher 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "1.2.2"
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.1-nitrokey-1" }
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", branch = "lookahead" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", branch = "lfs2-lookahead" } 
-trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
+trussed = { git = "https://github.com/Nitrokey/trussed", branch = "lfs2-lookahead" }
 
 # unreleased
 interchange = { git = "https://github.com/trussed-dev/interchange" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "1.2.2"
 # forked
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.1-nitrokey-1" }
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", branch = "lookahead" }
-lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey-1" }
+lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", branch = "lfs2-lookahead" } 
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
 
 # unreleased

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "1.2.2"
 [patch.crates-io]
 # forked
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.1-nitrokey-1" }
-littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
+littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", branch = "lookahead" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey-1" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
 

--- a/runners/embedded/src/flash.rs
+++ b/runners/embedded/src/flash.rs
@@ -33,7 +33,7 @@ where
     const WRITE_SIZE: usize = 256;
     const BLOCK_COUNT: usize = FLASH_PROPERTIES.size / Self::BLOCK_SIZE;
     type CACHE_SIZE = generic_array::typenum::U256;
-    type LOOKAHEADWORDS_SIZE = generic_array::typenum::U1;
+    type LOOKAHEAD_SIZE = generic_array::typenum::U1;
 
     fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, littlefs2::io::Error> {
         trace!("EFr {:x} {:x}", off, buf.len());

--- a/runners/embedded/src/soc_nrf52840/flash.rs
+++ b/runners/embedded/src/soc_nrf52840/flash.rs
@@ -18,7 +18,7 @@ impl littlefs2::driver::Storage for FlashStorage {
     const BLOCK_COUNT: usize = FLASH_SIZE / Self::BLOCK_SIZE;
 
     type CACHE_SIZE = generic_array::typenum::U256;
-    type LOOKAHEADWORDS_SIZE = generic_array::typenum::U2;
+    type LOOKAHEAD_SIZE = generic_array::typenum::U1;
 
     fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, littlefs2::io::Error> {
         // w/o this too much spam is generated, thus writes/deletes traces get lost

--- a/runners/embedded/src/soc_nrf52840/qspiflash.rs
+++ b/runners/embedded/src/soc_nrf52840/qspiflash.rs
@@ -132,7 +132,7 @@ impl littlefs2::driver::Storage for QspiFlash {
     const WRITE_SIZE: usize = 256;
     const BLOCK_COUNT: usize = Self::FLASH_SIZE / Self::BLOCK_SIZE;
     type CACHE_SIZE = generic_array::typenum::U256;
-    type LOOKAHEADWORDS_SIZE = generic_array::typenum::U2;
+    type LOOKAHEAD_SIZE = generic_array::typenum::U1;
 
     fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize, littlefs2::io::Error> {
         trace!("EFr {:x} {:x}", off, buf.len());


### PR DESCRIPTION
* this renames `LOOKAHEADWORDS_SIZE` to `LOOKAHEAD_SIZE` to correctly handle 
https://github.com/trussed-dev/littlefs2/pull/24 (for nrf & external flash)
* matching `lpc55-hal` adaptations are to be found here: 
https://github.com/Nitrokey/lpc55-hal/pull/1
* points to the patched `littlefs2` version to the `lookahead` [branch](https://github.com/Nitrokey/littlefs2/tree/lookahead) 
* points to the patched `lpc55-hal` version to the `lfs2-lookahead` [branch](https://github.com/Nitrokey/lpc55-hal/tree/lfs2-lookahead) 
* points to the patched `trussed` version to the `lfs2-lookahead` [branch](https://github.com/Nitrokey/trussed/tree/lfs2-lookahead) 
