### PR TITLE
Extend nightly CI checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ metadata:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - if: '$CI_PIPELINE_SOURCE == "web"'
   tags:
     - docker
@@ -44,7 +43,6 @@ check-firmware:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
   tags:
     - docker
   stage: build
@@ -59,7 +57,6 @@ check-usbip:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
   tags:
     - docker
   stage: build
@@ -80,6 +77,31 @@ lint:
   stage: build
   script:
     - make lint
+  after_script:
+    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
+
+build-nightly:
+  image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+  tags:
+    - docker
+  stage: build
+  parallel:
+    matrix:
+      - RUSTUP_TOOLCHAIN: [stable, nightly]
+  script:
+    - cargo --version
+    - rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
+    - make -C runners/embedded build-nk3am.bl
+    - make -C runners/embedded build-nk3am.bl FEATURES=test
+    - make -C runners/embedded build-nk3am.bl FEATURES=provisioner
+    - make -C runners/embedded build-nk3xn
+    - make -C runners/embedded build-nk3xn FEATURES=test
+    - make -C runners/embedded build-nk3xn FEATURES=provisioner
+    - cargo build --release --manifest-path runners/usbip/Cargo.toml
+    - cargo build --release --manifest-path runners/usbip/Cargo.toml --features test
+    - cargo build --release --manifest-path runners/usbip/Cargo.toml --features provisioner
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM rust:1.65
+FROM rust:1.68
 RUN apt-get update && \
     apt-get install -y python3 python3-toml git curl llvm clang libclang-dev gcc-arm-none-eabi libc6-dev-i386 make wget zip
 RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
-RUN rustup +nightly-2022-11-13 target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview
 WORKDIR /app


### PR DESCRIPTION
This patch adds additional checks to scheduled CI jobs:
- All binaries are built to catch errors during the linking stage that are not detected by the regular CI.
- The job is executed with the latest stable and the latest nightly Rust versions instead of the pinned version to find potential compatibility problems early.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/241