### PR TITLE
usbip: Disable CCID by default

### DIFF
--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 apdu-dispatch = "0.1"
 ctaphid-dispatch = "0.1"
 trussed = { version = "0.1", features = ["serde-extensions"]}
-trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid", "ccid"], optional = true }
+trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"], optional = true }
 usbd-ctaphid = { version = "0.1", optional = true }
 utils = { path = "../utils" }
 
@@ -58,6 +58,8 @@ log-all = [
     "opcard?/log-all",
     "provisioner-app?/log-all",
 ]
+
+trussed-usbip-ccid = ["trussed-usbip/ccid"]
 
 # Allow resetting FIDO authenticator (and possibly others) even after 10s uptime
 no-reset-time-window = ["fido-authenticator?/disable-reset-time-window"]

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -250,6 +250,7 @@ impl<R: Runner> trussed_usbip::Apps<'static, Client<R>, Dispatch> for Apps<R> {
         self.ctaphid_dispatch(f)
     }
 
+    #[cfg(feature = "trussed-usbip-ccid")]
     fn with_ccid_apps<T>(
         &mut self,
         f: impl FnOnce(&mut [&mut dyn apdu_dispatch::App<ApduCommandSize, ApduResponseSize>]) -> T,

--- a/docs/usbip.md
+++ b/docs/usbip.md
@@ -23,10 +23,6 @@ While this means that many low-level parts of the firmware are replaced with the
 
 ## Running the Simulation
 
-**Note:** Please read the full guide, especially the [Limitations][] section, before executing these steps.
-
-[Limitations]: #Limitations
-
 Clone the firmware repository [Nitrokey/nitrokey-3-firmware](https://github.com/Nitrokey/nitrokey-3-firmware) and enter the `runners/usbip` directory:
 
 ```
@@ -86,13 +82,15 @@ For more information on these options, execute `cargo run -- --help`.
 
 The Nitrokey 3 implements two transport protocols over USB: CTAPHID and CCID.
 There is an unresolved issue that triggers a kernel bug if the CCID transport is used with the USB/IP runner ([#261][]).
-Therefore it is recommended to only use the USB/IP runner with the CTAPHID transport.
+Therefore CCID is disabled by default and it is recommended to only use the USB/IP runner with the CTAPHID transport.
 Applications like [`opcard`][] support an alternative simulation method, `vsmartcard`, to reliably simulate the CCID transport.
 
 [#261]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/261
 [`opcard`]: https://github.com/Nitrokey/opcard-rs
 
-To avoid accidentally triggering this problem, it is recommended to stop `pcsc` before starting the USB/IP simulation:
+If you really want to use CCID with the USB/IP runner, activate the `ccid` feature.
+To avoid accidentally triggering this problem, it is recommended to stop `pcsc` before starting the USB/IP simulation if the `ccid` feature is activated.
 ```
 $ sudo systemctl stop pcscd.service pcscd.socket
+$ cargo run --features ccid
 ```

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -14,10 +14,11 @@ log = { version = "0.4.14", default-features = false }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 pretty_env_logger = "0.4.0"
 trussed = { version = "0.1", features = ["clients-3"] }
-trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid", "ccid"] }
+trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 utils = { path = "../../components/utils", features = ["log-all"] }
 dialoguer = { version = "0.10.4", default-features = false }
 
 [features]
 test = ["apps/test"]
 provisioner = ["apps/provisioner"]
+ccid = ["apps/trussed-usbip-ccid", "trussed-usbip/ccid"]


### PR DESCRIPTION
This patch adds a ccid feature to the usbip runner for the CCID transport and disables it by default.  This is to avoid accidentally triggering the kernel bug described in this issue:
    https://github.com/Nitrokey/nitrokey-3-firmware/issues/261

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/325