### PR TITLE
Stabilize oath-authenticator

### DIFF
--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -20,8 +20,8 @@ opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "v0.2.0", featur
 provisioner-app = { path = "../provisioner-app", optional = true }
 
 [features]
-default = ["admin-app", "fido-authenticator", "ndef-app", "trussed/clients-2"]
-alpha = ["oath-authenticator", "opcard", "trussed/clients-4"]
+default = ["admin-app", "fido-authenticator", "oath-authenticator", "ndef-app", "trussed/clients-3"]
+alpha = ["opcard", "trussed/clients-4"]
 provisioner = ["provisioner-app", "trussed/clients-3"]
 
 log-all = [


### PR DESCRIPTION
This patch moves oath-authenticator from the alpha apps to the stable apps.

To do:
- [ ] Integrate `trussed-auth`
- [ ] Implement encryption key derivation
- [ ] Settle name