### PR TITLE
 Use custom dispatch 

### DIFF
--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -201,7 +201,8 @@ mod app {
         let platform: ERL::types::RunnerPlatform =
             ERL::types::RunnerPlatform::new(chacha_rng, store, ui);
 
-        let mut trussed_service = trussed::service::Service::new(platform);
+        let mut trussed_service =
+            trussed::service::Service::with_dispatch(platform, apps::Dispatch::default());
 
         let apps = ERL::init_apps(&mut trussed_service, init_status, &store, !powered_by_usb);
 

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -1,3 +1,4 @@
+use apps::Dispatch;
 use embedded_hal::{
     blocking::i2c::{Read, Write},
     timer::{Cancel, CountDown},
@@ -26,7 +27,7 @@ use hal::{
 };
 use lpc55_hal as hal;
 use lpc55_hal::drivers::timer::Elapsed as _;
-use trussed::platform::UserInterface;
+use trussed::{platform::UserInterface, service::Service};
 use utils::OptionalStorage;
 
 use super::{
@@ -705,7 +706,7 @@ impl Stage5 {
         solobee_interface.set_status(trussed::platform::ui::Status::Idle);
 
         let board = types::RunnerPlatform::new(self.rng, self.store, solobee_interface);
-        let trussed = trussed::service::Service::new(board);
+        let trussed = Service::with_dispatch(board, Dispatch::default());
 
         Stage6 {
             status: self.status,

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -4,6 +4,7 @@ use crate::soc::types::Soc as SocT;
 pub use apdu_dispatch::{
     command::SIZE as ApduCommandSize, response::SIZE as ApduResponseSize, App as ApduApp,
 };
+use apps::Dispatch;
 use bitflags::bitflags;
 pub use ctaphid_dispatch::app::App as CtaphidApp;
 use littlefs2::{const_ram_storage, fs::Allocation, fs::Filesystem};
@@ -108,7 +109,7 @@ impl trussed::client::Syscall for RunnerSyscall {
     }
 }
 
-pub type Trussed = trussed::Service<RunnerPlatform>;
+pub type Trussed = trussed::Service<RunnerPlatform, Dispatch>;
 
 pub type Iso14443 = nfc_device::Iso14443<<SocT as Soc>::NfcDevice>;
 


### PR DESCRIPTION
This patch introduces a custom Dispatch implementation in the apps crate
and makes use of it in the embedded and usbip runners.  This is a
preparation for adding custom backends to the firmware.