### PR TITLE
Add rsa backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "provisioner-app",
  "trussed",
  "trussed-auth",
+ "trussed-rsa-alloc",
  "trussed-usbip",
  "usbd-ctaphid",
  "utils",
@@ -548,6 +549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,8 +835,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid",
+ "const-oid 0.7.1",
  "crypto-bigint 0.3.2",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid 0.9.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -881,6 +898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.2",
  "crypto-common",
  "subtle",
 ]
@@ -894,7 +912,7 @@ dependencies = [
  "der 0.4.5",
  "elliptic-curve",
  "hmac 0.11.0",
- "signature",
+ "signature 1.3.2",
 ]
 
 [[package]]
@@ -903,7 +921,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.3.2",
 ]
 
 [[package]]
@@ -2136,7 +2154,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
 dependencies = [
  "der 0.5.1",
- "pkcs8",
+ "pkcs8 0.8.0",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
  "zeroize",
 ]
 
@@ -2147,8 +2177,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der 0.5.1",
- "spki",
+ "spki 0.5.4",
  "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -2363,10 +2403,31 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.3.3",
+ "pkcs8 0.8.0",
  "rand_core",
  "smallvec",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+dependencies = [
+ "byteorder",
+ "digest 0.10.6",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1 0.4.1",
+ "pkcs8 0.9.0",
+ "rand_core",
+ "sha2 0.10.6",
+ "signature 2.0.0",
  "subtle",
  "zeroize",
 ]
@@ -2664,6 +2725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2791,16 @@ checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "base64ct",
  "der 0.5.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -2954,7 +3035,7 @@ dependencies = [
  "postcard 0.7.3",
  "rand_chacha",
  "rand_core",
- "rsa",
+ "rsa 0.6.1",
  "salty",
  "serde",
  "serde-indexed",
@@ -2976,6 +3057,20 @@ dependencies = [
  "serde-byte-array",
  "sha2 0.10.6",
  "subtle",
+ "trussed",
+]
+
+[[package]]
+name = "trussed-rsa-alloc"
+version = "0.1.0"
+source = "git+https://github.com/Nitrokey/trussed-rsa-backend.git?rev=311d2366f99cc300b03d61e7f6a0a07abd3e8700#311d2366f99cc300b03d61e7f6a0a07abd3e8700"
+dependencies = [
+ "delog",
+ "heapless-bytes 0.3.0",
+ "num-bigint-dig",
+ "postcard 0.7.3",
+ "rsa 0.8.2",
+ "serde",
  "trussed",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitro
 lpc55-hal = { git = "https://github.com/nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey-2" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.8" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.2.1"}
+trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", rev = "311d2366f99cc300b03d61e7f6a0a07abd3e8700"}
 
 # unreleased
 interchange = { git = "https://github.com/trussed-dev/interchange" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -13,6 +13,7 @@ utils = { path = "../utils" }
 
 # Backends
 trussed-auth = { version = "0.2.1", optional = true }
+trussed-rsa-alloc = { version = "0.1.0", optional = true }
 
 # apps
 admin-app = { git = "https://github.com/Nitrokey/admin-app", rev = "v0.1.0-nitrokey.2", optional = true }
@@ -28,7 +29,7 @@ default = [
     "fido-authenticator",
     "ndef-app",
     "oath-authenticator",
-    "trussed/clients-3"
+    "trussed/clients-3",
 ]
 alpha = ["opcard", "trussed/clients-4"]
 provisioner = ["provisioner-app", "trussed/clients-3"]
@@ -39,6 +40,7 @@ fido-authenticator = ["dep:fido-authenticator", "usbd-ctaphid"]
 
 # backends
 backend-auth = ["trussed-auth"]
+backend-rsa = ["trussed-rsa-alloc"]
 
 log-all = [
     "admin-app?/log-all",


### PR DESCRIPTION
This patch adds the RSA backend that will be necessary for the PIV application and for the updated OpenPGP smartcard.
The rsa backend is added behind the `rsa` feature flag, which is currently not enabled for anything.