### PR TITLE
admin-app: Add available blocks to status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "admin-app"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/admin-app?rev=v0.1.0-nitrokey.1#70fd0b22284c49fea79b2e617e07d4239f4983c2"
+source = "git+https://github.com/Nitrokey/admin-app?rev=v0.1.0-nitrokey.2#398f9b258d8cfab57a9353fcb61818f162db41c8"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -12,7 +12,7 @@ usbd-ctaphid = { version = "0.1", optional = true }
 utils = { path = "../utils" }
 
 # apps
-admin-app = { git = "https://github.com/Nitrokey/admin-app", rev = "v0.1.0-nitrokey.1", optional = true }
+admin-app = { git = "https://github.com/Nitrokey/admin-app", rev = "v0.1.0-nitrokey.2", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
 oath-authenticator = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "0.6.0", features = ["apdu-dispatch", "ctaphid"], optional = true }


### PR DESCRIPTION
This patch extends the status reported by the admin app with the available blocks on the internal and external filesystem at boot time.

Requires: https://github.com/Nitrokey/admin-app/pull/3