### PR TITLE
PIV: enable rsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memory-regions"
+version = "1.0.0"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2331,7 @@ dependencies = [
  "subtle",
  "trussed",
  "trussed-auth",
+ "trussed-rsa-alloc",
  "trussed-staging",
  "untrusted",
 ]

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -28,7 +28,7 @@ ndef-app = { path = "../ndef-app", optional = true }
 webcrypt = { version = "0.8.0", optional = true }
 secrets-app = { version = "0.13.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.1.1", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096", "admin-app"], optional = true }
-piv-authenticator = { version = "0.3.1", features = ["apdu-dispatch", "delog"], optional = true }
+piv-authenticator = { version = "0.3.1", features = ["apdu-dispatch", "delog", "rsa"], optional = true }
 provisioner-app = { path = "../provisioner-app", optional = true }
 se05x = { version = "0.1.1", optional = true}
 trussed-se050-backend = { version = "0.1.0", optional = true }


### PR DESCRIPTION
RSA support was put behind a flag for upstream merge but we forgot to enable this flag here