### PR TITLE
Use the nightly build-std option to compile std with panic_immediate_abort

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,6 @@ build-nightly:
       - RUSTUP_TOOLCHAIN: [stable, nightly]
   script:
     - cargo --version
-    - rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
     - make -C runners/embedded build-nk3am.bl
     - make -C runners/embedded build-nk3am.bl FEATURES=test
     - make -C runners/embedded build-nk3am.bl FEATURES=provisioner

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
  "humansize",
  "mime",
  "mime_guess",
- "nom 7.1.3",
+ "nom",
  "num-traits",
  "percent-encoding",
  "proc-macro2",
@@ -287,21 +287,22 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
-version = "0.56.0"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -510,11 +511,11 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 5.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1081,6 +1082,7 @@ dependencies = [
  "delog",
  "embedded-hal",
  "interchange 0.3.0",
+ "littlefs2-sys",
  "lpc55-hal",
  "lpc55-pac",
  "memory-regions",
@@ -1769,8 +1771,7 @@ dependencies = [
 [[package]]
 name = "littlefs2-sys"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25e4f545f6ca5415c6325066260e764674d7893dcf0017a52a2ef456ba915f5"
+source = "git+https://github.com/trussed-dev/littlefs2-sys.git?rev=39626c0dbc2f6c38b74889a5bf9d5a200614f121#39626c0dbc2f6c38b74889a5bf9d5a200614f121"
 dependencies = [
  "bindgen",
  "cc",
@@ -1934,16 +1935,6 @@ dependencies = [
  "nrf52840-hal",
  "nrf52840-pac",
  "utils",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -2203,12 +2194,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -2873,9 +2858,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch.git", tag = "
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "a9f8003a1d9f05f9eea39e615b9159bc0613fcb5" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch.git", tag = "v0.1.1-nitrokey.3" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }
+littlefs2-sys = { git = "https://github.com/trussed-dev/littlefs2-sys.git", rev = "39626c0dbc2f6c38b74889a5bf9d5a200614f121" }
 usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid.git", rev = "1db2e014f28669bc484c81ab0406c54b16bba33c" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
 RUN cargo install --git https://github.com/Nitrokey/github-comment --rev ac9713f9d6d04ed03fb67d0199ebffc78ba5dcab --locked
 RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 5af5b7ccba820ec9a56bd21c4b4f00fd93534689 --locked
+RUN rustup install nightly-2024-04-01
+RUN rustup component add rust-src --toolchain nightly-2024-04-01
 WORKDIR /app

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -44,6 +44,9 @@ systick-monotonic = { version = "1.0.0", optional = true }
 ### Allocator
 alloc-cortex-m = { version = "0.4.3", optional = true }
 
+# littlefs2-sys for intrinsics feature
+littlefs2-sys = { version = "0.1.7", optional = true }
+
 [build-dependencies]
 cargo-lock = "7"
 memory-regions = "1"
@@ -59,6 +62,9 @@ develop-no-press = ["develop", "no-buttons"]
 provisioner = ["apps/nk3-provisioner", "boards/provisioner", "write-undefined-flash", "no-buttons", "apps/no-reset-time-window", "lpc55-hardware-checks"]
 
 no-delog = ["boards/no-delog", "delog/knock-it-off"]
+
+# Disable littlefs use of compiler intrinsics
+littlefs-software-intrinsics = ["dep:littlefs2-sys", "littlefs2-sys/software-intrinsics"]
 
 # Do not use encryption for the filesystem
 no-encrypted-storage = ["boards/no-encrypted-storage"]

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -30,6 +30,16 @@ OUT_ELF = $(ARTIFACTS)/runner-$(BUILD_ID).elf
 OUT_IHEX = $(OUT_BIN).ihex
 CUSTOM_PROFILE=$(shell python3 -c "p = 'release-thin-lto' if '$(BOARD)' == 'nk3am' and 'test' in '$(FEATURES)'.split(',')  else 'release'; print(p); " )
 NO_DELOG_FEATURE=$(shell python3 -c "print('no-delog') if 'no-delog' not in '$(FEATURES)'.split(',') and 'log-semihosting' not in '$(FEATURES)'.split(',') and 'log-rtt' not in '$(FEATURES)'.split(',') else None; ")
+
+SHOULD_BUILD_STD=$(shell python3 -c "p = True if '$(BOARD)' == 'nk3xn' and 'test' in '$(FEATURES)'.split(',') else False; print(p)")
+ifeq ($(SHOULD_BUILD_STD), "True")
+	BUILD_STD='-Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort'
+	TOOLCHAIN='RUSTUP_TOOLCHAIN=nightly-2024-04-01'
+else
+	BUILD_STD=''
+	TOOLCHAIN=''
+endif
+
 RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
 
 # feature definition
@@ -104,8 +114,10 @@ build: build-banner check-var-BOARD check-var-SOC
 
 	cargo --version
 
-	cargo build --target $(TARGET) \
+	# NRF52/test -> "release-thin-lto", use "release" otherwise
+	$(TOOLCHAIN) cargo build --target $(TARGET) \
 		--features $(BUILD_FEATURES) \
+		$(BUILD_STD) \
 		--quiet --profile $(CUSTOM_PROFILE)
 
 	cp $(RAW_OUT) ./$(OUT_ELF)

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -35,15 +35,13 @@ SHOULD_BUILD_STD=$(shell python3 -c "p = True if '$(BOARD)' == 'nk3xn' and 'test
 ifeq ($(SHOULD_BUILD_STD), "True")
 	BUILD_STD='-Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort'
 	TOOLCHAIN='RUSTUP_TOOLCHAIN=nightly-2024-04-01'
-else
-	BUILD_STD=''
-	TOOLCHAIN=''
+	LITTLEFS_INTRINSICS_FEATURE='littlefs-software-intrinsics'
 endif
 
 RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
 
 # feature definition
-BUILD_FEATURES := board-$(BOARD),$(FEATURES),$(NO_DELOG_FEATURE)
+BUILD_FEATURES := board-$(BOARD),$(FEATURES),$(NO_DELOG_FEATURE),$(LITTLEFS_INTRINSICS_FEATURE)
 
 .PHONY: list build build-all reset program check doc check-all clean clean-all check-env set-vars lint-all lint
 


### PR DESCRIPTION
This ensures that panicking can be optimized out fully.
Panicking is now caught in a HardFault handler instead.

This is only enabled for LPC55 test releases. Other build configuration will use the  stable rust toolchain.

This needs a workaround for a linker error where the intrinsics used by littlefs are not found by the linker, so it disables use of intrinsics in littlefs when compiling std. See https://github.com/trussed-dev/littlefs2-sys/pull/12 