### PR TITLE
usbip: Add interactive user presence check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +879,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+dependencies = [
+ "console",
+ "shell-words",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1026,12 @@ checksum = "d7a4b4d10ac48d08bfe3db7688c402baadb244721f30a77ce360bd24c3dffe58"
 dependencies = [
  "num",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encrypted_container"
@@ -2718,6 +2747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,7 +3136,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/Nitrokey/pc-usbip-runner?tag=v0.0.1-nitrokey.1#e78883847fb01ac93179074ff29e13a0d470775b"
+source = "git+https://github.com/Nitrokey/pc-usbip-runner.git?tag=v0.0.1-nitrokey.2#d002d47f336e0da61c2e590170f044f2e4e7b548"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
@@ -3269,6 +3304,7 @@ dependencies = [
  "clap 3.2.23",
  "clap-num",
  "delog",
+ "dialoguer",
  "littlefs2",
  "log",
  "pretty_env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
 trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", branch = "hmacsha256p256" }
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
-trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner", tag = "v0.0.1-nitrokey.1" }
+trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.2" }
 
 [profile.release]
 codegen-units = 1

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -16,6 +16,7 @@ pretty_env_logger = "0.4.0"
 trussed = { version = "0.1", features = ["clients-3"] }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid", "ccid"] }
 utils = { path = "../../components/utils", features = ["log-all"] }
+dialoguer = { version = "0.10.4", default-features = false }
 
 [features]
 test = ["apps/test"]


### PR DESCRIPTION
This patch adds a setting for the usbip runner, user presence.  The default and current behavior is to always accept user presence checks. Alternatively, they can always be rejected or answered interactively with a prompt.  To make this work, we need to update the trussed-usbip crate to support keepalive messages.