### PR TITLE
Use Rust 1.68 for stable and alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,9 +1585,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
+checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
 name = "littlefs2"

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -11,11 +11,6 @@ else
   SOC = nrf52
 endif
 
-ifneq ($(findstring alpha,$(FEATURES)),)
-  RUSTUP_TOOLCHAIN = nightly-2022-11-13
-  export RUSTUP_TOOLCHAIN
-endif
-
 # rust triplet
 TARGET = $(shell python3 -c 'import toml; print(toml.load("$(CFG_PATH)")["platform"]["target"])')
 # gnu binutils-prefix
@@ -103,7 +98,6 @@ check-var-%:
 	@echo "**** BOARD:     $(shell printf %18s $(BOARD)) | SOC:      $(SOC)"
 	@echo "**** PROFILE:   $(shell printf %18s $(BUILD_PROFILE)) | BUILD_ID: $(BUILD_ID)"
 	@echo "**** FEATURES:  $(BUILD_FEATURES)"
-	@echo "**** TOOLCHAIN: $(RUSTUP_TOOLCHAIN)"
 	@echo "******************************************************************************************"
 
 list:

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![cfg_attr(feature = "alloc", feature(alloc_error_handler))]
 
 use interchange::Interchange;
 use littlefs2::fs::Filesystem;
@@ -298,16 +297,6 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     error_now!("{}", _info);
     soc::board::set_panic_led();
     loop {
-        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-#[cfg(feature = "alloc")]
-#[alloc_error_handler]
-fn oom(_: core::alloc::Layout) -> ! {
-    error_now!("Failed alloc");
-    loop {
-        soc::board::set_panic_led();
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.68.0"
 components = ["rustfmt", "llvm-tools-preview"]
 targets = ["thumbv7em-none-eabihf", "thumbv8m.main-none-eabi"]


### PR DESCRIPTION
This patch updates the default Rust version from 1.65 to 1.68.  As support for custom allocators has been stabilized, we can now also use it for the alpha (instead of nightly).  We just have to drop the custom alloc error handler (default: panic) and update the linked_list_allocator dependency.