### PR TITLE
Fix CTAP2 tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed?tag=v0.1.0-nitrokey.12#f3c95ab16fe6f9357a5d792e709e93d06c304b34"
+source = "git+https://github.com/Nitrokey/trussed?branch=service-reference#0708829cf2c4aa6648b60313499158ddf704044c"
 dependencies = [
  "aes",
  "bitflags 1.3.2",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/usbd-ctaphid?tag=v0.1.0-nitrokey.1#e9cbf904f548979685c4c06d75479b75e3695160"
+source = "git+https://github.com/trussed-dev/usbd-ctaphid#3f24df2f8b799eb203539c0e723854e8f7739f79"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/Nitrokey/pc-usbip-runner.git?tag=v0.0.1-nitrokey.2#d002d47f336e0da61c2e590170f044f2e4e7b548"
+source = "git+https://github.com/Nitrokey/pc-usbip-runner.git?tag=v0.0.1-nitrokey.3#43655c47e13687f96fab607e6f06b331538c6bfc"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "ctap-types"
 version = "0.1.2"
-source = "git+https://github.com/Nitrokey/ctap-types?tag=v0.1.2-nitrokey.1#d6cc1f56ab6ea45e041b3bd04df6a991cb96a8c8"
+source = "git+https://github.com/Nitrokey/ctap-types?tag=v0.1.2-nitrokey.2#86081fade42731b5f707d45e50a31bc051b8cf02"
 dependencies = [
  "bitflags 1.3.2",
  "cbor-smol",
@@ -1082,7 +1082,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.5#c471c81e25506d40b03f22f1b56fbc3441220ab8"
+source = "git+https://github.com/robin-nitrokey/fido-authenticator.git?branch=cred-id#e10589a3a8e4745ecccd59b7901166740284e5a2"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nit
 fido-authenticator = { git = "https://github.com/robin-nitrokey/fido-authenticator.git", branch = "cred-id" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
-trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }
+trussed = { git = "https://github.com/Nitrokey/trussed", branch = "service-reference" }
 
 # unreleased upstream changes
-usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid", tag = "v0.1.0-nitrokey.1" }
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.2" }
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.2-nitrokey.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
 trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", branch = "hmacsha256p256" }
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
-trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.2" }
+trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.3" }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ version = "1.5.0-test.20230704"
 [patch.crates-io]
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.3" }
-ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.1" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.5" }
+ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.2" }
+fido-authenticator = { git = "https://github.com/robin-nitrokey/fido-authenticator.git", branch = "cred-id" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }


### PR DESCRIPTION
This is a tracking PR that contains all changes required to pass the CTAP2-test-tool:
- https://github.com/Nitrokey/ctap-types/pull/7
- https://github.com/Nitrokey/fido-authenticator/pull/22
- https://github.com/Nitrokey/nitrokey-3-firmware/pull/314
- https://github.com/trussed-dev/trussed/pull/122
- https://github.com/trussed-dev/usbd-ctaphid/pull/6

See: https://github.com/Nitrokey/fido-authenticator/issues/6