### PR TITLE
lpc55-builder: Add provision-release target

### DIFF
--- a/docs/lpc55-quickstart.md
+++ b/docs/lpc55-quickstart.md
@@ -107,14 +107,7 @@ You might have to press the touch button during the command to confirm a reboot.
 
 ## Using the Alpha Firmware
 
-The alpha firmware can be built by activating the `alpha` feature.  It requires the nightly Rust compiler – check the `Makefile` in `runners/embedded` for the current nightly version:
-```
-$ grep RUSTUP_TOOLCHAIN runners/embedded/Makefile | head -1
-  RUSTUP_TOOLCHAIN = nightly-2022-11-13
-$ rustup +nightly-2022-11-13 target add thumbv8m.main-none-eabi
-```
-
-Make sure that you can compile the alpha firmware:
+The alpha firmware can be built by activating the `alpha` feature.  First, make sure that you can compile the alpha firmware:
 ```
 $ make -C runners/embedded build-nk3xn FEATURES=alpha
 ```

--- a/utils/lpc55-builder/Makefile
+++ b/utils/lpc55-builder/Makefile
@@ -20,11 +20,11 @@ run: build
 
 .PHONY: provision-develop
 provision-develop:
-	# Step 1: build & flash provisioner, configure device
-	$(MAKE) build FEATURES=develop,provisioner,$(FEATUERS)
+	# Step 1: reset CMPA, erase firmware, build & flash provisioner
 	./scripts/boot-to-bootrom.sh
 	./scripts/usbwait.sh 1fc9:0021 20a0:42dd
-	$(MAKE) bl-config-cmpa-develop
+	$(MAKE) build FEATURES=develop,provisioner,$(FEATUERS)
+	$(MAKE) bl-config-cmpa-empty
 	$(MAKE) bl-erase-firmware
 	$(MAKE) bl-flash
 	lpc55 reboot
@@ -32,6 +32,11 @@ provision-develop:
 	# Step 2: provision certs
 	$(MAKE) fw-provision-certs
 	./scripts/boot-to-bootrom.sh
+	./scripts/usbwait.sh 1fc9:0021
+	# Step 3: erase firmware, configure CMPA
+	$(MAKE) bl-erase-firmware
+	$(MAKE) bl-config-cmpa-develop
+	lpc55 reboot
 	./scripts/usbwait.sh 20a0:42dd
 	# Step 3: build & flash final firmware
 	$(MAKE) build FEATURES=develop,$(FEATURES)
@@ -42,7 +47,35 @@ provision-develop:
 
 .PHONY: provision-release
 provision-release:
-	# TODO: implement
+	# TODO: add secure boot
+	# Step 0: reset CMPA, erase firmware
+	./scripts/boot-to-bootrom.sh
+	./scripts/usbwait.sh 1fc9:0021 20a0:42dd
+	$(MAKE) bl-config-cmpa-empty
+	$(MAKE) bl-erase-firmware
+	lpc55 reboot
+	./scripts/usbwait.sh 1fc9:0021
+	# Step 1: build & flash provisioner, provision keystore
+	$(MAKE) build FEATURES=provisioner,$(FEATUERS)
+	$(MAKE) bl-provision-keystore
+	$(MAKE) bl-flash
+	lpc55 reboot
+	./scripts/usbwait.sh 20a0:42b2
+	# Step 2: provision certs
+	$(MAKE) fw-provision-certs
+	./scripts/boot-to-bootrom.sh
+	./scripts/usbwait.sh 1fc9:0021
+	# Step 3: erase firmware, configure CMPA
+	$(MAKE) bl-erase-firmware
+	$(MAKE) bl-config-cmpa-develop
+	lpc55 reboot
+	./scripts/usbwait.sh 20a0:42dd
+	# Step 3: build & flash final firmware
+	$(MAKE) build FEATURES=$(FEATURES)
+	$(MAKE) bl-erase-firmware
+	$(MAKE) bl-flash
+	lpc55 reboot
+	./scripts/usbwait.sh 20a0:42b2
 
 .PHONY: flash
 flash: build

--- a/utils/lpc55-builder/config/keystore.toml
+++ b/utils/lpc55-builder/config/keystore.toml
@@ -80,6 +80,3 @@ words = [
 [[provisions]]
 cmd = "ConfigureMemory"
 address = 0x20034000
-
-[[provisions]]
-cmd = "Reset"


### PR DESCRIPTION
This patch adds the provision-release target to the lpc55-builder Makefile that provisions the keystore and enables the encrypted storage using the PRINCE peripheral.  This setup is closer to production than our develop setup without storage encryption.  The advantage of the develop setup is that it is easy to read out the internal flash for debugging.