### PR TITLE
Add no-delog feature

### DIFF
--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -72,10 +72,12 @@ toml = "0.5"
 [features]
 default = ["alloc"]
 
-test = ["apps/test", "utils/test", "se050"]
+test = ["apps/test", "utils/test"]
 develop = ["no-encrypted-storage", "apps/no-reset-time-window", "log-traceP"]
 develop-no-press = ["develop", "no-buttons"]
 provisioner = ["apps/provisioner", "write-undefined-flash", "no-buttons", "apps/no-reset-time-window", "lpc55-hardware-checks"]
+
+no-delog = ["delog/knock-it-off"]
 
 # Do not use encryption for the filesystem
 no-encrypted-storage = []

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -32,14 +32,16 @@ OUT_BIN = $(ARTIFACTS)/runner-$(BUILD_ID).bin
 OUT_ELF = $(ARTIFACTS)/runner-$(BUILD_ID).elf
 OUT_IHEX = $(OUT_BIN).ihex
 CUSTOM_PROFILE=$(shell python3 -c "p = 'release-thin-lto' if '$(BOARD)' == 'nk3am' and 'test' in '$(COMMA_FEATURES)'.split(',')  else 'release'; print(p); " )
+NO_DELOG_FEATURE=$(shell python3 -c "print('no-delog') if 'no-delog' not in '$(BUILD_FEATURES)'.split(',') and 'log-semihosting' not in '$(BUILD_FEATURES)'.split(',') and 'log-rtt' not in '$(BUILD_FEATURES)'.split(',') else None; ")
 RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
 
 # feature definition
 BUILD_FEATURES := board-$(BOARD) $(FEATURES)
+ALL_FEATURES = $(BUILD_FEATURES) $(NO_DELOG_FEATURE)
 # assemble comma-seperated list to pass to `cargo build`
 delim = ,
 space := $(null) #
-COMMA_FEATURES = $(subst $(space),$(delim),$(BUILD_FEATURES))
+COMMA_FEATURES = $(subst $(space),$(delim),$(ALL_FEATURES))
 
 .PHONY: list build reset program check doc check-all clean clean-all check-env set-vars
 

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -143,6 +143,8 @@ mod app {
                     perf_timer.start(60_000_000.microseconds());
                 }
             });
+
+            #[cfg(not(feature = "no-delog"))]
             if time > 1_200_000 {
                 soc::Delogger::flush();
             }

--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -14,6 +14,7 @@ pub mod board;
 
 use delog::delog;
 
+#[cfg(not(feature = "no-delog"))]
 delog!(Delogger, 3 * 1024, 512, crate::types::DelogFlusher);
 
 const SECURE_FIRMWARE_VERSION: u32 = utils::VERSION.encode();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.74.0"
 components = ["rustfmt", "llvm-tools-preview"]
 targets = ["thumbv7em-none-eabihf", "thumbv8m.main-none-eabi"]


### PR DESCRIPTION
This feature fully disables delog, but this makes it a "negative" feature. So it can't be enabled by default and we need to find a way to enable it for production releases