### PR TITLE
Add CI_PIPELINE_SOURCE web to build-firmware-for-tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,6 +178,7 @@ build-firmware-for-tests:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'
   tags:
     - docker
   stage: build


### PR DESCRIPTION
Currently, the release CI cannot be started:
>  'hardware-tests' job needs 'build-firmware-for-tests' job, but
>  'build-firmware-for-tests' is not in any previous stage

This patch attempts to fix the problem by activating the build-firmware-for-tests jobs for pipelines triggered from the web interface.