### PR TITLE
ci: move common-jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,8 @@
-include: 'https://raw.githubusercontent.com/Nitrokey/common-ci-jobs/master/common_jobs.yml'
+
+include:
+  - project: 'nitrokey/gitlab-ci'
+    file:
+      - 'common-jobs/common_jobs.yml'
 
 stages:
   - pull-github


### PR DESCRIPTION
this moves the `.gitlab-ci.xml` include into our internal git(lab) instance