### PR TITLE
Add basic config mechanism for fido2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,6 +67,18 @@ check-usbip:
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
 
+test:
+  image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+  tags:
+    - docker
+  stage: build
+  script:
+    - cd components/apps && cargo test
+  after_script:
+    - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
+
 lint:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,12 +5,17 @@ version = 3
 [[package]]
 name = "admin-app"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/admin-app?tag=v0.1.0-nitrokey.3#15aec92ff3f30f2ad1ff157ac5077c7211a04c77"
+source = "git+https://github.com/Nitrokey/admin-app?tag=v0.1.0-nitrokey.4#5a8aedd1a6ec3d72df1954e8e13fb82982a946ed"
 dependencies = [
  "apdu-dispatch",
+ "cbor-smol",
  "ctaphid-dispatch",
  "delog",
+ "hex-literal 0.4.1",
  "iso7816",
+ "littlefs2",
+ "serde",
+ "strum_macros",
  "trussed",
 ]
 
@@ -27,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
@@ -87,13 +92,16 @@ version = "1.5.0-test.20230704"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
+ "cbor-smol",
  "ctaphid-dispatch",
  "fido-authenticator",
+ "hex",
  "ndef-app",
  "opcard",
  "piv-authenticator",
  "provisioner-app",
  "secrets-app",
+ "serde",
  "trussed",
  "trussed-auth",
  "trussed-rsa-alloc",
@@ -250,9 +258,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -1486,6 +1494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,9 +2315,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2342,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2564,7 +2578,7 @@ version = "0.12.0"
 source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.12.0#78283f591805fd3737f000e8c51213287ed3d338"
 dependencies = [
  "apdu-dispatch",
- "bitflags 2.3.1",
+ "bitflags 2.4.0",
  "block-padding",
  "cbor-smol",
  "ctaphid-dispatch",
@@ -2607,9 +2621,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
 dependencies = [
  "serde_derive",
 ]
@@ -2646,13 +2660,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2674,7 +2688,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2899,6 +2913,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,9 +2944,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3139,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "trussed-staging"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-staging.git?branch=hmacsha256p256#1b54bf8703d515688a58f2f605c3efa0f2f60ced"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?branch=hmacsha256p256#1b54bf8703d515688a58f2f605c3efa0f2f60ced"
 dependencies = [
  "chacha20poly1305",
  "delog",
@@ -3532,5 +3559,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ version = "1.5.0-test.20230704"
 
 [patch.crates-io]
 # forked
-admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.3" }
+admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.4" }
 ctap-types = { git = "https://github.com/Nitrokey/ctap-types", rev = "42751efdc3c717135e8f26ceaa6ce23fb57d0498" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", rev = "0e3e56558505f5fdc755c41ff91727c20cdd3ba6" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
+iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1"}
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }
 
@@ -32,8 +33,7 @@ opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
-trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", branch = "hmacsha256p256" }
-iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", branch = "hmacsha256p256" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.2" }
 
 [profile.release]

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 apdu-dispatch = "0.1"
 ctaphid-dispatch = "0.1"
+serde = { version = "1.0.180", default-features = false }
 trussed = { version = "0.1", features = ["serde-extensions"]}
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"], optional = true }
 usbd-ctaphid = { version = "0.1", optional = true }
@@ -17,7 +18,7 @@ trussed-rsa-alloc = { version = "0.1.0", optional = true }
 trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked", "encrypted-chunked"], optional = true }
 
 # apps
-admin-app = { version = "0.1.0", optional = true }
+admin-app = "0.1.0"
 fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
 webcrypt = { version = "0.7.0", optional = true }
@@ -26,15 +27,12 @@ opcard = { version = "1.1.1", features = ["apdu-dispatch", "delog", "rsa2048-gen
 piv-authenticator = { version = "0.3.1", features = ["apdu-dispatch", "delog"], optional = true }
 provisioner-app = { path = "../provisioner-app", optional = true }
 
+[dev-dependencies]
+cbor-smol = "0.4"
+hex = "0.4"
+
 [features]
-default = [
-    "admin-app",
-    "fido-authenticator",
-    "ndef-app",
-    "secrets-app",
-    "opcard",
-    "trussed/clients-4",
-]
+default = ["fido-authenticator", "ndef-app", "secrets-app", "opcard", "trussed/clients-4"]
 test = ["piv-authenticator", "webcrypt", "trussed/clients-6"]
 provisioner = ["provisioner-app", "trussed/clients-5"]
 
@@ -50,14 +48,7 @@ backend-auth = ["trussed-auth"]
 backend-rsa = ["trussed-rsa-alloc"]
 backend-staging = ["trussed-staging"]
 
-log-all = [
-    "admin-app?/log-all",
-    "fido-authenticator?/log-all",
-    "secrets-app?/log-all",
-    "webcrypt?/log-all",
-    "opcard?/log-all",
-    "provisioner-app?/log-all",
-]
+log-all = ["admin-app/log-all", "fido-authenticator?/log-all", "secrets-app?/log-all", "webcrypt?/log-all", "opcard?/log-all", "provisioner-app?/log-all"]
 
 trussed-usbip-ccid = ["trussed-usbip/ccid"]
 

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -259,7 +259,7 @@ pub fn init_apps(
 ) -> types::Apps {
     use trussed::platform::Store as _;
 
-    let mut admin = apps::AdminData::new(<SocT as types::Soc>::VARIANT);
+    let mut admin = apps::AdminData::new(*store, <SocT as types::Soc>::VARIANT);
     admin.init_status = init_status.bits();
     if !nfc_powered {
         if let Ok(ifs_blocks) = store.ifs().available_blocks() {

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -63,7 +63,6 @@ pub struct Runner;
 impl apps::Runner for Runner {
     type Syscall = RunnerSyscall;
     type Reboot = <SocT as Soc>::Reboot;
-    #[cfg(feature = "provisioner")]
     type Store = RunnerStore;
     #[cfg(feature = "provisioner")]
     type Filesystem = <SocT as Soc>::InternalFlashStorage;


### PR DESCRIPTION
This patch adds a basic config mechanism using the admin app.  The configuration is loaded and applied during initialization.  The admin app now has a special role, is constructed first and can no longer be disabled.  Other applications can receive a reference to the configuration loaded by the admin app.

To avoid overwriting configuration values for apps that are not enabled in the current firmware, the components of the Config struct are not feature-gated.  It could be simplified by using a derive macro but that seems overcomplicated for a first implementation.

The first use case for the config mechanism is enabling or disabling skipping the FIDO2 user presence check directly after boot.

## To do
- [x] Add test for serialized config size