### PR TITLE
Update fido-authenticator, ctap-types, webcrypt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "ctap-types"
 version = "0.1.2"
-source = "git+https://github.com/Nitrokey/ctap-types?rev=v0.1.2-nitrokey.3#0d9f6f5d7ff7f6c90c8f284037699f749daee641"
+source = "git+https://github.com/Nitrokey/ctap-types?tag=v0.1.2-nitrokey.4#702b5b5248f88091b22c46c936cb0f99425c0a61"
 dependencies = [
  "bitflags 1.3.2",
  "cbor-smol",
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?rev=v0.1.1-nitrokey.6#d318c117a26ce75194e122a36f6e03ec95c960e0"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.7#2f49017eec5a87bd2570593571b87a15a9890ed0"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",
@@ -3521,7 +3521,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "webcrypt"
 version = "0.8.0"
-source = "git+https://github.com/nitrokey/nitrokey-webcrypt-rust?tag=v0.8.0-rc2#d1b9fbb77df998f5fb1e9e8997afefaa69360508"
+source = "git+https://github.com/nitrokey/nitrokey-webcrypt-rust?tag=v0.8.0-rc3#e4ab7c371187ccfc69adcc098d0f81ece15ceae2"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ version = "1.5.0-test.20231026"
 [patch.crates-io]
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app", tag = "v0.1.0-nitrokey.5" }
-ctap-types = { git = "https://github.com/Nitrokey/ctap-types", rev = "v0.1.2-nitrokey.3" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", rev = "v0.1.1-nitrokey.6" }
+ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.4" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.7" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
@@ -29,7 +29,7 @@ usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitro
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.13.0-rc1" }
-webcrypt = { git = "https://github.com/nitrokey/nitrokey-webcrypt-rust", tag = "v0.8.0-rc2"}
+webcrypt = { git = "https://github.com/nitrokey/nitrokey-webcrypt-rust", tag = "v0.8.0-rc3"}
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.1.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.2" }
 se05x = { git = "https://github.com/Nitrokey/se05x.git", tag = "v0.1.0"} 


### PR DESCRIPTION
This patch updates fido-authenticator and ctap-types to fix an incompatibility with the Chromium credential management.

Depends on:
- https://github.com/Nitrokey/ctap-types/pull/13
- https://github.com/Nitrokey/fido-authenticator/pull/39