### PR TITLE
fido-authenticator: Limit resident credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - usbip: Add `--efs` option to store the external filesystem in a file.
 - Add variant to the status reported by admin-app ([#206][])
+- fido-authenticator: Limit number of resident credentials to ten ([#207][])
 
 [#206]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/206
+[#207]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/207
 
 # v1.3.1 (2023-04-05)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?rev=v0.1.1-nitrokey.2#d47a7c158f83cf60c9a0e3c13df53900342da665"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?rev=v0.1.1-nitrokey.3#7f6a09347babb4bc629ff7668807f3d987fa534f"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -17,7 +17,7 @@ trussed-rsa-alloc = { version = "0.1.0", optional = true }
 
 # apps
 admin-app = { git = "https://github.com/Nitrokey/admin-app", rev = "v0.1.0-nitrokey.2", optional = true }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", features = ["dispatch"], optional = true, rev = "v0.1.1-nitrokey.2" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", features = ["dispatch"], optional = true, rev = "v0.1.1-nitrokey.3" }
 ndef-app = { path = "../ndef-app", optional = true }
 oath-authenticator = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "0.10.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "v0.4.0", features = ["apdu-dispatch", "delog", "rsa2048", "rsa4096"], optional = true }

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -340,6 +340,7 @@ impl<R: Runner> App<R> for FidoApp<R> {
             fido_authenticator::Config {
                 max_msg_size: usbd_ctaphid::constants::MESSAGE_SIZE,
                 skip_up_timeout: Some(core::time::Duration::from_secs(2)),
+                max_resident_credential_count: Some(10),
             },
         )
     }


### PR DESCRIPTION
This patch introduces a limit of ten resident credentials, see: https://github.com/Nitrokey/nitrokey-3-firmware/issues/207

This PR depends on:
- https://github.com/Nitrokey/fido-authenticator/pull/12