### PR TITLE
docs: Update CTAPHID command list

### DIFF
--- a/docs/ctaphid-commands.md
+++ b/docs/ctaphid-commands.md
@@ -10,11 +10,11 @@ This document provides an overview of the [CTAPHID vendor commands][vendor] used
 | 0x61    | [admin-app][] (version) |
 | 0x62    | [admin-app][] (uuid)    |
 | 0x63    | [admin-app][] (locked)  |
-| 0x70    | [oath-authenticator][]  |
+| 0x70    | [secrets-app][]         |
 | 0x71    | [provisioner-app][]     |
 | 0x72    | [admin-app][]           |
 
 [vendor]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#usb-vendor-specific-commands
 [admin-app]: https://github.com/Nitrokey/admin-app
-[oath-authenticator]: https://github.com/nitrokey/oath-authenticator
 [provisioner-app]: https://github.com/Nitrokey/nitrokey-3-firmware/tree/main/components/provisioner-app
+[secrets-app]: https://github.com/Nitrokey/trussed-secrets-app

--- a/docs/ctaphid-commands.md
+++ b/docs/ctaphid-commands.md
@@ -12,8 +12,9 @@ This document provides an overview of the [CTAPHID vendor commands][vendor] used
 | 0x63    | [admin-app][] (locked)  |
 | 0x70    | [oath-authenticator][]  |
 | 0x71    | [provisioner-app][]     |
+| 0x72    | [admin-app][]           |
 
 [vendor]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#usb-vendor-specific-commands
-[admin-app]: https://github.com/solokeys/admin-app
+[admin-app]: https://github.com/Nitrokey/admin-app
 [oath-authenticator]: https://github.com/nitrokey/oath-authenticator
 [provisioner-app]: https://github.com/Nitrokey/nitrokey-3-firmware/tree/main/components/provisioner-app


### PR DESCRIPTION
This patch adds the new global command 0x72 for admin-app to the CTAPHID command list, see <https://github.com/Nitrokey/admin-app/pull/1>.