### PR TITLE
ci: remove upload and container build from scheduled

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,8 @@ variables:
   REPO_NAME: nitrokey-3-firmware
   MAIN_BRANCH: main 
   IMAGE_NAME: nitrokey3
-  COMMON_UPDATE_DOCKER: "true"
+  COMMON_UPDATE_DOCKER: "false"
+  COMMON_UPLOAD_FILES: "false"
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   LC_ALL: C.UTF-8
   LANG: C.UTF-8


### PR DESCRIPTION
This removes the nightly files upload and docker rebuild to re-activate the scheduled pipeline...