### PR TITLE
Update Nitrokey WebSmartCard to v0.8-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,28 +1315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-version"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
-dependencies = [
- "git-version-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "git-version-macro"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,16 +2272,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2342,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2607,9 +2579,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
 dependencies = [
  "serde_derive",
 ]
@@ -2635,6 +2607,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,13 +2627,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2674,7 +2655,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2917,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3390,8 +3371,8 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "webcrypt"
-version = "0.7.0"
-source = "git+https://github.com/Nitrokey/nitrokey-webcrypt-rust?tag=v0.7.0#01f821c9f3a76780e72bec6fe09d40898bfe6f95"
+version = "0.8.0"
+source = "git+https://github.com/Nitrokey/nitrokey-webcrypt-rust?tag=v0.8.0-rc1#9ec3d56095b810a5fab1e8bfd57fe58b5af2c18b"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",
@@ -3399,11 +3380,11 @@ dependencies = [
  "ctaphid-dispatch",
  "delog",
  "generic-array 0.14.7",
- "git-version",
  "heapless 0.7.16",
  "heapless-bytes 0.3.0",
  "serde",
  "serde-indexed",
+ "serde_bytes",
  "trussed",
  "trussed-rsa-alloc",
  "trussed-staging",
@@ -3532,5 +3513,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.12.0" }
-webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", tag = "v0.7.0"}
+webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", tag = "v0.8.0-rc1"}
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -20,7 +20,7 @@ trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked"
 admin-app = { version = "0.1.0", optional = true }
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
-webcrypt = { version = "0.7.0", optional = true }
+webcrypt = { version = "0.8.0", optional = true }
 secrets-app = { version = "0.12.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.1.1", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096"], optional = true }
 piv-authenticator = { version = "0.3.1", features = ["apdu-dispatch", "delog"], optional = true }


### PR DESCRIPTION
Update Nitrokey WebSmartCard to v0.8-rc1. New release has smaller memory requirements for the deserialization, thanks to moving off the heapless' buffers for the requests' fields.

Setting as draft, as the recent changes were not tested yet on the hardware.
Ideally on this occasion the LTO field change for NRF52 could be removed too.