### PR TITLE
provisionner-app: Upgrade salty to version 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,15 +993,6 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature 1.3.2",
-]
-
-[[package]]
-name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
@@ -2347,7 +2338,7 @@ dependencies = [
  "heapless-bytes",
  "littlefs2",
  "p256-cortex-m4",
- "salty 0.2.0",
+ "salty",
  "trussed",
 ]
 
@@ -2565,24 +2556,12 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "salty"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cdd38ed8bfe51e53ee991aae0791b94349d0a05cfdecd283835a8a965d4c37"
-dependencies = [
- "cosey",
- "ed25519 1.5.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "salty"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b947325a585e90733e0e9ec097228f40b637cc346f9bd68f84d5c6297d0fcfef"
 dependencies = [
  "cosey",
- "ed25519 2.2.3",
+ "ed25519",
  "subtle",
  "zeroize",
 ]
@@ -3196,7 +3175,7 @@ dependencies = [
  "postcard 0.7.3",
  "rand_chacha",
  "rand_core",
- "salty 0.3.0",
+ "salty",
  "serde",
  "serde-indexed",
  "sha-1",
@@ -3252,7 +3231,7 @@ dependencies = [
  "p256-cortex-m4",
  "postcard 0.7.3",
  "rand",
- "salty 0.3.0",
+ "salty",
  "se05x",
  "serde",
  "serde-byte-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,8 +28,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array 0.14.7",
- "heapless 0.7.16",
+ "generic-array",
+ "heapless",
 ]
 
 [[package]]
@@ -98,7 +98,7 @@ version = "0.1.2"
 source = "git+https://github.com/Nitrokey/apdu-dispatch.git?tag=v0.1.2-nitrokey.2#647029550ea204b7a714ddf8852b93e644f4a429"
 dependencies = [
  "delog",
- "heapless 0.7.16",
+ "heapless",
  "interchange 0.3.0",
  "iso7816",
 ]
@@ -114,7 +114,7 @@ dependencies = [
  "ctaphid-dispatch",
  "embedded-hal",
  "fido-authenticator",
- "heapless 0.7.16",
+ "heapless",
  "hex",
  "if_chain",
  "littlefs2",
@@ -134,18 +134,6 @@ dependencies = [
  "usbd-ctaphid",
  "utils",
  "webcrypt",
-]
-
-[[package]]
-name = "as-slice"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
-dependencies = [
- "generic-array 0.12.4",
- "generic-array 0.13.3",
- "generic-array 0.14.7",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -298,7 +286,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -307,7 +295,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -316,7 +304,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -422,8 +410,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d516e3e353d5fc5ee156028f43224033430fd08ef05f8d5dba18a57a4ee5df49"
 dependencies = [
  "delog",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "serde",
 ]
 
@@ -493,7 +481,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -677,7 +665,7 @@ dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
  "cortex-m-rtic-macros",
- "heapless 0.7.16",
+ "heapless",
  "rtic-core",
  "rtic-monotonic",
  "version_check",
@@ -707,22 +695,11 @@ dependencies = [
 
 [[package]]
 name = "cosey"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae70ebe61c8f9b022729efe68ed35d9330631edd39d873de975083deb4c74f8"
-dependencies = [
- "heapless-bytes 0.2.0",
- "serde",
- "serde_repr",
-]
-
-[[package]]
-name = "cosey"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb743c2c58b69b970e02f5ba7f552f75fcfc8393768e3ae4316e055aabacfdaa"
 dependencies = [
- "heapless-bytes 0.3.0",
+ "heapless-bytes",
  "serde",
  "serde_repr",
 ]
@@ -770,7 +747,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core",
  "subtle",
  "zeroize",
@@ -782,7 +759,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core",
  "subtle",
  "zeroize",
@@ -794,7 +771,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -804,7 +781,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
 ]
 
@@ -846,10 +823,10 @@ source = "git+https://github.com/trussed-dev/ctap-types.git?rev=7d4ad69e64ad3089
 dependencies = [
  "bitflags 1.3.2",
  "cbor-smol",
- "cosey 0.3.0",
+ "cosey",
  "delog",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "interchange 0.2.2",
  "iso7816",
  "serde",
@@ -865,8 +842,8 @@ version = "0.1.1"
 source = "git+https://github.com/Nitrokey/ctaphid-dispatch.git?tag=v0.1.1-nitrokey.3#7f08ac0229ca49a5e2cd69e001658e1b43bc0a2b"
 dependencies = [
  "delog",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "interchange 0.3.0",
  "ref-swap",
  "trussed",
@@ -897,7 +874,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -911,22 +888,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce93ba4502a73722aa4b955d97f4b1bd26f4f8da74315399ca58fb88fe2bdaae"
-dependencies = [
- "der_derive 0.2.2",
- "typenum",
-]
-
-[[package]]
-name = "der"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
 dependencies = [
  "crypto-bigint 0.2.5",
- "der_derive 0.4.1",
+ "der_derive",
 ]
 
 [[package]]
@@ -947,18 +914,6 @@ checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "zeroize",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fbbc8e9e0db3a9068cffa43dcf0e314eb9feff083b7afa6eaa9e698412bb23"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
 ]
 
 [[package]]
@@ -998,7 +953,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1062,7 +1017,7 @@ checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
  "crypto-bigint 0.2.5",
  "ff",
- "generic-array 0.14.7",
+ "generic-array",
  "group",
  "rand_core",
  "subtle",
@@ -1078,7 +1033,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core",
  "sec1",
  "subtle",
@@ -1123,9 +1078,9 @@ dependencies = [
  "embedded-storage",
  "embedded-time",
  "fm11nc08",
- "generic-array 0.14.7",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "generic-array",
+ "heapless",
+ "heapless-bytes",
  "interchange 0.3.0",
  "lfs-backup",
  "littlefs2",
@@ -1181,8 +1136,8 @@ source = "git+https://github.com/Nitrokey/trussed-secrets-app?tag=v0.13.0-rc2#c4
 dependencies = [
  "cbor-smol",
  "delog",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "serde",
  "trussed",
 ]
@@ -1229,7 +1184,7 @@ dependencies = [
  "ctap-types",
  "ctaphid-dispatch",
  "delog",
- "heapless 0.7.16",
+ "heapless",
  "interchange 0.2.2",
  "iso7816",
  "serde",
@@ -1259,7 +1214,7 @@ source = "git+https://github.com/Nitrokey/flexiber?tag=0.1.1.nitrokey#26f2c80474
 dependencies = [
  "delog",
  "flexiber_derive",
- "heapless 0.7.16",
+ "heapless",
 ]
 
 [[package]]
@@ -1411,24 +1366,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
@@ -1513,15 +1450,6 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
@@ -1543,24 +1471,12 @@ checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heapless"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
-dependencies = [
- "as-slice",
- "generic-array 0.14.7",
- "hash32 0.1.1",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
- "hash32 0.2.1",
+ "hash32",
  "rustc_version 0.4.0",
  "serde",
  "spin 0.9.8",
@@ -1569,22 +1485,11 @@ dependencies = [
 
 [[package]]
 name = "heapless-bytes"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729797499905912c3e4d6d20d5981720da157a27b834531d721905fb8a9b48a"
-dependencies = [
- "heapless 0.6.1",
- "serde",
- "typenum",
-]
-
-[[package]]
-name = "heapless-bytes"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7285eba272c6af3e9f15fb9e1c1b6e7d35aa70580ffe0d47af017e97dfb6f48b"
 dependencies = [
- "heapless 0.7.16",
+ "heapless",
  "serde",
  "serde_cbor",
  "typenum",
@@ -1731,7 +1636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1756,7 +1661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3af73ac9c821e7aea3280532118e15cdf9e7bb45c923cbf0e319ae25b27d20c"
 dependencies = [
  "delog",
- "heapless 0.7.16",
+ "heapless",
 ]
 
 [[package]]
@@ -1793,9 +1698,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 name = "lfs-backup"
 version = "0.1.0"
 dependencies = [
- "generic-array 0.14.7",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "generic-array",
+ "heapless",
+ "heapless-bytes",
  "littlefs2",
  "postcard 1.0.8",
  "rand",
@@ -1841,8 +1746,8 @@ dependencies = [
  "cstr_core",
  "cty",
  "delog",
- "generic-array 0.14.7",
- "heapless 0.7.16",
+ "generic-array",
+ "heapless",
  "littlefs2-sys",
  "serde",
 ]
@@ -1898,7 +1803,7 @@ dependencies = [
  "digest 0.9.0",
  "embedded-hal",
  "embedded-time",
- "generic-array 0.14.7",
+ "generic-array",
  "littlefs2",
  "lpc55-pac",
  "nb 1.1.0",
@@ -1933,17 +1838,6 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "micro-ecc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b861c7e7eba25ec3fe0fde221a46bf38bd1ad200a5404b6f7e45c99b74a00fa"
-dependencies = [
- "bindgen",
- "cc",
- "cty",
-]
 
 [[package]]
 name = "mime"
@@ -1987,7 +1881,7 @@ name = "ndef-app"
 version = "0.1.0"
 dependencies = [
  "apdu-dispatch",
- "heapless 0.7.16",
+ "heapless",
  "iso7816",
 ]
 
@@ -1998,23 +1892,10 @@ dependencies = [
  "apdu-dispatch",
  "delog",
  "embedded-time",
- "heapless 0.7.16",
+ "heapless",
  "interchange 0.3.0",
  "iso7816",
  "nb 1.1.0",
-]
-
-[[package]]
-name = "nisty"
-version = "0.1.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50765b4bf261cc343bc5eede18fcd48d1fbe0e5e9352f43a9d0423ddae3ef30"
-dependencies = [
- "cosey 0.2.0",
- "der 0.2.10",
- "heapless-bytes 0.2.0",
- "micro-ecc-sys",
- "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2204,8 +2085,8 @@ dependencies = [
  "apdu-dispatch",
  "cfg-if",
  "delog",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "hex-literal 0.4.1",
  "iso7816",
  "log",
@@ -2332,8 +2213,8 @@ dependencies = [
  "apdu-dispatch",
  "delog",
  "flexiber",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "hex-literal 0.3.4",
  "iso7816",
  "log",
@@ -2384,7 +2265,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
- "heapless 0.7.16",
+ "heapless",
  "postcard-cobs",
  "serde",
 ]
@@ -2396,7 +2277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
- "heapless 0.7.16",
+ "heapless",
  "serde",
 ]
 
@@ -2462,10 +2343,10 @@ dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",
  "delog",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "littlefs2",
- "nisty",
+ "p256-cortex-m4",
  "salty 0.2.0",
  "trussed",
 ]
@@ -2688,7 +2569,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77cdd38ed8bfe51e53ee991aae0791b94349d0a05cfdecd283835a8a965d4c37"
 dependencies = [
- "cosey 0.3.0",
+ "cosey",
  "ed25519 1.5.3",
  "subtle",
  "zeroize",
@@ -2700,7 +2581,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b947325a585e90733e0e9ec097228f40b637cc346f9bd68f84d5c6297d0fcfef"
 dependencies = [
- "cosey 0.3.0",
+ "cosey",
  "ed25519 2.2.3",
  "subtle",
  "zeroize",
@@ -2731,7 +2612,7 @@ dependencies = [
  "crc16",
  "delog",
  "embedded-hal",
- "heapless 0.7.16",
+ "heapless",
  "hex-literal 0.4.1",
  "iso7816",
  "lpc55-hal",
@@ -2750,7 +2631,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der 0.7.8",
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
  "zeroize",
 ]
@@ -2768,8 +2649,8 @@ dependencies = [
  "delog",
  "encrypted_container",
  "flexiber",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "hex-literal 0.3.4",
  "interchange 0.2.2",
  "iso7816",
@@ -3298,14 +3179,14 @@ dependencies = [
  "cfg-if",
  "chacha20",
  "chacha20poly1305",
- "cosey 0.3.0",
+ "cosey",
  "delog",
  "des",
  "embedded-hal",
  "flexiber",
- "generic-array 0.14.7",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "generic-array",
+ "heapless",
+ "heapless-bytes",
  "hex-literal 0.4.1",
  "hmac 0.12.1",
  "interchange 0.3.0",
@@ -3345,7 +3226,7 @@ version = "0.1.0"
 source = "git+https://github.com/trussed-dev/trussed-rsa-backend.git?rev=2f51478f0861ff8db19fdd5290f023ab6f4c2fb9#2f51478f0861ff8db19fdd5290f023ab6f4c2fb9"
 dependencies = [
  "delog",
- "heapless-bytes 0.3.0",
+ "heapless-bytes",
  "num-bigint-dig",
  "postcard 0.7.3",
  "rsa",
@@ -3535,7 +3416,7 @@ source = "git+https://github.com/Nitrokey/usbd-ccid?tag=v0.2.0-nitrokey.1#eeea54
 dependencies = [
  "delog",
  "embedded-time",
- "heapless 0.7.16",
+ "heapless",
  "interchange 0.3.0",
  "iso7816",
  "usb-device",
@@ -3550,8 +3431,8 @@ dependencies = [
  "ctaphid-dispatch",
  "delog",
  "embedded-time",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "heapless",
+ "heapless-bytes",
  "interchange 0.3.0",
  "ref-swap",
  "serde",
@@ -3722,9 +3603,9 @@ dependencies = [
  "ctap-types",
  "ctaphid-dispatch",
  "delog",
- "generic-array 0.14.7",
- "heapless 0.7.16",
- "heapless-bytes 0.3.0",
+ "generic-array",
+ "heapless",
+ "heapless-bytes",
  "serde",
  "serde-indexed",
  "serde_bytes",

--- a/components/provisioner-app/Cargo.toml
+++ b/components/provisioner-app/Cargo.toml
@@ -15,10 +15,8 @@ heapless-bytes = "0.3"
 littlefs2 = "0.4.0"
 salty = { version = "0.2", features = ["cose"] }
 trussed = "0.1"
+p256-cortex-m4 = "0.1.0-alpha.6"
 
-[dependencies.nisty]
-version = "0.1.0-alpha.5"
-features = ["asn1-der", "cose"]
 
 [features]
 log-all = []

--- a/components/provisioner-app/Cargo.toml
+++ b/components/provisioner-app/Cargo.toml
@@ -13,7 +13,7 @@ delog = "0.1"
 heapless = "0.7"
 heapless-bytes = "0.3"
 littlefs2 = "0.4.0"
-salty = { version = "0.2", features = ["cose"] }
+salty = { version = "0.3", features = ["cose"] }
 trussed = "0.1"
 p256-cortex-m4 = "0.1.0-alpha.6"
 


### PR DESCRIPTION
Remove one more duplicate dependency. Built on top of #405 