### PR TITLE
Stabilize opcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - usbip: Add `--efs` option to store the external filesystem in a file.
 - Add variant to the status reported by admin-app ([#206][])
 - fido-authenticator: Limit number of resident credentials to ten ([#207][])
+- Add opcard to the stable firmware ([#100][])
 
 ## Changed
 
@@ -13,6 +14,7 @@
   - piv-authenticator v0.2.0
   - secrets-app v0.10.0
 
+[#100]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/100
 [#206]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/206
 [#207]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/207
 

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -31,10 +31,11 @@ default = [
     "fido-authenticator",
     "ndef-app",
     "oath-authenticator",
-    "trussed/clients-3",
+    "opcard",
+    "trussed/clients-4",
 ]
-test = ["opcard", "piv-authenticator", "trussed/clients-5"]
-provisioner = ["provisioner-app", "trussed/clients-3"]
+test = ["piv-authenticator", "trussed/clients-5"]
+provisioner = ["provisioner-app", "trussed/clients-5"]
 
 # apps
 oath-authenticator = ["dep:oath-authenticator", "backend-auth"]

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -378,9 +378,10 @@ impl<R: Runner> App<R> for OpcardApp<R> {
         let uuid = runner.uuid();
         let mut options = opcard::Options::default();
         options.button_available = true;
-        options.serial = [0xa0, 0x20, uuid[0], uuid[1]];
+        // See scd/app-openpgp.c in GnuPG for the manufacturer IDs
+        options.manufacturer = 0x000Fu16.to_be_bytes();
+        options.serial = [uuid[0], uuid[1], uuid[2], uuid[3]];
         options.storage = trussed::types::Location::External;
-        // TODO: set manufacturer to Nitrokey
         Self::new(trussed, options)
     }
     fn backends(runner: &R) -> &'static [BackendId<Backend>] {

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -68,9 +68,9 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 
 [features]
-default = []
+default = ["alloc"]
 
-test = ["apps/test", "alloc"]
+test = ["apps/test"]
 develop = ["no-encrypted-storage", "apps/no-reset-time-window", "log-traceP"]
 develop-no-press = ["develop", "no-buttons"]
 provisioner = ["apps/provisioner", "write-undefined-flash", "no-buttons", "apps/no-reset-time-window", "lpc55-hardware-checks"]


### PR DESCRIPTION
This patch adds opcard to the default applications.  This also means
that we have to enable alloc per default for RSA support.

Fixes https://github.com/Nitrokey/nitrokey-3-firmware/issues/100