### PR TITLE
Minimal SE050 RNG implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher 0.4.4",
+ "dbl",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
 name = "critical-section"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +829,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1008,6 +1034,7 @@ dependencies = [
  "rand_core",
  "ref-swap",
  "rtt-target",
+ "se05x",
  "serde",
  "spi-memory",
  "systick-monotonic",
@@ -1602,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "iso7816"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/iso7816.git?tag=v0.1.1-nitrokey.1#d1ee4146c43b9f25d21821c70fefdd87b886f4a9"
+source = "git+https://github.com/trussed-dev/iso7816.git?rev=58152e8737bf59c1123e75dc94691f076b31e030#58152e8737bf59c1123e75dc94691f076b31e030"
 dependencies = [
  "delog",
  "heapless 0.7.16",
@@ -2571,6 +2598,26 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "se05x"
+version = "0.0.1"
+source = "git+https://github.com/Nitrokey/se05x.git?rev=2625b3387557a02d12948f2f44e980e37f1f9cca#2625b3387557a02d12948f2f44e980e37f1f9cca"
+dependencies = [
+ "aes",
+ "bitflags 2.4.0",
+ "byteorder",
+ "cmac",
+ "crc16",
+ "delog",
+ "embedded-hal",
+ "heapless 0.7.16",
+ "hex-literal 0.4.1",
+ "iso7816",
+ "lpc55-hal",
+ "nrf-hal-common",
+ "rand",
+]
 
 [[package]]
 name = "secrets-app"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitro
 ctap-types = { git = "https://github.com/Nitrokey/ctap-types", rev = "42751efdc3c717135e8f26ceaa6ce23fb57d0498" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", rev = "0e3e56558505f5fdc755c41ff91727c20cdd3ba6" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
-iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.1"}
+iso7816 = { git = "https://github.com/trussed-dev/iso7816.git", rev = "58152e8737bf59c1123e75dc94691f076b31e030"}
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.12" }
 
@@ -31,6 +31,7 @@ secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "
 webcrypt = { git = "https://github.com/Nitrokey/nitrokey-webcrypt-rust", tag = "v0.7.0"}
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
+se05x = { git = "https://github.com/Nitrokey/se05x.git", rev = "2625b3387557a02d12948f2f44e980e37f1f9cca"} 
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", tag = "v0.2.2-nitrokey.1" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", tag = "v0.1.0"}
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", branch = "hmacsha256p256" }

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0", default-features = false }
 heapless = "0.7"
 heapless-bytes = { version = "0.3.0", features = ["cbor"] }
 lfs-backup = { path = "../../components/lfs-backup" }
+se05x = { version = "0.0.1", optional = true}
 
 ### protocols and dispatchers
 apdu-dispatch = "0.1"
@@ -96,13 +97,14 @@ board-nk3am = ["soc-nrf52840", "extflash_spi"]
 
 board-nk3xn = ["soc-lpc55"]
 
-soc-nrf52840 = ["nrf52840-hal", "nrf52840-pac", "chacha20"]
-soc-lpc55 = ["lpc55-hal", "lpc55-pac", "fm11nc08", "systick-monotonic"]
+soc-nrf52840 = ["nrf52840-hal", "nrf52840-pac", "chacha20", "se05x?/nrf"]
+soc-lpc55 = ["lpc55-hal", "lpc55-pac", "fm11nc08", "se05x?/lpc55", "chacha20", "systick-monotonic"]
 
 extflash_qspi = []
 extflash_spi = []
 
 lpc55-hardware-checks = []
+se050 = ["se05x"]
 
 log-all = []
 log-trace = []

--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -46,6 +46,7 @@ pub fn init(
             hal.adc,
             hal.ctimer.0,
             hal.ctimer.1,
+            hal.ctimer.2,
             hal.ctimer.3,
             hal.ctimer.4,
             hal.pfr,

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -139,6 +139,7 @@ bitflags! {
         const INTERNAL_FLASH_ERROR = 0b00000010;
         const EXTERNAL_FLASH_ERROR = 0b00000100;
         const MIGRATION_ERROR = 0b00001000;
+        const SE050_RAND_ERROR = 0b00010000;
     }
 }
 


### PR DESCRIPTION
This patch implements entropy injection for the Trussed RNG using the SE050 without introducing the SE050 backend and Trussed extension.

Mostly extracted from https://github.com/Nitrokey/nitrokey-3-firmware/pull/335, currently lpc55-only.