### PR TITLE
fido-authenticator: Add large blobs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Unreleased
 
+### Features
+
 - Add an SE050 driver and its tests ([#335][])
 - Use SE050 entropy to bootstrap the random number generator ([#335][])
+- fido-authenticator: Implement the largeBlobKey extension and the largeBlobs command ([fido-authenticator#38][])
+
+[fido-authenticator#38]: https://github.com/Nitrokey/fido-authenticator/issues/38
 
 # 1.6.0 (2023-11-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "ctap-types"
 version = "0.1.2"
-source = "git+https://github.com/Nitrokey/ctap-types?tag=v0.1.2-nitrokey.4#702b5b5248f88091b22c46c936cb0f99425c0a61"
+source = "git+https://github.com/trussed-dev/ctap-types.git?rev=7d4ad69e64ad308944c012aef5b9cfd7654d9be8#7d4ad69e64ad308944c012aef5b9cfd7654d9be8"
 dependencies = [
  "bitflags 1.3.2",
  "cbor-smol",
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.8#f4cf88ae9e32c6da587fa87a67ea1522fbd80cb6"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.9#162ac6a2e603fb69944ff1679dced9752f0c7cf2"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",
@@ -1190,7 +1190,9 @@ dependencies = [
  "serde",
  "serde-indexed",
  "serde_cbor",
+ "sha2 0.10.8",
  "trussed",
+ "trussed-staging",
 ]
 
 [[package]]
@@ -3259,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed.git?rev=d97c64d0bc5f83ce22b0e0ed034a2b451616b3f9#d97c64d0bc5f83ce22b0e0ed034a2b451616b3f9"
+source = "git+https://github.com/trussed-dev/trussed.git?rev=b1781805a2e33615d2d00b8bec80c0b1f5870ca1#b1781805a2e33615d2d00b8bec80c0b1f5870ca1"
 dependencies = [
  "aes",
  "bitflags 2.4.1",
@@ -3347,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "trussed-staging"
 version = "0.1.0"
-source = "git+https://github.com/nitrokey/trussed-staging.git?tag=v0.1.0-nitrokey-hmac256p256.1#cec6260499a246d6ede687ea8ca2a97667295a23"
+source = "git+https://github.com/Nitrokey/trussed-staging.git?tag=v0.1.0-nitrokey-hmac256p256.2#a21f11a95254dee81c6534a1260b1318bfac87b5"
 dependencies = [
  "chacha20poly1305",
  "delog",
@@ -3676,7 +3678,7 @@ checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 [[package]]
 name = "webcrypt"
 version = "0.8.0"
-source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?tag=v0.8.0-rc4#4ec145499b7b2331ac36cb9656da4a732f7c7180"
+source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?tag=v0.8.0-rc5#012227d413666d82de416dc30c7e3008113cbadb"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,30 +13,30 @@ version = "1.6.0"
 [patch.crates-io]
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.7" }
-ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.4" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.8" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.9" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 
 # unreleased upstream changes
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch.git", tag = "v0.1.2-nitrokey.2" }
+ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "7d4ad69e64ad308944c012aef5b9cfd7654d9be8" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch.git", tag = "v0.1.1-nitrokey.3" }
 iso7816 = { git = "https://github.com/Nitrokey/iso7816.git", tag = "v0.1.1-nitrokey.2"}
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "d97c64d0bc5f83ce22b0e0ed034a2b451616b3f9" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "b1781805a2e33615d2d00b8bec80c0b1f5870ca1" }
 usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2", rev = "e6c46e7ba5ae19129e457a2182e40a439c0322fe" }
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.13.0-rc2" }
-webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc4"}
+webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc5" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "a824c6473ce1b88b45b32de21089401fc9f7f683" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.3" }
 se05x = { git = "https://github.com/Nitrokey/se05x.git", tag = "v0.1.0"} 
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "62235294bd63977bbb88eb01e7ac44b8010eb450" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "2f51478f0861ff8db19fdd5290f023ab6f4c2fb9" }
-trussed-staging = { git = "https://github.com/nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey-hmac256p256.1" }
+trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey-hmac256p256.2" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.3" }
 trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "v0.1.0-test-driver" }
 

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -21,7 +21,7 @@ trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked"
 
 # apps
 admin-app = "0.1.0"
-fido-authenticator = { version = "0.1.1", features = ["dispatch"], optional = true }
+fido-authenticator = { version = "0.1.1", features = ["chunked", "dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
 webcrypt = { version = "0.8.0", optional = true }
 secrets-app = { version = "0.13.0", features = ["apdu-dispatch", "ctaphid"], optional = true }

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -275,13 +275,16 @@ pub fn init_apps(
         }
     };
 
+    let runner = types::Runner {
+        is_efs_available: !nfc_powered,
+    };
     let data = apps::Data {
         admin,
         #[cfg(feature = "provisioner")]
         provisioner,
         _marker: Default::default(),
     };
-    types::Apps::with_service(&types::Runner, trussed, data)
+    types::Apps::with_service(&runner, trussed, data)
 }
 
 #[cfg(feature = "se050")]

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -69,7 +69,9 @@ pub trait Soc {
     fn device_uuid() -> &'static Self::UUID;
 }
 
-pub struct Runner;
+pub struct Runner {
+    pub is_efs_available: bool,
+}
 
 impl apps::Runner for Runner {
     type Syscall = RunnerSyscall;
@@ -82,6 +84,10 @@ impl apps::Runner for Runner {
 
     fn uuid(&self) -> [u8; 16] {
         *<SocT as Soc>::device_uuid()
+    }
+
+    fn is_efs_available(&self) -> bool {
+        self.is_efs_available
     }
 }
 

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -120,6 +120,10 @@ impl apps::Runner for Runner {
     fn uuid(&self) -> [u8; 16] {
         self.serial
     }
+
+    fn is_efs_available(&self) -> bool {
+        true
+    }
 }
 
 fn main() {


### PR DESCRIPTION
This patch updates fido-authenticator to add support for the largeBlobKey extension and the largeBlobs command.  See the fido-authenticator PR for more information:
- https://github.com/Nitrokey/fido-authenticator/pull/41