### PR TITLE
Update flexiber to the forked version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "1.5.0-test.20230613"
 admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.3" }
 ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.1" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.5" }
+flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }
 


### PR DESCRIPTION
The required patch is merged to upstream, but it was not released by tag, nor released on crates.io,
hence the tagged release use on fork.

This is a Secrets App dependency. The patch contains stability corrections (returns error, instead of panicking on unimplemented behavior).

Connected:
- https://lib.rs/crates/flexiber
- https://github.com/Nitrokey/flexiber
- https://github.com/nickray/flexiber