### PR TITLE
Disable hardware tests for releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,7 +178,6 @@ build-firmware-for-tests:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
-    - if: '$CI_PIPELINE_SOURCE == "web"'
   tags:
     - docker
   stage: build
@@ -201,7 +200,6 @@ build-firmware-for-tests:
 hardware-tests:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
-    - if: '$CI_PIPELINE_SOURCE == "web"'
   tags:
     - nk3-hw
   stage: test


### PR DESCRIPTION
This is a follow-up to https://github.com/Nitrokey/nitrokey-3-firmware/pull/363:

The build-firmware-for-tests job could potentially mess up the binaries generated for the release, so it is safer to drop the hardware tests from the release CI, especially as they do not work yet.