### PR TITLE
lpc55: Enable delog for log-rtt feature

### DIFF
--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -24,7 +24,11 @@ pub fn init(
     #[cfg(feature = "log-rtt")]
     rtt_target::rtt_init_print!();
 
-    #[cfg(any(feature = "log-semihosting", feature = "log-serial"))]
+    #[cfg(any(
+        feature = "log-rtt",
+        feature = "log-semihosting",
+        feature = "log-serial"
+    ))]
     Delogger::init_default(delog::LevelFilter::Debug, &crate::types::DELOG_FLUSHER).ok();
 
     crate::banner();


### PR DESCRIPTION
This patch adds log-rtt to the list of features that enable the delog initialization.