### PR TITLE
Add support for FIDO request cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 [[package]]
 name = "apdu-dispatch"
 version = "0.1.2"
-source = "git+https://github.com/trussed-dev/apdu-dispatch?rev=b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4#b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4"
+source = "git+https://github.com/Nitrokey/apdu-dispatch?tag=v0.1.2-nitrokey.1#b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4"
 dependencies = [
  "delog",
  "heapless 0.7.16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner?rev=e78883847fb01ac93179074ff29e13a0d470775b#e78883847fb01ac93179074ff29e13a0d470775b"
+source = "git+https://github.com/Nitrokey/pc-usbip-runner?tag=v0.0.1-nitrokey.1#e78883847fb01ac93179074ff29e13a0d470775b"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/usbd-ctaphid?rev=e9cbf904f548979685c4c06d75479b75e3695160#e9cbf904f548979685c4c06d75479b75e3695160"
+source = "git+https://github.com/Nitrokey/usbd-ctaphid?tag=v0.1.0-nitrokey.1#e9cbf904f548979685c4c06d75479b75e3695160"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "admin-app"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/admin-app?tag=v0.1.0-nitrokey.2#398f9b258d8cfab57a9353fcb61818f162db41c8"
+source = "git+https://github.com/Nitrokey/admin-app?tag=v0.1.0-nitrokey.3#15aec92ff3f30f2ad1ff157ac5077c7211a04c77"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
@@ -73,7 +73,7 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 [[package]]
 name = "apdu-dispatch"
 version = "0.1.2"
-source = "git+https://github.com/trussed-dev/apdu-dispatch.git?rev=b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4#b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4"
+source = "git+https://github.com/trussed-dev/apdu-dispatch?rev=b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4#b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4"
 dependencies = [
  "delog",
  "heapless 0.7.16",
@@ -763,12 +763,14 @@ dependencies = [
 [[package]]
 name = "ctaphid-dispatch"
 version = "0.1.1"
-source = "git+https://github.com/trussed-dev/ctaphid-dispatch?rev=d9eb980da163b613fdf759f6092b7c3bdcc0a22c#d9eb980da163b613fdf759f6092b7c3bdcc0a22c"
+source = "git+https://github.com/Nitrokey/ctaphid-dispatch?tag=v0.1.1-nitrokey.2#57cb3317878a8593847595319aa03ef17c29ec5b"
 dependencies = [
  "delog",
  "heapless 0.7.16",
  "heapless-bytes 0.3.0",
  "interchange 0.3.0",
+ "ref-swap",
+ "trussed",
 ]
 
 [[package]]
@@ -972,6 +974,7 @@ dependencies = [
  "nrf52840-hal",
  "nrf52840-pac",
  "rand_core",
+ "ref-swap",
  "rtt-target",
  "serde",
  "spi-memory",
@@ -1003,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "encrypted_container"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=0.11.0#7d3dbe963815500e3cc3abc8f56ff92d62328da4"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=75626206ca3410fdcef0bb77cd7fd7962054f077#75626206ca3410fdcef0bb77cd7fd7962054f077"
 dependencies = [
  "cbor-smol",
  "delog",
@@ -1049,7 +1052,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.4#857899bff75331b2c9a419f95457f541440c3a0d"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.5#c471c81e25506d40b03f22f1b56fbc3441220ab8"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",
@@ -2336,6 +2339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-swap"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c30c54dffee5b40af088d5d50aa3455c91a0127164b51f0215efc4cb28fb3c"
+
+[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,8 +2504,8 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secrets-app"
-version = "0.11.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=0.11.0#7d3dbe963815500e3cc3abc8f56ff92d62328da4"
+version = "0.12.0"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=75626206ca3410fdcef0bb77cd7fd7962054f077#75626206ca3410fdcef0bb77cd7fd7962054f077"
 dependencies = [
  "apdu-dispatch",
  "bitflags 2.3.1",
@@ -2982,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed?tag=v0.1.0-nitrokey.11#686aa7064de6a9cfb315c1903c1440f46cc8e840"
+source = "git+https://github.com/Nitrokey/trussed?tag=v0.1.0-nitrokey.12#f3c95ab16fe6f9357a5d792e709e93d06c304b34"
 dependencies = [
  "aes",
  "bitflags 1.3.2",
@@ -3019,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "trussed-auth"
 version = "0.2.2"
-source = "git+https://github.com/trussed-dev/trussed-auth?tag=v0.2.2#d704b046acb7b766a89adb95539805ee705b6710"
+source = "git+https://github.com/Nitrokey/trussed-auth?tag=v0.2.2-nitrokey.1#203a90dd13a7378f596b3099cd986a8da6185137"
 dependencies = [
  "chacha20poly1305",
  "hkdf",
@@ -3049,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "trussed-staging"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-staging.git?tag=v0.1.0#5d7816e921d9279e4e2e3f2755039839986ea7e5"
+source = "git+https://github.com/Nitrokey/trussed-staging.git?tag=v0.1.0-nitrokey.1#c6aa6bdd65f04eb746a2d65725ba2d01c27ae1f7"
 dependencies = [
  "chacha20poly1305",
  "delog",
@@ -3063,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner?rev=083fca7693a9a910dd2337d8eaf9d50ccd1987d0#083fca7693a9a910dd2337d8eaf9d50ccd1987d0"
+source = "git+https://github.com/trussed-dev/pc-usbip-runner?rev=e78883847fb01ac93179074ff29e13a0d470775b#e78883847fb01ac93179074ff29e13a0d470775b"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
@@ -3172,7 +3181,7 @@ checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 [[package]]
 name = "usbd-ccid"
 version = "0.2.0"
-source = "git+https://github.com/trussed-dev/usbd-ccid?rev=eeea54f85cfa69a43c676b63c030608830ea35ea#eeea54f85cfa69a43c676b63c030608830ea35ea"
+source = "git+https://github.com/Nitrokey/usbd-ccid?tag=v0.2.0-nitrokey.1#eeea54f85cfa69a43c676b63c030608830ea35ea"
 dependencies = [
  "delog",
  "embedded-time",
@@ -3185,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/usbd-ctaphid?rev=2f658fbe84e262037621b15cb867424c4a60b038#2f658fbe84e262037621b15cb867424c4a60b038"
+source = "git+https://github.com/trussed-dev/usbd-ctaphid?rev=e9cbf904f548979685c4c06d75479b75e3695160#e9cbf904f548979685c4c06d75479b75e3695160"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",
@@ -3194,7 +3203,9 @@ dependencies = [
  "heapless 0.7.16",
  "heapless-bytes 0.3.0",
  "interchange 0.3.0",
+ "ref-swap",
  "serde",
+ "trussed",
  "usb-device",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "encrypted_container"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=75626206ca3410fdcef0bb77cd7fd7962054f077#75626206ca3410fdcef0bb77cd7fd7962054f077"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.11.0-interrupt.1#4637a4b5a425636da0283962ce1979170a9ea1fd"
 dependencies = [
  "cbor-smol",
  "delog",
@@ -2505,7 +2505,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "secrets-app"
 version = "0.12.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=75626206ca3410fdcef0bb77cd7fd7962054f077#75626206ca3410fdcef0bb77cd7fd7962054f077"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.11.0-interrupt.1#4637a4b5a425636da0283962ce1979170a9ea1fd"
 dependencies = [
  "apdu-dispatch",
  "bitflags 2.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag =
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.2-nitrokey.1" }
 
 # unreleased crates
-secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "75626206ca3410fdcef0bb77cd7fd7962054f077" }
+secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.11.0-interrupt.1" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.0" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,27 +12,27 @@ version = "1.5.0-test.20230613"
 
 [patch.crates-io]
 # forked
-admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.2" }
+admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.3" }
 ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.1" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.4" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.5" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
-trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.11" }
+trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }
 
 # unreleased upstream changes
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", rev = "2f658fbe84e262037621b15cb867424c4a60b038" }
-usbd-ccid = { git = "https://github.com/trussed-dev/usbd-ccid", rev = "eeea54f85cfa69a43c676b63c030608830ea35ea" }
-ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch", rev = "d9eb980da163b613fdf759f6092b7c3bdcc0a22c" }
-apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch.git", rev = "b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4" }
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", rev = "e9cbf904f548979685c4c06d75479b75e3695160" }
+usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
+ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.2" }
+apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch", rev = "b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4" }
 
 # unreleased crates
-secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "0.11.0" }
+secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "75626206ca3410fdcef0bb77cd7fd7962054f077" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.0" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.2.2" }
+trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
-trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0"}
+trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey.1"}
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", rev = "083fca7693a9a910dd2337d8eaf9d50ccd1987d0" }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", rev = "e78883847fb01ac93179074ff29e13a0d470775b" }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
 trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey.1"}
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", rev = "e78883847fb01ac93179074ff29e13a0d470775b" }
+trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner", tag = "v0.0.1-nitrokey.1" }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.
 usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", rev = "e9cbf904f548979685c4c06d75479b75e3695160" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.2" }
-apdu-dispatch = { git = "https://github.com/trussed-dev/apdu-dispatch", rev = "b72d5eb9f4d7a3f107a78a2f0e41f3c403f4c7a4" }
+apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.2-nitrokey.1" }
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "75626206ca3410fdcef0bb77cd7fd7962054f077" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitro
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }
 
 # unreleased upstream changes
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", rev = "e9cbf904f548979685c4c06d75479b75e3695160" }
+usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid", tag = "v0.1.0-nitrokey.1" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.2" }
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.2-nitrokey.1" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -20,7 +20,7 @@ trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked"
 admin-app = { version = "0.1.0", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
-secrets-app = { version = "0.11.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
+secrets-app = { version = "0.12.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.1.0", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096"], optional = true }
 piv-authenticator = { version = "0.3.1", features = ["apdu-dispatch", "delog"], optional = true }
 provisioner-app = { path = "../provisioner-app", optional = true }

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -8,9 +8,8 @@ use apdu_dispatch::{
 use core::marker::PhantomData;
 use ctaphid_dispatch::app::App as CtaphidApp;
 use trussed::{
-    backend::BackendId, client::ClientBuilder, platform::Syscall, ClientImplementation, Platform,
-    interrupt::InterruptFlag,
-    Service,
+    backend::BackendId, client::ClientBuilder, interrupt::InterruptFlag, platform::Syscall,
+    ClientImplementation, Platform, Service,
 };
 
 #[cfg(feature = "admin-app")]
@@ -114,7 +113,11 @@ pub struct Apps<R: Runner> {
 impl<R: Runner> Apps<R> {
     pub fn new(
         runner: &R,
-        mut make_client: impl FnMut(&str, &'static [BackendId<Backend>], Option<&'static InterruptFlag>) -> Client<R>,
+        mut make_client: impl FnMut(
+            &str,
+            &'static [BackendId<Backend>],
+            Option<&'static InterruptFlag>,
+        ) -> Client<R>,
         data: Data<R>,
     ) -> Self {
         let _ = (runner, &mut make_client);
@@ -220,7 +223,10 @@ impl<R: Runner> trussed_usbip::Apps<'static, Client<R>, Dispatch> for Apps<R> {
         )
     }
 
-    fn with_ctaphid_apps<T>(&mut self, f: impl FnOnce(&mut [&mut dyn CtaphidApp<'static>]) -> T) -> T {
+    fn with_ctaphid_apps<T>(
+        &mut self,
+        f: impl FnOnce(&mut [&mut dyn CtaphidApp<'static>]) -> T,
+    ) -> T {
         self.ctaphid_dispatch(f)
     }
 
@@ -241,11 +247,19 @@ trait App<R: Runner>: Sized {
 
     fn new(
         runner: &R,
-        make_client: impl FnOnce(&str, &'static [BackendId<Backend>], Option<&'static InterruptFlag>) -> Client<R>,
+        make_client: impl FnOnce(
+            &str,
+            &'static [BackendId<Backend>],
+            Option<&'static InterruptFlag>,
+        ) -> Client<R>,
         data: Self::Data,
     ) -> Self {
         let backends = Self::backends(runner);
-        Self::with_client(runner, make_client(Self::CLIENT_ID, backends, Self::interrupt()), data)
+        Self::with_client(
+            runner,
+            make_client(Self::CLIENT_ID, backends, Self::interrupt()),
+            data,
+        )
     }
 
     fn with_client(runner: &R, trussed: Client<R>, data: Self::Data) -> Self;

--- a/components/provisioner-app/src/ctaphid.rs
+++ b/components/provisioner-app/src/ctaphid.rs
@@ -9,7 +9,7 @@ use trussed::{client, store::Store, types::LfsStorage, Client};
 
 const COMMAND_PROVISIONER: VendorCommand = VendorCommand::H71;
 
-impl<S, FS, T> App for Provisioner<S, FS, T>
+impl<S, FS, T> App<'static> for Provisioner<S, FS, T>
 where
     S: Store,
     FS: 'static + LfsStorage,

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -61,6 +61,7 @@ systick-monotonic = { version = "1.0.0", optional = true }
 ### Allocator
 alloc-cortex-m = { version = "0.4.3", optional = true }
 bitflags = "1.3.2"
+ref-swap = "0.1.0"
 
 [build-dependencies]
 cargo-lock = "7"

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -177,9 +177,9 @@ pub fn init_usb_nfc(
     let config = <SocT as Soc>::INTERFACE_CONFIG;
 
     use apdu_dispatch::interchanges::Channel as CcidChannel;
-    use trussed::interrupt::InterruptFlag;
-    use ref_swap::OptionRefSwap;
     use ctaphid_dispatch::types::Channel as CtapChannel;
+    use ref_swap::OptionRefSwap;
+    use trussed::interrupt::InterruptFlag;
     static CCID_CHANNEL: CcidChannel = Channel::new();
     static NFC_CHANNEL: CcidChannel = Channel::new();
     static CTAP_CHANNEL: CtapChannel = Channel::new();
@@ -191,7 +191,8 @@ pub fn init_usb_nfc(
 
     /* initialize dispatchers */
     let apdu_dispatch = apdu_dispatch::dispatch::ApduDispatch::new(ccid_rp, nfc_rp);
-    let ctaphid_dispatch = ctaphid_dispatch::dispatch::Dispatch::with_interrupt(ctaphid_rp, Some(&CTAP_INTERRUPT));
+    let ctaphid_dispatch =
+        ctaphid_dispatch::dispatch::Dispatch::with_interrupt(ctaphid_rp, Some(&CTAP_INTERRUPT));
 
     /* populate requesters (if bus options are provided) */
     let mut usb_classes = None;
@@ -201,10 +202,11 @@ pub fn init_usb_nfc(
         let ccid = usbd_ccid::Ccid::new(usbbus, ccid_rq, Some(config.card_issuer));
 
         /* Class #2: CTAPHID */
-        let ctaphid = usbd_ctaphid::CtapHid::with_interrupt(usbbus, ctaphid_rq, Some(&CTAP_INTERRUPT), 0u32)
-            .implements_ctap1()
-            .implements_ctap2()
-            .implements_wink();
+        let ctaphid =
+            usbd_ctaphid::CtapHid::with_interrupt(usbbus, ctaphid_rq, Some(&CTAP_INTERRUPT), 0u32)
+                .implements_ctap1()
+                .implements_ctap2()
+                .implements_wink();
 
         /* Class #3: Serial */
         let serial = usbd_serial::SerialPort::new(usbbus);

--- a/runners/embedded/src/soc_nrf52840/trussed_ui.rs
+++ b/runners/embedded/src/soc_nrf52840/trussed_ui.rs
@@ -93,7 +93,7 @@ where
         let threshold: u8 = 1;
 
         let start_time = self.uptime().as_millis();
-        let timeout_at = start_time + 28_000u128;
+        let timeout_at = start_time + 1_000u128;
         let mut next_check = start_time + 25u128;
 
         self.set_status(ui::Status::WaitingForUserPresence);

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -129,7 +129,7 @@ pub type Trussed = trussed::Service<RunnerPlatform, Dispatch>;
 pub type Iso14443 = nfc_device::Iso14443<<SocT as Soc>::NfcDevice>;
 
 pub type ApduDispatch = apdu_dispatch::dispatch::ApduDispatch<'static>;
-pub type CtaphidDispatch = ctaphid_dispatch::dispatch::Dispatch<'static>;
+pub type CtaphidDispatch = ctaphid_dispatch::dispatch::Dispatch<'static, 'static>;
 
 pub type Apps = apps::Apps<Runner>;
 

--- a/runners/embedded/src/types/usbnfc.rs
+++ b/runners/embedded/src/types/usbnfc.rs
@@ -3,7 +3,7 @@ use crate::types::Soc;
 
 pub type CcidClass =
     usbd_ccid::Ccid<'static, 'static, <SocT as Soc>::UsbBus, { apdu_dispatch::interchanges::SIZE }>;
-pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, 'static,'static, <SocT as Soc>::UsbBus>;
+pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, 'static, 'static, <SocT as Soc>::UsbBus>;
 // pub type KeyboardClass = usbd_hid::hid_class::HIDClass<'static, <SocT as Soc>::UsbBus>;
 pub type SerialClass = usbd_serial::SerialPort<'static, <SocT as Soc>::UsbBus>;
 

--- a/runners/embedded/src/types/usbnfc.rs
+++ b/runners/embedded/src/types/usbnfc.rs
@@ -3,7 +3,7 @@ use crate::types::Soc;
 
 pub type CcidClass =
     usbd_ccid::Ccid<'static, 'static, <SocT as Soc>::UsbBus, { apdu_dispatch::interchanges::SIZE }>;
-pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, 'static, <SocT as Soc>::UsbBus>;
+pub type CtapHidClass = usbd_ctaphid::CtapHid<'static, 'static,'static, <SocT as Soc>::UsbBus>;
 // pub type KeyboardClass = usbd_hid::hid_class::HIDClass<'static, <SocT as Soc>::UsbBus>;
 pub type SerialClass = usbd_serial::SerialPort<'static, <SocT as Soc>::UsbBus>;
 
@@ -37,6 +37,6 @@ impl UsbClasses {
 pub struct UsbNfcInit {
     pub usb_classes: Option<UsbClasses>,
     pub apdu_dispatch: apdu_dispatch::dispatch::ApduDispatch<'static>,
-    pub ctaphid_dispatch: ctaphid_dispatch::dispatch::Dispatch<'static>,
+    pub ctaphid_dispatch: ctaphid_dispatch::dispatch::Dispatch<'static, 'static>,
     pub iso14443: Option<super::Iso14443>,
 }


### PR DESCRIPTION
# Close #199 

## Trussed must accept and check an interrupt flag

- https://github.com/trussed-dev/trussed/pull/125

## Dispatcher and usb drivers needs to exchange the `InterruptFlag` of the running application

Similar work will be needed for the CCID stack too, but is not as urgent, so to simplify we just do CTAPHID  

- https://github.com/trussed-dev/ctaphid-dispatch/pull/4
- https://github.com/trussed-dev/usbd-ctaphid/pull/5

## Backends need adaptation

There is a breaking change. Since the CoreContext holds a reference to the interrupt flag, it can't be created as easily as before, and therefore the Fliestore need to take a `ClientId` rather than a CoreContext to be created.

- https://github.com/trussed-dev/trussed-auth/pull/35
- https://github.com/Nitrokey/trussed-staging/pull/7

## All apps must be updated to make their interrupt flag accessible to the dispatch

- https://github.com/Nitrokey/admin-app/pull/4
- https://github.com/Nitrokey/fido-authenticator/pull/15
- https://github.com/Nitrokey/trussed-secrets-app/pull/72

## Other needed adaptations

- https://github.com/trussed-dev/pc-usbip-runner/pull/26

## [RefSwap](https://github.com/Nitrokey/ref-swap)

Safe wrapper around AtomicPtr for exchanging interrupt flags between the driver and the dispatch.

## In the runner:

Apps need to all have a static `InterruptFlag`. The dispatch crates need to share an `OptionRefSwap` to exchange the InterruptFlag.

See https://github.com/trussed-dev/trussed/discussions/124