### PR TITLE
Update fido-authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+### Bugfixes
+
+- Fix overwriting existing resident FIDO2 credentials ([#254][])
+
+[#254]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/254
+
 ## v1.4.0-rc.1 (2023-04-27)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.3#7f6a09347babb4bc629ff7668807f3d987fa534f"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.4#857899bff75331b2c9a419f95457f541440c3a0d"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "1.4.0-rc.1"
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.2" }
 ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.1" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.3" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.4" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.11" }
 


### PR DESCRIPTION
This patch updates fido-authenticator to fix overwriting existing resident FIDO2 credentials.

Depends on:
- https://github.com/Nitrokey/fido-authenticator/pull/14