### PR TITLE
usbip: Add attach target to Makefile

### DIFF
--- a/runners/usbip/Makefile
+++ b/runners/usbip/Makefile
@@ -11,3 +11,11 @@ check:
 lint:
 	cargo clippy --no-deps
 	cargo fmt -- --check
+
+.PHONY: attach
+attach:
+	lsmod | grep vhci-hcd || sudo modprobe vhci-hcd
+	sudo usbip list -r "localhost"
+	sudo usbip attach -r "localhost" -b "1-1"
+	sudo usbip attach -r "localhost" -b "1-1"
+	sleep 5


### PR DESCRIPTION
This patch adds an attach target, copied from the trussed-usbip repository, to the Makefile for the usbip runner.  This target loads the kernel module required for usbip and activates the usbip device.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/322