### PR TITLE
Release v1.5.0-test.20231026

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "apps"
-version = "1.5.0-test.20230704"
+version = "1.5.0-test.20231026"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-runner-lib"
-version = "1.5.0-test.20230704"
+version = "1.5.0-test.20231026"
 dependencies = [
  "alloc-cortex-m",
  "apdu-dispatch",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "usbip-runner"
-version = "1.5.0-test.20230704"
+version = "1.5.0-test.20231026"
 dependencies = [
  "apps",
  "cfg-if",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "utils"
-version = "1.5.0-test.20230704"
+version = "1.5.0-test.20231026"
 dependencies = [
  "delog",
  "littlefs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0-test.20230704"
+version = "1.5.0-test.20231026"
 
 [patch.crates-io]
 # forked


### PR DESCRIPTION
Tested with https://github.com/Nitrokey/nitrokey-3-tests/commit/a70cad378ef6ae07c92641a4bc809fec32f63e10:
- ✔️ usbip
- ✔️ usbip upgrade from f3b5aad32b654965859db1330c921bfd6710c053

Tested with https://github.com/Nitrokey/nitrokey-3-tests/pull/31/commits/635fd6e6f8a210b3ce3944552eb0f79e7a55cdef:
- ✔️ lpc55