### PR TITLE
Update secrets-app to v0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "encrypted_container"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.11.0-interrupt.1#4637a4b5a425636da0283962ce1979170a9ea1fd"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.12.0#78283f591805fd3737f000e8c51213287ed3d338"
 dependencies = [
  "cbor-smol",
  "delog",
@@ -1081,9 +1081,8 @@ dependencies = [
 
 [[package]]
 name = "flexiber"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3df5b1466eec7b03f5848d8388b99975a0ba1a26510db61ba87c2a6177938e5"
+version = "0.1.1"
+source = "git+https://github.com/Nitrokey/flexiber?tag=0.1.1.nitrokey#26f2c8047472cffde13d0be280a001733cbf44c7"
 dependencies = [
  "delog",
  "flexiber_derive",
@@ -1093,8 +1092,7 @@ dependencies = [
 [[package]]
 name = "flexiber_derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500c147f43e74e711720769dd7f37bc90dc6e0798621bfe5e3acb8239fd2f826"
+source = "git+https://github.com/Nitrokey/flexiber?tag=0.1.1.nitrokey#26f2c8047472cffde13d0be280a001733cbf44c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2505,7 +2503,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "secrets-app"
 version = "0.12.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.11.0-interrupt.1#4637a4b5a425636da0283962ce1979170a9ea1fd"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.12.0#78283f591805fd3737f000e8c51213287ed3d338"
 dependencies = [
  "apdu-dispatch",
  "bitflags 2.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag =
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.2-nitrokey.1" }
 
 # unreleased crates
-secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.11.0-interrupt.1" }
+secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.12.0" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.0" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }

--- a/utils/nrf-builder/Makefile
+++ b/utils/nrf-builder/Makefile
@@ -55,7 +55,7 @@ ALL_ARTIFACTS := $(FW_NAME_RELEASE) $(FW_NAME_PROVISIONER) $(FW_NAME_DEVELOP) \
 
 SRCS = $(shell find $(FW_RUNNER)/src -name "*.rs" )
 
-TTY := $(wildcard /dev/serial/by-id/usb-Nitrokey_Nitrokey_3_Bootloader*)
+TTY := /dev/serial/by-id/usb-Nitrokey_Nitrokey_3_Bootloader*
 
 EXTRA_FEATURES :=
 


### PR DESCRIPTION
Tested on NK3 AM, with touch button accepting all automatically (`EXTRA_FEATURES=no-buttons`):
- [report-pynitrokey-v0.4.38-20-g2c57d06_secrets-v0.12-rc1_nk3-v1.5.0-test.20230613-26-gda3607c.html.gz](https://github.com/Nitrokey/nitrokey-3-firmware/files/11949296/report-pynitrokey-v0.4.38-20-g2c57d06_secrets-v0.12-rc1_nk3-v1.5.0-test.20230613-26-gda3607c.html.gz)

Load tests included.

Versions:
- pynitrokey: v0.4.38-20-g2c57d06
- secrets: v0.12-rc1
- nk3: v1.5.0-test.20230613-26-gda3607c

With this PR comes also:
- Flexiber update to 1.1
- fix for the TTY selection by id


Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/303
Fixes:
- https://github.com/Nitrokey/nitrokey-3-firmware/issues/300
- https://github.com/Nitrokey/nitrokey-3-firmware/issues/296

-------

Edit: re-released `v0.12-rc1` as `v0.12`, and updated the initial commit.