### PR TITLE
usbip: Add user presence mechanism using signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,6 +2759,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,6 +3328,7 @@ dependencies = [
  "log",
  "pretty_env_logger",
  "rand_core",
+ "signal-hook",
  "trussed",
  "trussed-usbip",
  "utils",

--- a/docs/usbip.md
+++ b/docs/usbip.md
@@ -75,6 +75,7 @@ Note that some log message use the `!` target so you might not be able to filter
   - `accept-all` (default) always accepts user presence checks.
   - `reject-all` always rejects user presence checks.
   - `interactive` shows a query on stderr when a user presence check is executed.
+  - `signal` accepts the next user presence check within one second after receiving a SIGUSR1 signal, e. g. with `pkill -SIGUSR1 usbip-runner`.
 
 For more information on these options, execute `cargo run -- --help`.
 

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -9,14 +9,15 @@ cfg-if = { version = "1.0.0" }
 clap = { version = "3.0.0", features = ["cargo", "derive"] }
 clap-num = "1.0.0"
 delog = { version = "0.1.6", features = ["std-log"] }
+dialoguer = { version = "0.10.4", default-features = false }
 littlefs2 = { version = "0.4" }
 log = { version = "0.4.14", default-features = false }
-rand_core = { version = "0.6.4", features = ["getrandom"] }
 pretty_env_logger = "0.4.0"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
+signal-hook = { version = "0.3.17", default-features = false }
 trussed = { version = "0.1", features = ["clients-3"] }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 utils = { path = "../../components/utils", features = ["log-all"] }
-dialoguer = { version = "0.10.4", default-features = false }
 
 [features]
 test = ["apps/test"]

--- a/runners/usbip/src/ui.rs
+++ b/runners/usbip/src/ui.rs
@@ -1,0 +1,149 @@
+use std::{
+    process,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    thread,
+    time::{Duration, SystemTime},
+};
+
+use dialoguer::Confirm;
+use log::{debug, info};
+use signal_hook::{consts::signal::SIGUSR1, flag};
+use trussed::platform::{consent, reboot, ui::Status};
+
+pub struct UserInterface {
+    start_time: std::time::Instant,
+    user_presence: UserPresence,
+    status: Status,
+    cached_user_presence: Option<bool>,
+    show_prompt: bool,
+}
+
+impl UserInterface {
+    pub fn new(user_presence: UserPresence) -> Self {
+        Self {
+            start_time: std::time::Instant::now(),
+            user_presence,
+            status: Status::Idle,
+            cached_user_presence: None,
+            show_prompt: false,
+        }
+    }
+
+    fn is_user_present(&mut self) -> bool {
+        if let Some(user_presence) = self.cached_user_presence {
+            user_presence
+        } else {
+            match &self.user_presence {
+                UserPresence::Fixed(user_present) => *user_present,
+                UserPresence::Interactive => {
+                    let user_present = Confirm::new()
+                        .with_prompt("User presence?")
+                        .interact()
+                        .unwrap();
+                    if !user_present {
+                        self.cached_user_presence = Some(user_present);
+                    }
+                    user_present
+                }
+                UserPresence::Signal(signals) => {
+                    if self.show_prompt {
+                        eprintln!("Confirm user presence request with SIGUSR1.");
+                        self.show_prompt = false;
+                    }
+                    signals.user_presence()
+                }
+            }
+        }
+    }
+}
+
+impl trussed::platform::UserInterface for UserInterface {
+    fn check_user_presence(&mut self) -> consent::Level {
+        // The call is repeated until it times out or returns something else than None so we cache
+        // the user selection.
+        let user_present = self.is_user_present();
+        let consent = if user_present {
+            consent::Level::Normal
+        } else {
+            consent::Level::None
+        };
+        debug!("Answering user presence check with consent level {consent:?}");
+        if consent == consent::Level::None {
+            thread::sleep(Duration::from_millis(100));
+        }
+        consent
+    }
+
+    fn set_status(&mut self, status: Status) {
+        info!("Set status: {:?}", status);
+
+        let is_waiting = status == Status::WaitingForUserPresence;
+        trussed_usbip::set_waiting(is_waiting);
+        if is_waiting {
+            info!(">>>> Received confirmation request");
+        } else if self.cached_user_presence.is_some() {
+            debug!("Resetting cached user consent");
+            self.cached_user_presence = None;
+        }
+        self.show_prompt = is_waiting && status != self.status;
+
+        self.status = status;
+    }
+
+    fn refresh(&mut self) {}
+
+    fn uptime(&mut self) -> core::time::Duration {
+        self.start_time.elapsed()
+    }
+
+    fn reboot(&mut self, to: reboot::To) -> ! {
+        info!("Restart!  ({:?})", to);
+        process::exit(25);
+    }
+}
+
+#[derive(Clone)]
+pub enum UserPresence {
+    Fixed(bool),
+    Interactive,
+    Signal(Arc<Signals>),
+}
+
+pub struct Signals {
+    epoch: SystemTime,
+    usr1: Arc<AtomicBool>,
+    usr1_timeout: AtomicU64,
+}
+
+impl Signals {
+    pub fn new() -> Self {
+        let signals = Signals {
+            epoch: SystemTime::now(),
+            usr1: Default::default(),
+            usr1_timeout: Default::default(),
+        };
+        flag::register(SIGUSR1, Arc::clone(&signals.usr1))
+            .expect("failed to register signal handler");
+        signals
+    }
+
+    fn user_presence(&self) -> bool {
+        let timestamp = self.epoch.elapsed().unwrap();
+        let timeout = Duration::from_millis(self.usr1_timeout.swap(0, Ordering::Relaxed));
+        timestamp < timeout
+    }
+
+    pub fn update(&self) -> ! {
+        loop {
+            if self.usr1.swap(false, Ordering::Relaxed) {
+                let timeout = self.epoch.elapsed().unwrap() + Duration::from_secs(1);
+                let timeout_millis = timeout.as_millis().try_into().unwrap();
+                self.usr1_timeout.store(timeout_millis, Ordering::Relaxed);
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+}


### PR DESCRIPTION
This patch adds a new user presence mechanism to the usbip runner that accepts the next user presence request within one second after receiving a SIGUSR1 signal.  This makes it possible to script user presence requests, e. g. for test suites.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/321