### PR TITLE
Add full version and init status to admin app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "admin-app"
 version = "0.1.0"
-source = "git+https://github.com/solokeys/admin-app#efcd26bfb9c4b746de1ae6caca085dc5c26eccc4"
+source = "git+https://github.com/nitrokey/admin-app?rev=v0.1.0-nitrokey.1#70fd0b22284c49fea79b2e617e07d4239f4983c2"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
@@ -940,6 +940,7 @@ dependencies = [
  "alloc-cortex-m",
  "apdu-dispatch",
  "apps",
+ "bitflags",
  "cargo-lock",
  "cfg-if",
  "chacha20 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "apps"
-version = "0.1.0"
+version = "1.2.2"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -96,6 +96,7 @@ dependencies = [
  "trussed",
  "trussed-usbip",
  "usbd-ctaphid 0.1.0",
+ "utils",
 ]
 
 [[package]]
@@ -1001,6 +1002,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -1966,7 +1977,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
 ]
 
@@ -2023,6 +2034,17 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log",
+ "rand",
+]
 
 [[package]]
 name = "quote"
@@ -2771,10 +2793,11 @@ dependencies = [
 
 [[package]]
 name = "utils"
-version = "0.1.0"
+version = "1.2.2"
 dependencies = [
  "delog",
  "littlefs2",
+ "quickcheck",
 ]
 
 [[package]]

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apps"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]
@@ -9,6 +9,7 @@ ctaphid-dispatch = "0.1"
 trussed = "0.1"
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ctaphid", "ccid"], optional = true }
 usbd-ctaphid = { version = "0.1", optional = true }
+utils = { path = "../utils" }
 
 # apps
 admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -12,7 +12,7 @@ usbd-ctaphid = { version = "0.1", optional = true }
 utils = { path = "../utils" }
 
 # apps
-admin-app = { git = "https://github.com/solokeys/admin-app", optional = true }
+admin-app = { git = "https://github.com/nitrokey/admin-app", rev = "v0.1.0-nitrokey.1", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
 oath-authenticator = { git = "https://github.com/nitrokey/oath-authenticator", rev = "0.3.0", features = ["apdu-dispatch", "ctaphid"], optional = true }

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -24,7 +24,6 @@ pub trait Runner {
     type Filesystem: trussed::types::LfsStorage + 'static;
 
     fn uuid(&self) -> [u8; 16];
-    fn version(&self) -> u32;
 }
 
 pub struct NonPortable<R: Runner> {
@@ -203,7 +202,8 @@ impl<R: Runner> App<R> for AdminApp<R> {
     type NonPortable = ();
 
     fn with_client(runner: &R, trussed: Client<R>, _: ()) -> Self {
-        Self::new(trussed, runner.uuid(), runner.version())
+        const VERSION: u32 = utils::VERSION.encode();
+        Self::new(trussed, runner.uuid(), VERSION)
     }
 }
 

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]
@@ -14,3 +14,6 @@ log-info = []
 log-debug = []
 log-warn = []
 log-error = []
+
+[dev-dependencies]
+quickcheck = "1.0.3"

--- a/components/utils/src/constants.rs
+++ b/components/utils/src/constants.rs
@@ -1,0 +1,81 @@
+use core::fmt::{self, Display, Formatter};
+
+pub const VERSION: Version = Version::from_env();
+pub const VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Version {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+    pub pre: Option<&'static str>,
+}
+
+impl Version {
+    pub const fn from_env() -> Self {
+        Self {
+            major: parse_simple_u8(env!("CARGO_PKG_VERSION_MAJOR")),
+            minor: parse_simple_u8(env!("CARGO_PKG_VERSION_MINOR")),
+            patch: parse_simple_u8(env!("CARGO_PKG_VERSION_PATCH")),
+            pre: optional_str(env!("CARGO_PKG_VERSION_PRE")),
+        }
+    }
+
+    pub const fn encode(&self) -> u32 {
+        if self.patch >= 64 {
+            panic!("patch version must not be larger than 63");
+        }
+        ((self.major as u32) << 22) | ((self.minor as u32) << 6) | (self.patch as u32)
+    }
+
+    pub const fn usb_release(&self) -> u16 {
+        u16::from_be_bytes([self.major, self.minor])
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}.{}.{}", self.major, self.minor, self.patch)?;
+        if let Some(pre) = self.pre {
+            write!(f, "-{pre}")?;
+        }
+        Ok(())
+    }
+}
+
+const fn parse_simple_u8(s: &str) -> u8 {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        panic!("number may not be empty");
+    }
+    let mut value = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] < b'0' || bytes[i] > b'9' {
+            panic!("number must only contain ASCII digits");
+        }
+        value *= 10;
+        value += bytes[i] - b'0';
+        i += 1;
+    }
+    value
+}
+
+const fn optional_str(s: &str) -> Option<&str> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    quickcheck::quickcheck! {
+        fn test_parse_simple_u8(value: u8) -> bool {
+            parse_simple_u8(&value.to_string()) == value
+        }
+    }
+}

--- a/components/utils/src/lib.rs
+++ b/components/utils/src/lib.rs
@@ -1,8 +1,10 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 extern crate delog;
 delog::generate_macros!();
 
+mod constants;
 mod storage;
 
+pub use constants::{Version, VERSION, VERSION_STRING};
 pub use storage::{OptionalStorage, RamStorage};

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -56,6 +56,7 @@ systick-monotonic = { version = "1.0.0", optional = true }
 
 ### Allocator
 alloc-cortex-m = { version = "0.4.3", optional = true }
+bitflags = "1.3.2"
 
 [build-dependencies]
 cargo-lock = "7"

--- a/runners/embedded/build.rs
+++ b/runners/embedded/build.rs
@@ -174,17 +174,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     // write 'build_constants.rs' header
     writeln!(&mut f, "pub mod build_constants {{").expect("Could not write build_constants.rs.");
 
-    add_build_variable!(&mut f, "CARGO_PKG_VERSION_MAJOR", u8);
-    add_build_variable!(&mut f, "CARGO_PKG_VERSION_MINOR", u8);
-    add_build_variable!(&mut f, "CARGO_PKG_VERSION_PATCH", u8);
-
     add_build_variable!(&mut f, "CARGO_PKG_HASH", hash_long);
     add_build_variable!(&mut f, "CARGO_PKG_HASH_SHORT", hash_short);
-
-    // Add integer version of the version number
-    let major: u32 = str::parse(env!("CARGO_PKG_VERSION_MAJOR")).unwrap();
-    let minor: u32 = str::parse(env!("CARGO_PKG_VERSION_MINOR")).unwrap();
-    let patch: u32 = str::parse(env!("CARGO_PKG_VERSION_PATCH")).unwrap();
 
     // USB Identifiers
     add_build_variable!(
@@ -211,18 +202,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let raw_issuer = config.identifier.ccid_issuer.as_bytes();
     ccid_bytes[..raw_issuer.len()].clone_from_slice(raw_issuer);
     add_build_variable!(&mut f, "CCID_ISSUER", ccid_bytes, [u8; 13]);
-
-    if major >= 1024 || minor > 9999 || patch >= 64 {
-        panic!("config.firmware.product can at most be 1023.9999.63 for versions in customer data");
-    } else if major >= 256 || minor >= 256 {
-        panic!("USB release version number overflow (maximum: major 255, minor 255)");
-    }
-
-    let version_to_check: u32 = (major << 22) | (minor << 6) | patch;
-    add_build_variable!(&mut f, "CARGO_PKG_VERSION", version_to_check, u32);
-
-    let usb_release_version: u16 = ((major as u16) << 8) | (minor as u16);
-    add_build_variable!(&mut f, "USB_RELEASE", usb_release_version, u16);
 
     add_build_variable!(
         &mut f,

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -51,6 +51,8 @@ mod app {
 
     #[init()]
     fn init(mut ctx: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
+        let mut init_status = ERL::types::InitStatus::default();
+
         #[cfg(feature = "alloc")]
         embedded_runner_lib::init_alloc();
 
@@ -116,7 +118,8 @@ mod app {
         #[cfg(not(feature = "extflash_qspi"))]
         let extflash = ERL::soc::types::ExternalStorage::new();
 
-        let store: ERL::types::RunnerStore = ERL::init_store(internal_flash, extflash, false);
+        let store: ERL::types::RunnerStore =
+            ERL::init_store(internal_flash, extflash, false, &mut init_status);
 
         let usbnfcinit = ERL::init_usb_nfc(usbd_ref, None);
         /* TODO: set up fingerprint device */
@@ -200,7 +203,7 @@ mod app {
 
         let mut trussed_service = trussed::service::Service::new(platform);
 
-        let apps = ERL::init_apps(&mut trussed_service, &store, !powered_by_usb);
+        let apps = ERL::init_apps(&mut trussed_service, init_status, &store, !powered_by_usb);
 
         let rtc_mono = RtcMonotonic::new(ctx.device.RTC0);
 

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -198,7 +198,7 @@ pub fn init_apps(
     _store: &types::RunnerStore,
     _on_nfc_power: bool,
 ) -> types::Apps {
-    let admin = apps::AdminAppNonPortable {
+    let admin = apps::AdminData {
         init_status: init_status.bits(),
     };
     #[cfg(feature = "provisioner")]
@@ -209,20 +209,20 @@ pub fn init_apps(
         let int_flash_ref = unsafe { types::INTERNAL_STORAGE.as_mut().unwrap() };
         let rebooter: fn() -> ! = <SocT as types::Soc>::Reboot::reboot_to_firmware_update;
 
-        apps::ProvisionerNonPortable {
+        apps::ProvisionerData {
             store,
             stolen_filesystem: int_flash_ref,
             nfc_powered: _on_nfc_power,
             rebooter,
         }
     };
-    let non_portable = apps::NonPortable {
+    let data = apps::Data {
         admin,
         #[cfg(feature = "provisioner")]
         provisioner,
         _marker: Default::default(),
     };
-    types::Apps::with_service(&types::Runner, trussed, non_portable)
+    types::Apps::with_service(&types::Runner, trussed, data)
 }
 
 #[inline(never)]

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -29,12 +29,10 @@ static ALLOCATOR: alloc_cortex_m::CortexMHeap = alloc_cortex_m::CortexMHeap::emp
 
 pub fn banner() {
     info!(
-        "Embedded Runner ({}:{}) using librunner {}.{}.{}",
+        "Embedded Runner ({}:{}) using librunner {}",
         <SocT as Soc>::SOC_NAME,
         <SocT as Soc>::BOARD_NAME,
-        types::build_constants::CARGO_PKG_VERSION_MAJOR,
-        types::build_constants::CARGO_PKG_VERSION_MINOR,
-        types::build_constants::CARGO_PKG_VERSION_PATCH
+        utils::VERSION,
     );
 }
 
@@ -160,7 +158,7 @@ pub fn init_usb_nfc(
 			.product(config.usb_product)
 			.manufacturer(config.usb_manufacturer)
 			/*.serial_number(config.usb_serial)  <---- don't configure serial to not be identifiable */
-			.device_release(crate::types::build_constants::USB_RELEASE)
+			.device_release(utils::VERSION.usb_release())
 			.max_packet_size_0(64)
 			.composite_with_iads()
 			.build();

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -41,7 +41,7 @@ use crate::{
         buttons::{self, Press},
         rgb_led::RgbLed,
     },
-    types::{self, usbnfc::UsbNfcInit as UsbNfc, Apps, RunnerStore, Trussed},
+    types::{self, usbnfc::UsbNfcInit as UsbNfc, Apps, InitStatus, RunnerStore, Trussed},
 };
 
 struct Peripherals {
@@ -75,6 +75,7 @@ struct Flash {
 }
 
 pub struct Stage0 {
+    status: InitStatus,
     peripherals: Peripherals,
 }
 
@@ -142,6 +143,7 @@ impl Stage0 {
             gpio,
         };
         Stage1 {
+            status: self.status,
             peripherals: self.peripherals,
             clocks,
         }
@@ -149,6 +151,7 @@ impl Stage0 {
 }
 
 pub struct Stage1 {
+    status: InitStatus,
     peripherals: Peripherals,
     clocks: Clocks,
 }
@@ -307,6 +310,7 @@ impl Stage1 {
             old_firmware_version,
         };
         Stage2 {
+            status: self.status,
             peripherals: self.peripherals,
             clocks: self.clocks,
             basic,
@@ -315,6 +319,7 @@ impl Stage1 {
 }
 
 pub struct Stage2 {
+    status: InitStatus,
     peripherals: Peripherals,
     clocks: Clocks,
     basic: Basic,
@@ -381,6 +386,7 @@ impl Stage2 {
             nfc_irq,
             &mut self.basic.delay_timer,
             force_nfc_reconfig,
+            &mut self.status,
         )
     }
 
@@ -463,6 +469,7 @@ impl Stage2 {
 
         let usb_nfc = crate::init_usb_nfc(usb_bus, nfc_chip);
         Stage3 {
+            status: self.status,
             peripherals: self.peripherals,
             clocks: self.clocks,
             basic: self.basic,
@@ -473,6 +480,7 @@ impl Stage2 {
 }
 
 pub struct Stage3 {
+    status: InitStatus,
     peripherals: Peripherals,
     clocks: Clocks,
     basic: Basic,
@@ -505,6 +513,7 @@ impl Stage3 {
             rng,
         };
         Stage4 {
+            status: self.status,
             peripherals: self.peripherals,
             clocks: self.clocks,
             basic: self.basic,
@@ -516,6 +525,7 @@ impl Stage3 {
 }
 
 pub struct Stage4 {
+    status: InitStatus,
     peripherals: Peripherals,
     clocks: Clocks,
     basic: Basic,
@@ -584,7 +594,7 @@ impl Stage4 {
         );
         // TODO: poll iso14443
         let simulated_efs = external.is_ram();
-        let store = crate::init_store(internal, external, simulated_efs);
+        let store = crate::init_store(internal, external, simulated_efs, &mut self.status);
         info!("mount end {} ms", self.basic.perf_timer.elapsed().0 / 1000);
 
         // return to slow freq
@@ -608,6 +618,7 @@ impl Stage4 {
         self.basic.delay_timer.cancel().ok();
 
         Stage5 {
+            status: self.status,
             peripherals: self.peripherals,
             clocks: self.clocks,
             basic: self.basic,
@@ -661,6 +672,7 @@ fn initialize_fs_flash(flash_gordon: &mut FlashGordon, prince: &mut Prince<hal::
 }
 
 pub struct Stage5 {
+    status: InitStatus,
     peripherals: Peripherals,
     clocks: Clocks,
     basic: Basic,
@@ -696,6 +708,7 @@ impl Stage5 {
         let trussed = trussed::service::Service::new(board);
 
         Stage6 {
+            status: self.status,
             peripherals: self.peripherals,
             clocks: self.clocks,
             basic: self.basic,
@@ -707,6 +720,7 @@ impl Stage5 {
 }
 
 pub struct Stage6 {
+    status: InitStatus,
     peripherals: Peripherals,
     clocks: Clocks,
     basic: Basic,
@@ -716,7 +730,7 @@ pub struct Stage6 {
 }
 
 impl Stage6 {
-    fn perform_data_migrations(&self) {
+    fn perform_data_migrations(&mut self) {
         // FIDO2 attestation cert (<= 1.0.2)
         if self.basic.old_firmware_version <= 4194306 {
             debug!("data migration: updating FIDO2 attestation cert");
@@ -727,6 +741,7 @@ impl Stage6 {
                 include_bytes!("../../data/fido-cert.der"),
             );
             if res.is_err() {
+                self.status.insert(InitStatus::MIGRATION_ERROR);
                 error!("failed to replace attestation cert");
             }
         }
@@ -735,7 +750,12 @@ impl Stage6 {
     #[inline(never)]
     pub fn next(mut self) -> All {
         self.perform_data_migrations();
-        let apps = crate::init_apps(&mut self.trussed, &self.store, self.clocks.is_nfc_passive);
+        let apps = crate::init_apps(
+            &mut self.trussed,
+            self.status,
+            &self.store,
+            self.clocks.is_nfc_passive,
+        );
         let clock_controller = if self.clocks.is_nfc_passive {
             let adc = self.basic.adc.take();
             let clocks = self.clocks.clocks;
@@ -777,10 +797,14 @@ pub struct All {
 
 #[inline(never)]
 pub fn start(syscon: hal::Syscon, pmc: hal::Pmc, anactrl: hal::Anactrl) -> Stage0 {
+    let status = Default::default();
     let peripherals = Peripherals {
         syscon,
         pmc,
         anactrl,
     };
-    Stage0 { peripherals }
+    Stage0 {
+        status,
+        peripherals,
+    }
 }

--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -15,6 +15,8 @@ use delog::delog;
 
 delog!(Delogger, 3 * 1024, 512, crate::types::DelogFlusher);
 
+const SECURE_FIRMWARE_VERSION: u32 = utils::VERSION.encode();
+
 pub fn init(
     device_peripherals: lpc55_hal::raw::Peripherals,
     core_peripherals: rtic::export::Peripherals,
@@ -30,7 +32,7 @@ pub fn init(
     let hal = lpc55_hal::Peripherals::from((device_peripherals, core_peripherals));
 
     let require_prince = cfg!(not(feature = "no-encrypted-storage"));
-    let secure_firmware_version = Some(crate::types::build_constants::CARGO_PKG_VERSION);
+    let secure_firmware_version = Some(SECURE_FIRMWARE_VERSION);
     let nfc_enabled = true;
     let boot_to_bootrom = true;
 

--- a/runners/embedded/src/soc_lpc55/nfc.rs
+++ b/runners/embedded/src/soc_lpc55/nfc.rs
@@ -1,4 +1,5 @@
 use super::spi::Spi;
+use crate::types::InitStatus;
 use lpc55_hal::{
     self,
     drivers::{
@@ -28,6 +29,7 @@ pub fn try_setup(
     // fm: &mut NfcChip,
     timer: &mut Timer<impl lpc55_hal::peripherals::ctimer::Ctimer<Enabled>>,
     always_reconfig: bool,
+    status: &mut InitStatus,
 ) -> Option<NfcChip> {
     // Start unselected.
     let nfc_cs = NfcCsPin::take()
@@ -48,6 +50,7 @@ pub fn try_setup(
 
     if current_regu_config == 0xff {
         // No nfc chip connected
+        status.insert(InitStatus::NFC_ERROR);
         info!("No NFC chip connected");
         return None;
     }
@@ -82,6 +85,7 @@ pub fn try_setup(
             timer,
         );
         if r.is_err() {
+            status.insert(InitStatus::NFC_ERROR);
             info!("Eeprom failed.  No NFC chip connected?");
             return None;
         }

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -25,7 +25,7 @@ pub struct Config {
     pub usb_product: &'static str,
     pub usb_manufacturer: &'static str,
     pub usb_serial: &'static str,
-    // pub usb_release: u16 --> taken from build_constants::USB_RELEASE
+    // pub usb_release: u16 --> taken from utils::VERSION::usb_release()
     pub usb_id_vendor: u16,
     pub usb_id_product: u16,
 }
@@ -67,10 +67,6 @@ impl apps::Runner for Runner {
 
     fn uuid(&self) -> [u8; 16] {
         *<SocT as Soc>::device_uuid()
-    }
-
-    fn version(&self) -> u32 {
-        build_constants::CARGO_PKG_VERSION
     }
 }
 

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -4,6 +4,7 @@ use crate::soc::types::Soc as SocT;
 pub use apdu_dispatch::{
     command::SIZE as ApduCommandSize, response::SIZE as ApduResponseSize, App as ApduApp,
 };
+use bitflags::bitflags;
 pub use ctaphid_dispatch::app::App as CtaphidApp;
 use littlefs2::{const_ram_storage, fs::Allocation, fs::Filesystem};
 use trussed::types::{LfsResult, LfsStorage};
@@ -115,6 +116,16 @@ pub type ApduDispatch = apdu_dispatch::dispatch::ApduDispatch;
 pub type CtaphidDispatch = ctaphid_dispatch::dispatch::Dispatch;
 
 pub type Apps = apps::Apps<Runner>;
+
+bitflags! {
+    #[derive(Default)]
+    pub struct InitStatus: u8 {
+        const NFC_ERROR = 0b00000001;
+        const INTERNAL_FLASH_ERROR = 0b00000010;
+        const EXTERNAL_FLASH_ERROR = 0b00000100;
+        const MIGRATION_ERROR = 0b00001000;
+    }
+}
 
 #[derive(Debug)]
 pub struct DelogFlusher {}

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -186,6 +186,7 @@ fn exec<S: StoreProvider + Clone>(store: S, options: trussed_usbip::Options, ser
         })
         .exec::<apps::Apps<Runner<S>>, _, _>(|_platform| {
             let non_portable = apps::NonPortable {
+                admin: Default::default(),
                 #[cfg(feature = "provisioner")]
                 provisioner: apps::ProvisionerNonPortable {
                     store: unsafe { S::store() },

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -101,7 +101,6 @@ impl trussed::platform::UserInterface for UserInterface {
 
 struct Runner<S: StoreProvider> {
     serial: [u8; 16],
-    version: u32,
     _marker: std::marker::PhantomData<S>,
 }
 
@@ -112,13 +111,8 @@ impl<S: StoreProvider> Runner<S> {
             OsRng.fill_bytes(&mut uuid);
             uuid
         });
-        let major: u32 = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
-        let minor: u32 = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap();
-        let patch: u32 = env!("CARGO_PKG_VERSION_PATCH").parse().unwrap();
-        let version = (major << 22) | (minor << 6) | patch;
         Runner {
             serial,
-            version,
             _marker: Default::default(),
         }
     }
@@ -137,10 +131,6 @@ impl<S: StoreProvider> apps::Runner for Runner<S> {
 
     fn uuid(&self) -> [u8; 16] {
         self.serial
-    }
-
-    fn version(&self) -> u32 {
-        self.version
     }
 }
 

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -185,10 +185,10 @@ fn exec<S: StoreProvider + Clone>(store: S, options: trussed_usbip::Options, ser
             platform.user_interface().set_inner(ui);
         })
         .exec::<apps::Apps<Runner<S>>, _, _>(|_platform| {
-            let non_portable = apps::NonPortable {
+            let data = apps::Data {
                 admin: Default::default(),
                 #[cfg(feature = "provisioner")]
-                provisioner: apps::ProvisionerNonPortable {
+                provisioner: apps::ProvisionerData {
                     store: unsafe { S::store() },
                     stolen_filesystem: unsafe { S::ifs() },
                     nfc_powered: false,
@@ -196,6 +196,6 @@ fn exec<S: StoreProvider + Clone>(store: S, options: trussed_usbip::Options, ser
                 },
                 _marker: Default::default(),
             };
-            (&runner, non_portable)
+            (&runner, data)
         });
 }


### PR DESCRIPTION
This patch adds the full version string and the init status to the admin app.  The init status is set:
- if we fail to communicate with the NFC chip
- if we can’t mount the internal or external flash and have to re-format it
- if a data migration fails