### PR TITLE
Update Secrets App to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,10 +91,10 @@ dependencies = [
  "ctaphid-dispatch",
  "fido-authenticator",
  "ndef-app",
- "oath-authenticator",
  "opcard",
  "piv-authenticator",
  "provisioner-app",
+ "secrets-app",
  "trussed",
  "trussed-auth",
  "trussed-rsa-alloc",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "encrypted_container"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=0.10.0#a424326b13362e844ac2709816f9968656e4da1f"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=0.11.0-rc1#8c4453f8fbe9c1dd973f742b22eef4a55136fc29"
 dependencies = [
  "cbor-smol",
  "delog",
@@ -1984,27 +1984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oath-authenticator"
-version = "0.10.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=0.10.0#a424326b13362e844ac2709816f9968656e4da1f"
-dependencies = [
- "apdu-dispatch",
- "cbor-smol",
- "ctaphid-dispatch",
- "delog",
- "encrypted_container",
- "flexiber",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
- "hex-literal 0.3.4",
- "interchange 0.2.2",
- "iso7816",
- "serde",
- "trussed",
- "trussed-auth",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,6 +2488,28 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secrets-app"
+version = "0.11.0"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=0.11.0-rc1#8c4453f8fbe9c1dd973f742b22eef4a55136fc29"
+dependencies = [
+ "apdu-dispatch",
+ "block-padding",
+ "cbor-smol",
+ "ctaphid-dispatch",
+ "delog",
+ "encrypted_container",
+ "flexiber",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "hex-literal 0.3.4",
+ "interchange 0.2.2",
+ "iso7816",
+ "serde",
+ "trussed",
+ "trussed-auth",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ interchange = { git = "https://github.com/trussed-dev/interchange" }
 usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid" }
 
 # unreleased crates
-oath-authenticator = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "0.10.0" }
+secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "0.11.0-rc1" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.0.0" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.2.0" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.2.2" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -20,7 +20,7 @@ trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked"
 admin-app = { version = "0.1.0", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
-oath-authenticator = { version = "0.10.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
+secrets-app = { version = "0.11.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.0.0", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096"], optional = true }
 piv-authenticator = { version = "0.2.0", features = ["apdu-dispatch", "delog"], optional = true }
 provisioner-app = { path = "../provisioner-app", optional = true }
@@ -30,7 +30,7 @@ default = [
     "admin-app",
     "fido-authenticator",
     "ndef-app",
-    "oath-authenticator",
+    "secrets-app",
     "opcard",
     "trussed/clients-4",
 ]
@@ -38,7 +38,7 @@ test = ["piv-authenticator", "trussed/clients-5"]
 provisioner = ["provisioner-app", "trussed/clients-5"]
 
 # apps
-oath-authenticator = ["dep:oath-authenticator", "backend-auth"]
+secrets-app = ["dep:secrets-app", "backend-auth"]
 fido-authenticator = ["dep:fido-authenticator", "usbd-ctaphid"]
 opcard = ["dep:opcard", "backend-rsa", "backend-auth", "backend-staging"]
 piv-authenticator = ["dep:piv-authenticator", "backend-rsa", "backend-auth", "backend-staging"]
@@ -51,7 +51,7 @@ backend-staging = ["trussed-staging"]
 log-all = [
     "admin-app?/log-all",
     "fido-authenticator?/log-all",
-    "oath-authenticator?/log-all",
+    "secrets-app?/log-all",
     "opcard?/log-all",
     "provisioner-app?/log-all",
 ]

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -352,11 +352,13 @@ impl<R: Runner> App<R> for OathApp<R> {
 
     type Data = ();
 
-    fn with_client(_runner: &R, trussed: Client<R>, _: ()) -> Self {
+    fn with_client(runner: &R, trussed: Client<R>, _: ()) -> Self {
+        let uuid = runner.uuid();
         let options = oath_authenticator::Options::new(
             Location::External,
             CustomStatus::ReverseHotpSuccess.into(),
             CustomStatus::ReverseHotpError.into(),
+            [uuid[0], uuid[1], uuid[2], uuid[3]]
         );
         Self::new(trussed, options)
     }

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+const SECRETS_APP_CREDENTIALS_COUNT_LIMIT: u16 = 50;
+
 use apdu_dispatch::{
     command::SIZE as ApduCommandSize, response::SIZE as ApduResponseSize, App as ApduApp,
 };
@@ -47,8 +49,8 @@ type AdminApp<R> = admin_app::App<Client<R>, <R as Runner>::Reboot, AdminStatus>
 type FidoApp<R> = fido_authenticator::Authenticator<fido_authenticator::Conforming, Client<R>>;
 #[cfg(feature = "ndef-app")]
 type NdefApp = ndef_app::App<'static>;
-#[cfg(feature = "oath-authenticator")]
-type OathApp<R> = oath_authenticator::Authenticator<Client<R>>;
+#[cfg(feature = "secrets-app")]
+type SecretsApp<R> = secrets_app::Authenticator<Client<R>>;
 #[cfg(feature = "opcard")]
 type OpcardApp<R> = opcard::Card<Client<R>>;
 #[cfg(feature = "piv-authenticator")]
@@ -59,9 +61,9 @@ type ProvisionerApp<R> =
 
 #[repr(u8)]
 pub enum CustomStatus {
-    #[cfg(feature = "oath-authenticator")]
+    #[cfg(feature = "secrets-app")]
     ReverseHotpSuccess = 0,
-    #[cfg(feature = "oath-authenticator")]
+    #[cfg(feature = "secrets-app")]
     ReverseHotpError = 1,
 }
 
@@ -76,9 +78,9 @@ impl TryFrom<u8> for CustomStatus {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            #[cfg(feature = "oath-authenticator")]
+            #[cfg(feature = "secrets-app")]
             0 => Ok(Self::ReverseHotpSuccess),
-            #[cfg(feature = "oath-authenticator")]
+            #[cfg(feature = "secrets-app")]
             1 => Ok(Self::ReverseHotpError),
             _ => Err(UnknownStatusError(value)),
         }
@@ -94,8 +96,8 @@ pub struct Apps<R: Runner> {
     fido: FidoApp<R>,
     #[cfg(feature = "ndef-app")]
     ndef: NdefApp,
-    #[cfg(feature = "oath-authenticator")]
-    oath: OathApp<R>,
+    #[cfg(feature = "secrets-app")]
+    oath: SecretsApp<R>,
     #[cfg(feature = "opcard")]
     opcard: OpcardApp<R>,
     #[cfg(feature = "piv-authenticator")]
@@ -129,7 +131,7 @@ impl<R: Runner> Apps<R> {
             fido: App::new(runner, &mut make_client, ()),
             #[cfg(feature = "ndef-app")]
             ndef: NdefApp::new(),
-            #[cfg(feature = "oath-authenticator")]
+            #[cfg(feature = "secrets-app")]
             oath: App::new(runner, &mut make_client, ()),
             #[cfg(feature = "opcard")]
             opcard: App::new(runner, &mut make_client, ()),
@@ -169,7 +171,7 @@ impl<R: Runner> Apps<R> {
         f(&mut [
             #[cfg(feature = "ndef-app")]
             &mut self.ndef,
-            #[cfg(feature = "oath-authenticator")]
+            #[cfg(feature = "secrets-app")]
             &mut self.oath,
             #[cfg(feature = "opcard")]
             &mut self.opcard,
@@ -193,7 +195,7 @@ impl<R: Runner> Apps<R> {
             &mut self.fido,
             #[cfg(feature = "admin-app")]
             &mut self.admin,
-            #[cfg(feature = "oath-authenticator")]
+            #[cfg(feature = "secrets-app")]
             &mut self.oath,
             #[cfg(feature = "provisioner-app")]
             &mut self.provisioner,
@@ -346,19 +348,20 @@ impl<R: Runner> App<R> for FidoApp<R> {
     }
 }
 
-#[cfg(feature = "oath-authenticator")]
-impl<R: Runner> App<R> for OathApp<R> {
+#[cfg(feature = "secrets-app")]
+impl<R: Runner> App<R> for SecretsApp<R> {
     const CLIENT_ID: &'static str = "secrets";
 
     type Data = ();
 
     fn with_client(runner: &R, trussed: Client<R>, _: ()) -> Self {
         let uuid = runner.uuid();
-        let options = oath_authenticator::Options::new(
+        let options = secrets_app::Options::new(
             Location::External,
             CustomStatus::ReverseHotpSuccess.into(),
             CustomStatus::ReverseHotpError.into(),
-            [uuid[0], uuid[1], uuid[2], uuid[3]]
+            [uuid[0], uuid[1], uuid[2], uuid[3]],
+            SECRETS_APP_CREDENTIALS_COUNT_LIMIT,
         );
         Self::new(trussed, options)
     }


### PR DESCRIPTION
Update Secrets App to v0.11

- Rename to Secrets App / secrets-app / secrets_app
- Add credentials limit, and set to 50
- Send serial number
- Change dependency to use `0.11.0-rc1`


To discuss:
- [ ] where to keep the constant for the credentials limit