### PR TITLE
Fix embedded runner always recompiling

### DIFF
--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -125,11 +125,7 @@ build: build-banner $(SRCS) check-var-BOARD check-var-BUILD_PROFILE check-var-SO
 
 	cargo --version
 
-	cp -f $(CFG_PATH) cfg.toml
-	echo '' >> cfg.toml
-	echo '[build]' >> cfg.toml
-	echo 'build_profile = "$(BUILD_PROFILE)"' >> cfg.toml
-	echo 'board = "$(BOARD)"' >> cfg.toml
+	./create_cfg.sh $(CFG_PATH) $(BUILD_PROFILE) $(BOARD)
 
 	# NRF52/test -> "release-thin-lto", use "release" otherwise
 	cargo build --target $(TARGET) \
@@ -150,11 +146,7 @@ check: check-banner $(SRCS) check-var-BOARD check-var-BUILD_PROFILE check-var-SO
 
 	cargo --version
 
-	cp -f $(CFG_PATH) cfg.toml
-	echo '' >> cfg.toml
-	echo '[build]' >> cfg.toml
-	echo 'build_profile = "$(BUILD_PROFILE)"' >> cfg.toml
-	echo 'board = "$(BOARD)"' >> cfg.toml
+	./create_cfg.sh $(CFG_PATH) $(BUILD_PROFILE) $(BOARD)
 
 	cargo check --target $(TARGET) \
 		--features $(COMMA_FEATURES) \

--- a/runners/embedded/create_cfg.sh
+++ b/runners/embedded/create_cfg.sh
@@ -6,7 +6,7 @@ BOARD="$3"
 
 
 TMP_CFG=$(mktemp)
-cp -f "$CFG_PATH" $TMP_CFG
+cp "$CFG_PATH" $TMP_CFG
 echo '' >> $TMP_CFG
 echo '[build]' >> $TMP_CFG
 echo "build_profile = \"$BUILD_PROFILE\"" >> $TMP_CFG
@@ -15,5 +15,6 @@ echo "board = \"$BOARD\"" >> $TMP_CFG
 diff $TMP_CFG cfg.toml 
 if [ "$?" != 0 ]; then
   mv -f $TMP_CFG cfg.toml
+else
+  rm $TMP_CFG
 fi
-rm -f $TMP_CFG

--- a/runners/embedded/create_cfg.sh
+++ b/runners/embedded/create_cfg.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+CFG_PATH="$1"
+BUILD_PROFILE="$2"
+BOARD="$3"
+
+
+TMP_CFG=$(mktemp)
+cp -f "$CFG_PATH" $TMP_CFG
+echo '' >> $TMP_CFG
+echo '[build]' >> $TMP_CFG
+echo "build_profile = \"$BUILD_PROFILE\"" >> $TMP_CFG
+echo "board = \"$BOARD\"" >> $TMP_CFG
+
+diff $TMP_CFG cfg.toml 
+if [ "$?" != 0 ]; then
+  mv -f $TMP_CFG cfg.toml
+fi
+rm -f $TMP_CFG


### PR DESCRIPTION
Cargo recompiles (and reruns the build.rs) if the cfg.toml file has been modified Previously all calls to `make` rewrote this file and thus caused unneccessary recompilation. This patch adds a check that the contents of the file should actually be modified before rewriting it.