### PR TITLE
NRF52 debug tools update

### DIFF
--- a/utils/nrf-bootloader/Makefile
+++ b/utils/nrf-bootloader/Makefile
@@ -66,7 +66,9 @@ UPLOAD_SH = $(BL_DIR)/upload.sh
 
 FW_SIGNED = fw_signed_update.zip
 FW_RAW = fw_unsigned.hex
-TTYDEV = /dev/ttyACM1
+TTYDEV := $(wildcard /dev/serial/by-id/usb-Nitrokey_Nitrokey_3_Bootloader*)
+# /dev/serial/by-id/usb-Nitrokey_Nitrokey_3-if02
+# /dev/serial/by-id/usb-Nitrokey_Nitrokey_3_Bootloader_F95AF80A9E98-if00
 
 fw-assemble-dfu: $(FW_SIGNED)
 

--- a/utils/nrf-builder/Makefile
+++ b/utils/nrf-builder/Makefile
@@ -55,7 +55,7 @@ ALL_ARTIFACTS := $(FW_NAME_RELEASE) $(FW_NAME_PROVISIONER) $(FW_NAME_DEVELOP) \
 
 SRCS = $(shell find $(FW_RUNNER)/src -name "*.rs" )
 
-TTY := $(shell ls -1rt /dev/ttyACM* | tail -n 1 | xargs)
+TTY := $(wildcard /dev/serial/by-id/usb-Nitrokey_Nitrokey_3_Bootloader*)
 
 EXTRA_FEATURES :=
 

--- a/utils/nrf-debugging/binary.elf
+++ b/utils/nrf-debugging/binary.elf
@@ -1,0 +1,1 @@
+../../runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.elf

--- a/utils/nrf-debugging/gdb-stack.cmds
+++ b/utils/nrf-debugging/gdb-stack.cmds
@@ -1,0 +1,25 @@
+set pagination off
+set logging file gdb.txt
+set logging on
+
+set architecture arm
+set endian little
+set arm fallback-mode thumb
+set arm force-mode thumb
+set style enabled off
+file binary.elf
+target remote :3333
+
+
+define stepinf
+    while(1)
+	p $msp
+    step
+    end
+end
+
+# Automatically start tracing upon reaching the following line
+# b transport.rs:181
+# commands
+# stepinf
+# end

--- a/utils/nrf-debugging/graph_stack.py
+++ b/utils/nrf-debugging/graph_stack.py
@@ -1,0 +1,36 @@
+from matplotlib import pyplot as plt
+
+"""
+Quickly graph gdb msp prints.
+
+rg -F "= (*mut ()) " gdb.txt > gdb.txt.stack
+
+Expected format is like:
+
+...
+$38057 = (*mut ()) 0x2001b478
+$38058 = (*mut ()) 0x2001b478
+...
+
+"""
+
+PATH = 'gdb.txt.stack'
+
+def main():
+    data = []
+    with open(PATH, 'r') as f:
+        for line in f:
+            num = int(line.split()[-1], 16)
+            num = num - 0x20000000
+            num = num // 1024
+            data.append(num)
+
+    print(len(data))
+    plt.plot(data)
+    plt.ylabel('free stack memory left [kB]')
+    plt.xlabel('sample no.')
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR concerns debug tooling for NRF52 hardware:
- select bootloader by name, to make sure other device is not connected to during flashing (evaluated lazily at the call moment)
- add simple tracing and graphing script for stack memory diagnostics

Connected: https://github.com/Nitrokey/nitrokey-3-firmware/pull/118

Further work ideas:
- ideally gdb would step out automatically, while being in the Rust core libraries (e.g. memcpy) - should be achievable with Python.

Example chart:
![image](https://github.com/Nitrokey/nitrokey-3-firmware/assets/17005426/8ebdf787-923a-4561-9967-46a6a4161ddb)
