### PR TITLE
Refactor versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "apps"
-version = "1.5.0-test.20231030"
+version = "1.5.0"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -294,6 +309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,7 +347,7 @@ dependencies = [
  "cargo_metadata",
  "csv",
  "getopts",
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "serde_derive",
  "serde_json",
@@ -340,7 +361,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c408da54db4c50d4693f7e649c299bc9de9c23ead86249e5368830bb32a734b"
 dependencies = [
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "toml",
  "url",
@@ -363,7 +384,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "serde_json",
 ]
@@ -452,6 +473,18 @@ dependencies = [
  "cipher 0.4.4",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -594,6 +627,12 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cortex-m"
@@ -1009,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-runner-lib"
-version = "1.5.0-test.20231030"
+version = "1.5.0"
 dependencies = [
  "alloc-cortex-m",
  "apdu-dispatch",
@@ -1293,7 +1332,7 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata",
  "gumdrop",
- "semver 1.0.19",
+ "semver 1.0.20",
  "serde",
  "toml",
 ]
@@ -1577,6 +1616,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1697,15 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2429,14 +2500,14 @@ checksum = "09c30c54dffee5b40af088d5d50aa3455c91a0127164b51f0215efc4cb28fb3c"
 
 [[package]]
 name = "regex"
-version = "1.9.6"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.9",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2450,13 +2521,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2467,9 +2538,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rsa"
@@ -2564,7 +2635,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.19",
+ "semver 1.0.20",
 ]
 
 [[package]]
@@ -2660,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
@@ -3446,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "usbip-runner"
-version = "1.5.0-test.20231030"
+version = "1.5.0"
 dependencies = [
  "apps",
  "cfg-if",
@@ -3466,11 +3537,14 @@ dependencies = [
 
 [[package]]
 name = "utils"
-version = "1.5.0-test.20231030"
+version = "1.5.0"
 dependencies = [
+ "chrono",
  "delog",
  "littlefs2",
  "quickcheck",
+ "regex",
+ "semver 1.0.20",
 ]
 
 [[package]]
@@ -3517,6 +3591,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "webcrypt"
@@ -3575,6 +3703,15 @@ name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0-test.20231030"
+version = "1.5.0"
 
 [patch.crates-io]
 # forked

--- a/components/utils/Cargo.toml
+++ b/components/utils/Cargo.toml
@@ -7,13 +7,20 @@ edition = "2021"
 delog = "0.1"
 littlefs2 = "0.4"
 
+[build-dependencies]
+chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
+regex = { version = "1.10.2", default-features = false }
+semver = "1.0.20"
+
+[dev-dependencies]
+quickcheck = "1.0.3"
+
 [features]
+test = []
+
 log-all = []
 log-none = []
 log-info = []
 log-debug = []
 log-warn = []
 log-error = []
-
-[dev-dependencies]
-quickcheck = "1.0.3"

--- a/components/utils/build.rs
+++ b/components/utils/build.rs
@@ -1,0 +1,112 @@
+use std::process::Command;
+
+use chrono::{Datelike as _, Local};
+use regex::Regex;
+use semver::{BuildMetadata, Prerelease, Version};
+
+// We have a crate version, as defined in the Cargo.toml, and a firmware version, as reported by
+// the device e. g. in the admin app.  The firmware version is determined using these steps:
+//
+// 1. The crate version is either <major>.<minor>.<patch> or <major>.<minor>.<patch>-rc.<n>.
+// 2. If the test feature is activated, the prerelease component for the firmware version is set to
+//    test.<yyyy><mm><dd>.
+// 3. If built from a tag in the CI, the tag name must be a semver version with the v prefix.  The
+//    major, minor and patch components must match the crate version, the prerelease component must
+//    match the crate version or the prerelease component computed in step (2), and the build
+//    metadata must be empty.
+// 4. Unless the firmware is built in the release CI, the build metadata for the firmware version
+//    is set to git-<commit> or git-<commit>-dirty.
+//
+// The environment variable NK3_FIRMWARE_VERSION is set to the calculated firmware version.
+
+const PATTERN_PRE: &str = r"rc\.\d+";
+
+fn main() {
+    let mut version = crate_version();
+    let test_prerelease = test_prerelease();
+
+    if let Some(tag_version) = tag_version() {
+        assert_eq!(
+            tag_version.major, version.major,
+            "bad major component in tag"
+        );
+        assert_eq!(
+            tag_version.minor, version.minor,
+            "bad minor component in tag"
+        );
+        assert_eq!(
+            tag_version.patch, version.patch,
+            "bad patch component in tag"
+        );
+        assert!(
+            tag_version.pre == version.pre || tag_version.pre == test_prerelease,
+            "prerelease component {} in tag must be one of: {}, {}",
+            tag_version.pre,
+            version.pre,
+            test_prerelease,
+        );
+        assert_eq!(
+            tag_version.build,
+            BuildMetadata::EMPTY,
+            "build metadata in tag must be empty"
+        );
+    }
+
+    if cfg!(feature = "test") {
+        // We intentionally overwrite the rc.<n> prerelease component if it is set
+        version.pre = test_prerelease;
+    }
+    if !is_release() {
+        if let Some(build_metadata) = build_metadata() {
+            version.build = build_metadata;
+        }
+    }
+
+    println!("cargo:rustc-env=NK3_FIRMWARE_VERSION={version}");
+}
+
+fn crate_version() -> Version {
+    let version = Version::parse(env!("CARGO_PKG_VERSION")).expect("failed to parse crate version");
+    assert!(
+        version.build.is_empty(),
+        "crate version may not have build metadata: {version}"
+    );
+    if !version.pre.is_empty() {
+        let r = Regex::new(PATTERN_PRE).unwrap();
+        assert!(
+            r.is_match(version.pre.as_str()),
+            "unexpected pre version: {}",
+            version.pre
+        );
+    }
+    version
+}
+
+fn tag_version() -> Option<Version> {
+    option_env!("CI_COMMIT_TAG")
+        .map(|s| s.strip_prefix("v").expect("tag must start with v"))
+        .map(|s| Version::parse(s).expect("failed to parse version from tag"))
+}
+
+fn test_prerelease() -> Prerelease {
+    let now = Local::now();
+    let pre = format!("test.{:04}{:02}{:02}", now.year(), now.month(), now.day());
+    pre.parse().unwrap()
+}
+
+fn build_metadata() -> Option<BuildMetadata> {
+    // We want to get the latest commit and whether the working tree is dirty.  Apparently, there
+    // is no easy machine-readble way to do the latter so we use git-describe with --exclude * so
+    // that we don’t get tag names, only commit shas.
+    Command::new("git")
+        .args(["describe", "--always", "--dirty", "--exclude", "*"])
+        .output()
+        .ok()
+        .map(|output| String::from_utf8(output.stdout).expect("invalid output from git describe"))
+        .map(|s| format!("git.{}", s.trim().replace('-', ".")))
+        .map(|s| s.parse().unwrap())
+}
+
+fn is_release() -> bool {
+    option_env!("CI_PIPELINE_SOURCE") == Some("web")
+}

--- a/components/utils/src/constants.rs
+++ b/components/utils/src/constants.rs
@@ -1,23 +1,22 @@
-use core::fmt::{self, Display, Formatter};
-
 pub const VERSION: Version = Version::from_env();
-pub const VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
+pub const VERSION_STRING: &str = env!("NK3_FIRMWARE_VERSION");
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Version {
     pub major: u8,
     pub minor: u8,
     pub patch: u8,
-    pub pre: Option<&'static str>,
 }
 
 impl Version {
     pub const fn from_env() -> Self {
+        let major = parse_simple_u8(env!("CARGO_PKG_VERSION_MAJOR"));
+        let minor = parse_simple_u8(env!("CARGO_PKG_VERSION_MINOR"));
+        let patch = parse_simple_u8(env!("CARGO_PKG_VERSION_PATCH"));
         Self {
-            major: parse_simple_u8(env!("CARGO_PKG_VERSION_MAJOR")),
-            minor: parse_simple_u8(env!("CARGO_PKG_VERSION_MINOR")),
-            patch: parse_simple_u8(env!("CARGO_PKG_VERSION_PATCH")),
-            pre: optional_str(env!("CARGO_PKG_VERSION_PRE")),
+            major,
+            minor,
+            patch,
         }
     }
 
@@ -30,16 +29,6 @@ impl Version {
 
     pub const fn usb_release(&self) -> u16 {
         u16::from_be_bytes([self.major, self.minor])
-    }
-}
-
-impl Display for Version {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "v{}.{}.{}", self.major, self.minor, self.patch)?;
-        if let Some(pre) = self.pre {
-            write!(f, "-{pre}")?;
-        }
-        Ok(())
     }
 }
 
@@ -59,14 +48,6 @@ const fn parse_simple_u8(s: &str) -> u8 {
         i += 1;
     }
     value
-}
-
-const fn optional_str(s: &str) -> Option<&str> {
-    if s.is_empty() {
-        None
-    } else {
-        Some(s)
-    }
 }
 
 #[cfg(test)]

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -14,20 +14,16 @@ As we have a `Cargo.lock` file with fixed dependency versions, we don’t automa
 
 ## Releasing
 
-### Creating Releases
-
-To release a new version of the firmware, perform the following steps:
-1. Update the version counter in `Cargo.toml`.
+To release a stable release or release candidate of the firmware, perform the following steps:
+1. Update the version counter in `Cargo.toml` using the patterns `<major>.<minor>.<patch>` or `<major>.<minor>.<patch>-rc.<n>`.
 2. Run the firmware build for the embedded runner and add the updated `Cargo.lock`.
 3. Update the changelog.
-4. Commit all changed files and create a signed tag with a `v` prefix and the version number, for example `v1.0.0`.
-5. Create a release on GitHub and copy the relevant section from the changelog to the release description.
+4. Commit all changed files, create a PR and merge it once reviewed.
+5. Create a signed tag with a `v` prefix and the version number, for example `v1.0.0` or `v1.5.0-rc.0`.
 
-### Signing Releases (lpc55)
+To release a test release, just create a signed tag with the version number using the pattern `v<major>.<minor>.<patch>-test.<yyyy><mm><dd>`, for example `v1.5.0-test.20231106`.
 
-1. Download the `firmware-nk3xn.bin` and `commands.bd` as built by the CI from the release tag.
-2. Sign the firmware and build a SB2.1 image using the `commands.bd` file.
-3. Upload the SB2.1 image to the GitHub release using the filename pattern `firmware-<device>-<chip>-v<version>.sb2`, for example `firmware-nk3xn-lpc55-v1.0.0.sb2`.
+Refer to the internal documentation for more details on the release process.
 
 ## Forking Dependencies
 

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -73,7 +73,7 @@ toml = "0.5"
 [features]
 default = ["alloc"]
 
-test = ["apps/test", "se050", "se050-test-app"]
+test = ["apps/test", "utils/test", "se050", "se050-test-app"]
 develop = ["no-encrypted-storage", "apps/no-reset-time-window", "log-traceP"]
 develop-no-press = ["develop", "no-buttons"]
 provisioner = ["apps/provisioner", "write-undefined-flash", "no-buttons", "apps/no-reset-time-window", "lpc55-hardware-checks"]

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -36,7 +36,7 @@ pub fn banner() {
         "Embedded Runner ({}:{}) using librunner {}",
         <SocT as Soc>::SOC_NAME,
         <SocT as Soc>::BOARD_NAME,
-        utils::VERSION,
+        utils::VERSION_STRING,
     );
 }
 


### PR DESCRIPTION
This patch changes the way we handle versioning:  The crate version defined in the root Cargo.toml is now only changed for stable releases or release candidates.  The test suffix is automatically added if the test feature is enabled.  Additionally, build metadata with the Git commit and worktree status is added to the version string.  Finally, there are additional checks to make sure that tag names match the computed version.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/339

All required steps are added to a build script.  It would be possible to move some or all of them into the Makefile, but this makes sure that we get consistent results independent of the build method, it is easier to implement all checks and for me it did not cause any unnecessary rebuilds.

Still requires some testing with the CI, but I’ll wait with that until the recent CI changes are merged.