### PR TITLE
Add Nitrokey WebCrypt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3335,6 +3335,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "webcrypt"
 version = "0.7.0"
+source = "git+https://github.com/Nitrokey/nitrokey-webcrypt-rust?branch=use-backends#2c7586e643a6d4a4f51ca3e4fadcbd3e60a9edef"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3335,7 +3335,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "webcrypt"
 version = "0.7.0"
-source = "git+https://github.com/Nitrokey/nitrokey-webcrypt-rust?branch=use-backends#2c7586e643a6d4a4f51ca3e4fadcbd3e60a9edef"
+source = "git+https://github.com/Nitrokey/nitrokey-webcrypt-rust?tag=v0.7.0#01f821c9f3a76780e72bec6fe09d40898bfe6f95"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "trussed-usbip",
  "usbd-ctaphid",
  "utils",
+ "webcrypt",
 ]
 
 [[package]]
@@ -1285,6 +1286,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,14 +3085,16 @@ dependencies = [
 [[package]]
 name = "trussed-staging"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-staging.git?tag=v0.1.0-nitrokey.1#c6aa6bdd65f04eb746a2d65725ba2d01c27ae1f7"
+source = "git+https://github.com/Nitrokey/trussed-staging.git?branch=hmacsha256p256#1b54bf8703d515688a58f2f605c3efa0f2f60ced"
 dependencies = [
  "chacha20poly1305",
  "delog",
+ "hmac 0.12.1",
  "littlefs2",
  "rand_core",
  "serde",
  "serde-byte-array",
+ "sha2 0.10.6",
  "trussed",
 ]
 
@@ -3300,6 +3331,26 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "webcrypt"
+version = "0.7.0"
+dependencies = [
+ "apdu-dispatch",
+ "cbor-smol",
+ "ctap-types",
+ "ctaphid-dispatch",
+ "delog",
+ "generic-array 0.14.7",
+ "git-version",
+ "heapless 0.7.16",
+ "heapless-bytes 0.3.0",
+ "serde",
+ "serde-indexed",
+ "trussed",
+ "trussed-rsa-alloc",
+ "trussed-staging",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner", tag = "v0
 
 [profile.release]
 codegen-units = 1
-lto = true
+lto = "thin"
 opt-level = "z"
 incremental = false
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,14 @@ apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.12.0" }
+#webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", branch = "use-backends", optional = true }
+webcrypt = { path = "../nitrokey-webcrypt-rust" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
-trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey.1"}
+#trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey.1"}
+trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", branch = "hmacsha256p256" }
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner", tag = "v0.0.1-nitrokey.1" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,11 @@ apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.12.0" }
-#webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", branch = "use-backends", optional = true }
-webcrypt = { path = "../nitrokey-webcrypt-rust" }
+webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", branch = "use-backends", optional = true }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
-#trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey.1"}
 trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", branch = "hmacsha256p256" }
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner", tag = "v0.0.1-nitrokey.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.12.0" }
-webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", branch = "use-backends", optional = true }
+webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", tag = "v0.7.0"}
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -20,6 +20,7 @@ trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked"
 admin-app = { version = "0.1.0", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
+webcrypt = { version = "0.7.0", optional = true }
 secrets-app = { version = "0.12.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.1.1", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096"], optional = true }
 piv-authenticator = { version = "0.3.1", features = ["apdu-dispatch", "delog"], optional = true }
@@ -34,11 +35,12 @@ default = [
     "opcard",
     "trussed/clients-4",
 ]
-test = ["piv-authenticator", "trussed/clients-5"]
+test = ["piv-authenticator", "webcrypt", "trussed/clients-6"]
 provisioner = ["provisioner-app", "trussed/clients-5"]
 
 # apps
 secrets-app = ["dep:secrets-app", "backend-auth"]
+webcrypt = ["dep:webcrypt", "backend-auth", "backend-rsa", "backend-staging", "trussed-staging/hmacsha256p256"]
 fido-authenticator = ["dep:fido-authenticator", "usbd-ctaphid"]
 opcard = ["dep:opcard", "backend-rsa", "backend-auth", "backend-staging"]
 piv-authenticator = ["dep:piv-authenticator", "backend-rsa", "backend-auth", "backend-staging"]
@@ -52,6 +54,7 @@ log-all = [
     "admin-app?/log-all",
     "fido-authenticator?/log-all",
     "secrets-app?/log-all",
+    "webcrypt?/log-all",
     "opcard?/log-all",
     "provisioner-app?/log-all",
 ]

--- a/components/apps/src/dispatch.rs
+++ b/components/apps/src/dispatch.rs
@@ -21,9 +21,12 @@ use trussed_rsa_alloc::SoftwareRsa;
 
 #[cfg(feature = "backend-staging")]
 use trussed_staging::{
-    hmacsha256p256::HmacSha256P256Extension, streaming::ChunkedExtension,
-    wrap_key_to_file::WrapKeyToFileExtension, StagingBackend, StagingContext,
+    streaming::ChunkedExtension, wrap_key_to_file::WrapKeyToFileExtension, StagingBackend,
+    StagingContext,
 };
+
+#[cfg(all(feature = "webcrypt", feature = "backend-staging"))]
+use trussed_staging::hmacsha256p256::HmacSha256P256Extension;
 
 #[derive(Debug)]
 pub struct Dispatch {
@@ -129,6 +132,7 @@ impl ExtensionDispatch for Dispatch {
                     request,
                     resources,
                 ),
+                #[cfg(feature = "webcrypt")]
                 Extension::HmacShaP256 => <StagingBackend as ExtensionImpl<HmacSha256P256Extension>>::extension_request_serialized(
                     &mut self.staging,
                     &mut ctx.core,
@@ -219,7 +223,7 @@ impl ExtensionId<WrapKeyToFileExtension> for Dispatch {
     const ID: Self::Id = Self::Id::WrapKeyToFile;
 }
 
-#[cfg(feature = "backend-staging")]
+#[cfg(all(feature = "backend-staging", feature = "webcrypt"))]
 impl ExtensionId<HmacSha256P256Extension> for Dispatch {
     type Id = Extension;
 

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -397,6 +397,7 @@ impl<R: Runner> App<R> for WebcryptApp<R> {
     fn backends(runner: &R) -> &'static [BackendId<Backend>] {
         const BACKENDS_WEBCRYPT: &[BackendId<Backend>] = &[
             BackendId::Custom(Backend::SoftwareRsa),
+            BackendId::Custom(Backend::Staging),
             BackendId::Custom(Backend::Auth),
             BackendId::Core,
         ];

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -198,8 +198,8 @@ impl<R: Runner> Apps<R> {
             &mut self.admin,
             #[cfg(feature = "provisioner-app")]
             &mut self.provisioner,
-            #[cfg(feature = "webcrypt")]
-            &mut self.webcrypt,
+            // #[cfg(feature = "webcrypt")]
+            // &mut self.webcrypt,
         ])
     }
 

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -15,6 +15,8 @@ use trussed::{
 #[cfg(feature = "admin-app")]
 pub use admin_app::Reboot;
 use trussed::types::Location;
+
+#[cfg(feature = "webcrypt")]
 use webcrypt::PeekingBypass;
 
 mod dispatch;
@@ -132,6 +134,7 @@ impl<R: Runner> Apps<R> {
             provisioner,
             ..
         } = data;
+        #[cfg(feature = "webcrypt")]
         let webcrypt_fido_bypass = PeekingBypass::new(
             App::new(runner, &mut make_client, ()),
             App::new(runner, &mut make_client, ()),

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -51,6 +51,8 @@ type FidoApp<R> = fido_authenticator::Authenticator<fido_authenticator::Conformi
 type NdefApp = ndef_app::App<'static>;
 #[cfg(feature = "secrets-app")]
 type SecretsApp<R> = secrets_app::Authenticator<Client<R>>;
+#[cfg(feature = "webcrypt")]
+type WebcryptApp<R> = webcrypt::Webcrypt<Client<R>>;
 #[cfg(feature = "opcard")]
 type OpcardApp<R> = opcard::Card<Client<R>>;
 #[cfg(feature = "piv-authenticator")]
@@ -104,7 +106,8 @@ pub struct Apps<R: Runner> {
     piv: PivApp<R>,
     #[cfg(feature = "provisioner-app")]
     provisioner: ProvisionerApp<R>,
-
+    #[cfg(feature = "webcrypt")]
+    webcrypt: WebcryptApp<R>,
     /// Avoid compilation error if no feature is used.
     /// Without it, the type parameter `R` is not used
     _compile_no_feature: PhantomData<R>,
@@ -143,6 +146,8 @@ impl<R: Runner> Apps<R> {
             piv: App::new(runner, &mut make_client, ()),
             #[cfg(feature = "provisioner-app")]
             provisioner: App::new(runner, &mut make_client, provisioner),
+            #[cfg(feature = "webcrypt")]
+            webcrypt: App::new(runner, &mut make_client, ()),
             _compile_no_feature: PhantomData::default(),
         }
     }
@@ -188,6 +193,8 @@ impl<R: Runner> Apps<R> {
             &mut self.admin,
             #[cfg(feature = "provisioner-app")]
             &mut self.provisioner,
+            #[cfg(feature = "webcrypt")]
+            &mut self.webcrypt,
         ])
     }
 
@@ -196,6 +203,8 @@ impl<R: Runner> Apps<R> {
         F: FnOnce(&mut [&mut dyn CtaphidApp<'static>]) -> T,
     {
         f(&mut [
+            #[cfg(feature = "webcrypt")]
+            &mut self.webcrypt,
             #[cfg(feature = "fido-authenticator")]
             &mut self.fido,
             #[cfg(feature = "admin-app")]
@@ -373,6 +382,26 @@ impl<R: Runner> App<R> for FidoApp<R> {
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();
         Some(&INTERRUPT)
+    }
+}
+
+#[cfg(feature = "webcrypt")]
+impl<R: Runner> App<R> for WebcryptApp<R> {
+    const CLIENT_ID: &'static str = "webcrypt";
+
+    type Data = ();
+
+    fn with_client(_runner: &R, trussed: Client<R>, _: ()) -> Self {
+        Self::new(trussed)
+    }
+    fn backends(runner: &R) -> &'static [BackendId<Backend>] {
+        const BACKENDS_WEBCRYPT: &[BackendId<Backend>] = &[
+            BackendId::Custom(Backend::SoftwareRsa),
+            BackendId::Custom(Backend::Auth),
+            BackendId::Core,
+        ];
+        let _ = runner;
+        BACKENDS_WEBCRYPT
     }
 }
 


### PR DESCRIPTION
Add Nitrokey WebCrypt application

For now to be available only in the testing releases.

Fixes https://github.com/Nitrokey/nitrokey-3-firmware/issues/273
Connected: https://github.com/Nitrokey/nitrokey-webcrypt-rust/issues/4

Can be tested against:
- https://webcrypt.nitrokey.com/ (tested with Chrome; `Reset and Login -> sign and decrypt`)
- `v0.2-28-g610f42f` / https://github.com/Nitrokey/nitrokey-webcrypt-tests/tree/devel (`make FIDO2`)

Built with:
```
$  make flash-develop EXTRA_FEATURES=apps/test,no-buttons
```

-----------

Edit: NK3 AM test results:
- [report.zip](https://github.com/Nitrokey/nitrokey-3-firmware/files/11918773/report.zip)