### PR TITLE
Handle config error in admin app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Add an SE050 driver and its tests ([#335][])
 - Use SE050 entropy to bootstrap the random number generator ([#335][])
 - fido-authenticator: Implement the largeBlobKey extension and the largeBlobs command ([fido-authenticator#38][])
+- Report errors when loading the configuration during initialization and disable opcard if an error occured ([#394][])
 
+[#394]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/394
 [fido-authenticator#38]: https://github.com/Nitrokey/fido-authenticator/issues/38
 
 # 1.6.0 (2023-11-23)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "admin-app"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/admin-app.git?tag=v0.1.0-nitrokey.7#c83c8a27c20b4b6820d60cb8ef2204c51f398db0"
+source = "git+https://github.com/Nitrokey/admin-app.git?tag=v0.1.0-nitrokey.9#75c7c969cfa811aa774d1a08d48e8563f8732497"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",
@@ -109,10 +109,12 @@ version = "1.6.0"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
+ "bitflags 1.3.2",
  "cbor-smol",
  "ctaphid-dispatch",
  "embedded-hal",
  "fido-authenticator",
+ "heapless 0.7.16",
  "hex",
  "if_chain",
  "littlefs2",
@@ -1065,7 +1067,6 @@ dependencies = [
  "alloc-cortex-m",
  "apdu-dispatch",
  "apps",
- "bitflags 1.3.2",
  "cargo-lock",
  "cfg-if",
  "chacha20 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "1.6.0"
 
 [patch.crates-io]
 # forked
-admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.7" }
+admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.9" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.9" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 
 [dependencies]
 apdu-dispatch = "0.1"
+bitflags = "1.3.2"
 ctaphid-dispatch = "0.1"
+heapless = "0.7"
 serde = { version = "1.0.180", default-features = false }
 trussed = { version = "0.1", features = ["serde-extensions"]}
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"], optional = true }

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -61,7 +61,6 @@ systick-monotonic = { version = "1.0.0", optional = true }
 
 ### Allocator
 alloc-cortex-m = { version = "0.4.3", optional = true }
-bitflags = "1.3.2"
 ref-swap = "0.1.0"
 se05x = { version = "0.0.1", optional = true }
 

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -53,7 +53,7 @@ mod app {
 
     #[init()]
     fn init(mut ctx: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
-        let mut init_status = ERL::types::InitStatus::default();
+        let mut init_status = apps::InitStatus::default();
 
         #[cfg(feature = "alloc")]
         embedded_runner_lib::init_alloc();

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -1,7 +1,7 @@
 use apdu_dispatch::interchanges::{
     Channel as CcidChannel, Requester as CcidRequester, Responder as CcidResponder,
 };
-use apps::Dispatch;
+use apps::{Dispatch, InitStatus};
 use embedded_hal::{
     blocking::i2c::{Read, Write},
     timer::{Cancel, CountDown},
@@ -50,7 +50,7 @@ use crate::{
         buttons::{self, Press},
         rgb_led::RgbLed,
     },
-    types::{self, usbnfc::UsbNfcInit as UsbNfc, Apps, InitStatus, Iso14443, RunnerStore, Trussed},
+    types::{self, usbnfc::UsbNfcInit as UsbNfc, Apps, Iso14443, RunnerStore, Trussed},
 };
 
 type UsbBusType = usb_device::bus::UsbBusAllocator<<super::types::Soc as types::Soc>::UsbBus>;

--- a/runners/embedded/src/soc_lpc55/nfc.rs
+++ b/runners/embedded/src/soc_lpc55/nfc.rs
@@ -1,5 +1,5 @@
 use super::spi::Spi;
-use crate::types::InitStatus;
+use apps::InitStatus;
 use lpc55_hal::{
     self,
     drivers::{

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -5,7 +5,6 @@ pub use apdu_dispatch::{
     command::SIZE as ApduCommandSize, response::SIZE as ApduResponseSize, App as ApduApp,
 };
 use apps::{Dispatch, Variant};
-use bitflags::bitflags;
 pub use ctaphid_dispatch::app::App as CtaphidApp;
 #[cfg(feature = "se050")]
 use embedded_hal::blocking::delay::DelayUs;
@@ -151,17 +150,6 @@ pub type ApduDispatch = apdu_dispatch::dispatch::ApduDispatch<'static>;
 pub type CtaphidDispatch = ctaphid_dispatch::dispatch::Dispatch<'static, 'static>;
 
 pub type Apps = apps::Apps<Runner>;
-
-bitflags! {
-    #[derive(Default)]
-    pub struct InitStatus: u8 {
-        const NFC_ERROR = 0b00000001;
-        const INTERNAL_FLASH_ERROR = 0b00000010;
-        const EXTERNAL_FLASH_ERROR = 0b00000100;
-        const MIGRATION_ERROR = 0b00001000;
-        const SE050_RAND_ERROR = 0b00010000;
-    }
-}
 
 #[derive(Debug)]
 pub struct DelogFlusher {}


### PR DESCRIPTION
This patch updates the admin-app dependency to report errors when loading the config from IFS during intialization.  It adds a new init status flag CONFIG_ERROR and disables the opcard application if such an error occured to ensure security and stability (as the opcard configuration will determine the backend that is used).