### PR TITLE
Update trussed-usbip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/Nitrokey/pc-usbip-runner.git?tag=v0.0.1-nitrokey.2#d002d47f336e0da61c2e590170f044f2e4e7b548"
+source = "git+https://github.com/Nitrokey/pc-usbip-runner.git?tag=v0.0.1-nitrokey.3#43655c47e13687f96fab607e6f06b331538c6bfc"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", branch = "hmacsha256p256" }
-trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.2" }
+trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.3" }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
This leads to a more stable simulation as we no longer spam keepalive messages.