### PR TITLE
lpc55: Move USB initialization to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 - fido-authenticator: Reduce the maximum credential ID length for improved compatibility ([fido-authenticator#37][])
 - fido-authenticator: Multiple changes to improve compliance with the specification (overview: [fido-authenticator#6][])
 - Correct maximum binary size for LPC55 and only enable PRINCE for the subregions used for the filesystem ([#355][])
+- lpc55: Move USB initialization to the end of the boot process to make sure that the device can respond to all requests, fixing a potential delay when connecting the device under Linux ([#302][])
 
+[#302]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/302
 [#314]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/314
 [#321]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/321
 [#335]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/335

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -12,6 +12,8 @@ delog!(Delogger, 3 * 1024, 512, ERL::types::DelogFlusher);
 #[rtic::app(device = nrf52840_hal::pac, peripherals = true, dispatchers = [SWI3_EGU3, SWI4_EGU4, SWI5_EGU5])]
 mod app {
     use super::{Delogger, ERL, ERL::soc::rtic_monotonic::RtcDuration};
+    use apdu_dispatch::interchanges::Channel as CcidChannel;
+    use interchange::Channel;
     use nrf52840_hal::{
         gpio::{p0, p1},
         gpiote::Gpiote,
@@ -140,7 +142,9 @@ mod app {
         let store: ERL::types::RunnerStore =
             ERL::init_store(internal_flash, extflash, false, &mut init_status);
 
-        let usbnfcinit = ERL::init_usb_nfc(usbd_ref, None);
+        static NFC_CHANNEL: CcidChannel = Channel::new();
+        let (_nfc_rq, nfc_rp) = NFC_CHANNEL.split().unwrap();
+        let usbnfcinit = ERL::init_usb_nfc(usbd_ref, None, nfc_rp);
         /* TODO: set up fingerprint device */
         /* TODO: set up SE050 device */
         use nrf52840_hal::prelude::OutputPin;

--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -60,11 +60,10 @@ pub fn init(
             hal.flexcomm.5,
             hal.inputmux,
             hal.pint,
-            hal.usbhs,
             nfc_enabled,
         )
         .next(hal.rng, hal.prince, hal.flash)
         .next()
         .next(hal.rtc)
-        .next()
+        .next(hal.usbhs)
 }


### PR DESCRIPTION
This patch splits the NFC and USB initialization and moves the USB initialization to the end of the initialization process on the lpc55. This makes sure that we can respond to all USB requests as the poll task is started directly after the init process.

Previously, we initialized the USB interface at the beginning of the process so that we could not respond to requests until the end of the init process.  This could potentially mean that the device would lose the initial GET DESCRIPTOR request sent by the Linux kernel, causing a delay of typically 5 s after connecting the device.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/302