### PR TITLE
Extend gitignore

### DIFF
--- a/ssh/troubles/.gitignore
+++ b/ssh/troubles/.gitignore
@@ -1,0 +1,2 @@
+data
+key.pub

--- a/utils/nrf-bootloader/.gitignore
+++ b/utils/nrf-bootloader/.gitignore
@@ -1,0 +1,1 @@
+signing-key

--- a/utils/nrf-builder/.gitignore
+++ b/utils/nrf-builder/.gitignore
@@ -1,0 +1,4 @@
+*.bin
+*.zip
+*.hex
+test-certs


### PR DESCRIPTION
This patch adds three gitignore files so that executing the examples and builders in this repository does not create untracked files.