### PR TITLE
NRF: use SPIM instead of QSPI for external storage

### DIFF
--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -91,7 +91,7 @@ alloc = ["alloc-cortex-m"]
 
 board-nrfdk = ["soc-nrf52840", "extflash_qspi"]
 board-proto1 = ["soc-nrf52840"]
-board-nk3am = ["soc-nrf52840", "extflash_qspi"]
+board-nk3am = ["soc-nrf52840", "extflash_spi"]
 
 board-nk3xn = ["soc-lpc55"]
 
@@ -99,6 +99,8 @@ soc-nrf52840 = ["nrf52840-hal", "nrf52840-pac", "chacha20"]
 soc-lpc55 = ["lpc55-hal", "lpc55-pac", "fm11nc08", "systick-monotonic"]
 
 extflash_qspi = []
+extflash_spi = []
+
 lpc55-hardware-checks = []
 
 log-all = []

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -115,7 +115,24 @@ mod app {
 
             qspi_extflash
         };
-        #[cfg(not(feature = "extflash_qspi"))]
+        #[cfg(feature = "extflash_spi")]
+        let extflash = {
+            use nrf52840_hal::Spim;
+            //Spim::new(spi, pins, config.speed(), config.mode())
+            let spim = Spim::new(
+                ctx.device.SPIM3,
+                board_gpio.flashnfc_spi.take().unwrap(),
+                nrf52840_hal::spim::Frequency::M2,
+                nrf52840_hal::spim::MODE_0,
+                0x00u8,
+            );
+            use crate::ERL::flash::ExtFlashStorage;
+            let res = ExtFlashStorage::try_new(spim, board_gpio.flash_cs.take().unwrap());
+
+            res.unwrap()
+        };
+
+        #[cfg(not(any(feature = "extflash_qspi", feature = "extflash_spi")))]
         let extflash = ERL::soc::types::ExternalStorage::new();
 
         let store: ERL::types::RunnerStore =
@@ -277,7 +294,7 @@ mod app {
     fn task_trussed(ctx: task_trussed::Context) {
         let mut trussed = ctx.shared.trussed;
 
-        trace!("irq SWI0_EGU0");
+        //trace!("irq SWI0_EGU0");
         trussed.lock(|trussed| {
             ERL::runtime::run_trussed(trussed);
         });

--- a/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/mod.rs
@@ -7,14 +7,15 @@ use backends::EFSBackupBackend;
 use ifs_flash_old::FlashStorage as OldFlashStorage;
 use lfs_backup::{BackupBackend, FSBackupError, Result};
 
-use crate::soc::{flash::FlashStorage, qspiflash::QspiFlash};
+use crate::soc::{flash::FlashStorage, types::Soc as SocT};
+use crate::types::Soc;
 
 pub fn migrate<'a>(
     old_ifs_storage: &mut OldFlashStorage,
     old_ifs_alloc: &mut littlefs2::fs::Allocation<OldFlashStorage>,
     ifs_alloc: &mut littlefs2::fs::Allocation<FlashStorage>,
     ifs_storage: &mut FlashStorage,
-    efs_storage: &mut QspiFlash,
+    efs_storage: &mut <SocT as Soc>::ExternalFlashStorage,
 ) -> Result<()> {
     let old_mounted = littlefs2::fs::Filesystem::mount(old_ifs_alloc, old_ifs_storage)
         .map_err(|_| FSBackupError::LittleFs2Err)?;


### PR DESCRIPTION
Extracted from hw-key-nrf-spi