### PR TITLE
Bump all dependencies to their interchange 0.3.0 versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,12 +73,11 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 [[package]]
 name = "apdu-dispatch"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898c4ae30eeab17a209d5576cf7b312fdbee4d1cb739333c1308908fc841a5fb"
+source = "git+https://github.com/trussed-dev/apdu-dispatch?rev=6a2720d06930b715a7af9411a12c7fcf35d5995f#6a2720d06930b715a7af9411a12c7fcf35d5995f"
 dependencies = [
  "delog",
  "heapless 0.7.16",
- "interchange 0.2.2",
+ "interchange 0.3.0",
  "iso7816",
 ]
 
@@ -764,12 +763,12 @@ dependencies = [
 [[package]]
 name = "ctaphid-dispatch"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/ctaphid-dispatch?tag=v0.1.1-nitrokey.1#8dbb490da47c598cf6525432edef5ae296903b1a"
+source = "git+https://github.com/sosthene-nitrokey/ctaphid-dispatch?rev=143387d590fdb8ad587367a3053ef61ebf301f71#143387d590fdb8ad587367a3053ef61ebf301f71"
 dependencies = [
  "delog",
  "heapless 0.7.16",
  "heapless-bytes 0.3.0",
- "interchange 0.2.2",
+ "interchange 0.3.0",
 ]
 
 [[package]]
@@ -963,7 +962,7 @@ dependencies = [
  "generic-array 0.14.7",
  "heapless 0.7.16",
  "heapless-bytes 0.3.0",
- "interchange 0.2.2",
+ "interchange 0.3.0",
  "lfs-backup",
  "littlefs2",
  "lpc55-hal",
@@ -1527,7 +1526,8 @@ checksum = "310d743c23f798f10d5ba2f77fdd3eff06aaf2d8f8b9d78beba7fb1167f4ccbf"
 [[package]]
 name = "interchange"
 version = "0.3.0"
-source = "git+https://github.com/trussed-dev/interchange#1fe9629098bf63a01f7b63595c2b470f6148acb6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cfaa4be499da454ab279e04dee4837e71b3803eced4bd2b4cdec4bb3377b4f"
 dependencies = [
  "loom",
 ]
@@ -1803,7 +1803,7 @@ dependencies = [
  "delog",
  "embedded-time",
  "heapless 0.7.16",
- "interchange 0.2.2",
+ "interchange 0.3.0",
  "iso7816",
  "nb 1.1.0",
 ]
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner#f3a680ca4c9a1411838ae0774f1713f79d4c2979"
+source = "git+https://github.com/trussed-dev/pc-usbip-runner?rev=8dfb126a06dcc476015eacfc938d7838830372d1#8dfb126a06dcc476015eacfc938d7838830372d1"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
@@ -3172,13 +3172,12 @@ checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 [[package]]
 name = "usbd-ccid"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855caab212e6d9358cd924b1fc2f7d3d14fe0762bf3ccb052f2b00e2e3954084"
+source = "git+https://github.com/trussed-dev/usbd-ccid?rev=7e1f11bd125651382d4b403226327de5df5f86b6#7e1f11bd125651382d4b403226327de5df5f86b6"
 dependencies = [
  "delog",
  "embedded-time",
  "heapless 0.7.16",
- "interchange 0.2.2",
+ "interchange 0.3.0",
  "iso7816",
  "usb-device",
 ]
@@ -3186,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/usbd-ctaphid#46070aa05f763163fc67a9194038dbf33bb04082"
+source = "git+https://github.com/trussed-dev/usbd-ctaphid?rev=9dd79aeeb927ab7fdb882fdca8f9324f64d1292c#9dd79aeeb927ab7fdb882fdca8f9324f64d1292c"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",
@@ -3194,7 +3193,7 @@ dependencies = [
  "embedded-time",
  "heapless 0.7.16",
  "heapless-bytes 0.3.0",
- "interchange 0.2.2",
+ "interchange 0.3.0",
  "serde",
  "usb-device",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 [[package]]
 name = "apdu-dispatch"
 version = "0.1.2"
-source = "git+https://github.com/trussed-dev/apdu-dispatch?rev=6a2720d06930b715a7af9411a12c7fcf35d5995f#6a2720d06930b715a7af9411a12c7fcf35d5995f"
+source = "git+https://github.com/trussed-dev/apdu-dispatch.git?rev=b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4#b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4"
 dependencies = [
  "delog",
  "heapless 0.7.16",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "ctaphid-dispatch"
 version = "0.1.1"
-source = "git+https://github.com/sosthene-nitrokey/ctaphid-dispatch?rev=143387d590fdb8ad587367a3053ef61ebf301f71#143387d590fdb8ad587367a3053ef61ebf301f71"
+source = "git+https://github.com/trussed-dev/ctaphid-dispatch?rev=d9eb980da163b613fdf759f6092b7c3bdcc0a22c#d9eb980da163b613fdf759f6092b7c3bdcc0a22c"
 dependencies = [
  "delog",
  "heapless 0.7.16",
@@ -3063,11 +3063,11 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner?rev=8dfb126a06dcc476015eacfc938d7838830372d1#8dfb126a06dcc476015eacfc938d7838830372d1"
+source = "git+https://github.com/trussed-dev/pc-usbip-runner?rev=083fca7693a9a910dd2337d8eaf9d50ccd1987d0#083fca7693a9a910dd2337d8eaf9d50ccd1987d0"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
- "interchange 0.2.2",
+ "interchange 0.3.0",
  "log",
  "trussed",
  "usb-device",
@@ -3172,7 +3172,7 @@ checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 [[package]]
 name = "usbd-ccid"
 version = "0.2.0"
-source = "git+https://github.com/trussed-dev/usbd-ccid?rev=7e1f11bd125651382d4b403226327de5df5f86b6#7e1f11bd125651382d4b403226327de5df5f86b6"
+source = "git+https://github.com/trussed-dev/usbd-ccid?rev=eeea54f85cfa69a43c676b63c030608830ea35ea#eeea54f85cfa69a43c676b63c030608830ea35ea"
 dependencies = [
  "delog",
  "embedded-time",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/usbd-ctaphid?rev=9dd79aeeb927ab7fdb882fdca8f9324f64d1292c#9dd79aeeb927ab7fdb882fdca8f9324f64d1292c"
+source = "git+https://github.com/trussed-dev/usbd-ctaphid?rev=2f658fbe84e262037621b15cb867424c4a60b038#2f658fbe84e262037621b15cb867424c4a60b038"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.1" }
 
 # unreleased upstream changes
-interchange = { git = "https://github.com/trussed-dev/interchange" }
 usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid" }
 
 # unreleased crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nit
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.4" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.11" }
-ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.1" }
 
 # unreleased upstream changes
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid" }
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", rev = "9dd79aeeb927ab7fdb882fdca8f9324f64d1292c" }
+usbd-ccid = { git = "https://github.com/trussed-dev/usbd-ccid", rev = "7e1f11bd125651382d4b403226327de5df5f86b6" }
+ctaphid-dispatch = { git = "https://github.com/sosthene-nitrokey/ctaphid-dispatch", rev = "143387d590fdb8ad587367a3053ef61ebf301f71" }
+apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch", rev = "6a2720d06930b715a7af9411a12c7fcf35d5995f" }
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "0.11.0" }
@@ -29,8 +31,8 @@ piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.2.2" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
 trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0"}
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner" }
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", rev = "8dfb126a06dcc476015eacfc938d7838830372d1" }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitro
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.11" }
 
 # unreleased upstream changes
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", rev = "9dd79aeeb927ab7fdb882fdca8f9324f64d1292c" }
-usbd-ccid = { git = "https://github.com/trussed-dev/usbd-ccid", rev = "7e1f11bd125651382d4b403226327de5df5f86b6" }
-ctaphid-dispatch = { git = "https://github.com/sosthene-nitrokey/ctaphid-dispatch", rev = "143387d590fdb8ad587367a3053ef61ebf301f71" }
-apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch", rev = "6a2720d06930b715a7af9411a12c7fcf35d5995f" }
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", rev = "2f658fbe84e262037621b15cb867424c4a60b038" }
+usbd-ccid = { git = "https://github.com/trussed-dev/usbd-ccid", rev = "eeea54f85cfa69a43c676b63c030608830ea35ea" }
+ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch", rev = "d9eb980da163b613fdf759f6092b7c3bdcc0a22c" }
+apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4" }
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "0.11.0" }
@@ -32,7 +32,7 @@ trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
 trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0"}
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", rev = "8dfb126a06dcc476015eacfc938d7838830372d1" }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", rev = "083fca7693a9a910dd2337d8eaf9d50ccd1987d0" }
 
 [profile.release]
 codegen-units = 1

--- a/components/nfc-device/Cargo.toml
+++ b/components/nfc-device/Cargo.toml
@@ -12,7 +12,7 @@ nb = "1"
 
 apdu-dispatch = "0.1"
 iso7816 = "0.1"
-interchange = "0.2.1"
+interchange = "0.3.0"
 
 [features]
 default = []

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -36,7 +36,7 @@ ctap-types = "0.1"
 
 ### trussed core
 trussed = "0.1"
-interchange = "0.2"
+interchange = "0.3"
 littlefs2 = { version = "0.4", features = ["c-stubs"] }
 
 ### usb machinery

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use interchange::Interchange;
+use interchange::Channel;
 use littlefs2::fs::Filesystem;
 use soc::types::Soc as SocT;
 use types::Soc;
@@ -176,10 +176,15 @@ pub fn init_usb_nfc(
 ) -> types::usbnfc::UsbNfcInit {
     let config = <SocT as Soc>::INTERFACE_CONFIG;
 
+    use apdu_dispatch::interchanges::Channel as CcidChannel;
+    use ctaphid_dispatch::types::Channel as CtapChannel;
+    static CCID_CHANNEL: CcidChannel = Channel::new();
+    static NFC_CHANNEL: CcidChannel = Channel::new();
+    static CTAP_CHANNEL: CtapChannel = Channel::new();
     /* claim interchanges */
-    let (ccid_rq, ccid_rp) = apdu_dispatch::interchanges::Contact::claim().unwrap();
-    let (nfc_rq, nfc_rp) = apdu_dispatch::interchanges::Contactless::claim().unwrap();
-    let (ctaphid_rq, ctaphid_rp) = ctaphid_dispatch::types::HidInterchange::claim().unwrap();
+    let (ccid_rq, ccid_rp) = CCID_CHANNEL.split().unwrap();
+    let (nfc_rq, nfc_rp) = NFC_CHANNEL.split().unwrap();
+    let (ctaphid_rq, ctaphid_rp) = CTAP_CHANNEL.split().unwrap();
 
     /* initialize dispatchers */
     let apdu_dispatch = apdu_dispatch::dispatch::ApduDispatch::new(ccid_rp, nfc_rp);

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -128,8 +128,8 @@ pub type Trussed = trussed::Service<RunnerPlatform, Dispatch>;
 
 pub type Iso14443 = nfc_device::Iso14443<<SocT as Soc>::NfcDevice>;
 
-pub type ApduDispatch = apdu_dispatch::dispatch::ApduDispatch;
-pub type CtaphidDispatch = ctaphid_dispatch::dispatch::Dispatch;
+pub type ApduDispatch = apdu_dispatch::dispatch::ApduDispatch<'static>;
+pub type CtaphidDispatch = ctaphid_dispatch::dispatch::Dispatch<'static>;
 
 pub type Apps = apps::Apps<Runner>;
 

--- a/runners/embedded/src/types/usbnfc.rs
+++ b/runners/embedded/src/types/usbnfc.rs
@@ -1,13 +1,9 @@
 use crate::soc::types::Soc as SocT;
 use crate::types::Soc;
 
-pub type CcidClass = usbd_ccid::Ccid<
-    'static,
-    <SocT as Soc>::UsbBus,
-    apdu_dispatch::interchanges::Contact,
-    { apdu_dispatch::interchanges::SIZE },
->;
-pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, <SocT as Soc>::UsbBus>;
+pub type CcidClass =
+    usbd_ccid::Ccid<'static, 'static, <SocT as Soc>::UsbBus, { apdu_dispatch::interchanges::SIZE }>;
+pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, 'static, <SocT as Soc>::UsbBus>;
 // pub type KeyboardClass = usbd_hid::hid_class::HIDClass<'static, <SocT as Soc>::UsbBus>;
 pub type SerialClass = usbd_serial::SerialPort<'static, <SocT as Soc>::UsbBus>;
 
@@ -40,7 +36,7 @@ impl UsbClasses {
 
 pub struct UsbNfcInit {
     pub usb_classes: Option<UsbClasses>,
-    pub apdu_dispatch: apdu_dispatch::dispatch::ApduDispatch,
-    pub ctaphid_dispatch: ctaphid_dispatch::dispatch::Dispatch,
+    pub apdu_dispatch: apdu_dispatch::dispatch::ApduDispatch<'static>,
+    pub ctaphid_dispatch: ctaphid_dispatch::dispatch::Dispatch<'static>,
     pub iso14443: Option<super::Iso14443>,
 }


### PR DESCRIPTION
Dependant Open PRs:

- pc-usbip-runner:
  - https://github.com/trussed-dev/pc-usbip-runner/pull/25
  - [ ] tag release
- usbd-ccid:
  - https://github.com/trussed-dev/usbd-ccid/pull/10
  - [ ] tag release
- apdu-dispatch:
  - https://github.com/trussed-dev/apdu-dispatch/pull/16
  - [ ] tag release
- usbd-ctaphid:
  - https://github.com/trussed-dev/usbd-ctaphid/pull/4
  - [ ] tag release
- ctaphid-dispatch:
  - https://github.com/trussed-dev/ctaphid-dispatch/pull/3
  - [ ] tag release