### PR TITLE
Prepare release 1.6.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,7 +196,7 @@ hardware-tests:
   stage: test
   script:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@git.nitrokey.com/nitrokey/nitrokey-hardware-test.git --recursive
-    - git -C nitrokey-hardware-test checkout v1.0
+    - git -C nitrokey-hardware-test checkout v1.0.3
     - make -C nitrokey-hardware-test ci FW=../artifacts MODEL=$MODEL TESTS=pynitrokey,nk3test
     - cp nitrokey-hardware-test/artifacts/Nitrokey3TestSuite/report-junit.xml nitrokey-hardware-test/artifacts/report-junit.xml
   dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
+# Unreleased
+
+- Add an SE050 driver and its tests ([#335][])
+- Use SE050 entropy to bootstrap the random number generator ([#335][])
+
+# 1.6.0 (2023-11-23)
+
+- no additions since v1.6.0-rc.1
+
 # 1.6.0-rc.1 (2023-11-10)
 
 ### Features
 
-- Add an SE050 driver and its tests ([#335][])
 - usbip: Add user presence check ([#314][], [#321][])
 - admin-app: Add config mechanism ([#344][])
 
 ### Changed
 
-- Use SE050 entropy to bootstrap the random number generator ([#335][])
 - secrets-app: Update to v0.13.0-rc.1
   - Confirm credential removal with a touch ([trussed-secrets-app#92][])
   - Allow to update credential ([trussed-secrets-app#65][])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "apps"
-version = "1.6.0-rc.1"
+version = "1.6.0"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-runner-lib"
-version = "1.6.0-rc.1"
+version = "1.6.0"
 dependencies = [
  "alloc-cortex-m",
  "apdu-dispatch",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "usbip-runner"
-version = "1.6.0-rc.1"
+version = "1.6.0"
 dependencies = [
  "apps",
  "cfg-if",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "utils"
-version = "1.6.0-rc.1"
+version = "1.6.0"
 dependencies = [
  "chrono",
  "delog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "admin-app"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/admin-app.git?rev=c83c8a27c20b4b6820d60cb8ef2204c51f398db0#c83c8a27c20b4b6820d60cb8ef2204c51f398db0"
+source = "git+https://github.com/Nitrokey/admin-app.git?tag=v0.1.0-nitrokey.7#c83c8a27c20b4b6820d60cb8ef2204c51f398db0"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",
@@ -3347,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "trussed-staging"
 version = "0.1.0"
-source = "git+https://github.com/nitrokey/trussed-staging.git?branch=hmacsha256p256-rebased#cec6260499a246d6ede687ea8ca2a97667295a23"
+source = "git+https://github.com/nitrokey/trussed-staging.git?tag=v0.1.0-nitrokey-hmac256p256.1#cec6260499a246d6ede687ea8ca2a97667295a23"
 dependencies = [
  "chacha20poly1305",
  "delog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0-rc.1"
+version = "1.6.0"
 
 [patch.crates-io]
 # forked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "1.6.0-rc.1"
 
 [patch.crates-io]
 # forked
-admin-app = { git = "https://github.com/Nitrokey/admin-app.git", rev = "c83c8a27c20b4b6820d60cb8ef2204c51f398db0" }
+admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.7" }
 ctap-types = { git = "https://github.com/Nitrokey/ctap-types", tag = "v0.1.2-nitrokey.4" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.8" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
@@ -36,7 +36,7 @@ piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag
 se05x = { git = "https://github.com/Nitrokey/se05x.git", tag = "v0.1.0"} 
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "62235294bd63977bbb88eb01e7ac44b8010eb450" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "2f51478f0861ff8db19fdd5290f023ab6f4c2fb9" }
-trussed-staging = { git = "https://github.com/nitrokey/trussed-staging.git", branch = "hmacsha256p256-rebased" }
+trussed-staging = { git = "https://github.com/nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey-hmac256p256.1" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.3" }
 trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "v0.1.0-test-driver" }
 


### PR DESCRIPTION
* Version bump to `v1.6.0`
* Update changelog (no changes since v1.6.0-rc.1)

waits for #387 merge, then rebase, then let's go