### PR TITLE
wait 5 more seconds for dev to show up during provision-develop

### DIFF
--- a/utils/lpc55-builder/Makefile
+++ b/utils/lpc55-builder/Makefile
@@ -29,6 +29,8 @@ provision-develop:
 	$(MAKE) bl-flash
 	lpc55 reboot
 	./scripts/usbwait.sh 20a0:42b2
+	# wait 5 more seconds for the device to show up properly again
+	sleep 5
 	# Step 2: provision certs
 	$(MAKE) fw-provision-certs
 	./scripts/boot-to-bootrom.sh


### PR DESCRIPTION
related to https://github.com/Nitrokey/nitrokey-3-firmware/issues/187#issuecomment-1484869788

just an idea, if it doesn't fit, I'll close this but so far it works with this patch