### PR TITLE
Update usbd-ctaphid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,8 +2722,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb69f660f962236eb21565780c433412ad0ba35e5106f53191cdf443c1d03d2"
+source = "git+https://github.com/trussed-dev/usbd-ctaphid#46070aa05f763163fc67a9194038dbf33bb04082"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.
 
 # unreleased
 interchange = { git = "https://github.com/trussed-dev/interchange" }
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
This patch updates usbd-ctaphid to fix a panic for long messages returned by ctaphid-dispatch.

Fixes https://github.com/Nitrokey/nitrokey-3-firmware/issues/159