### PR TITLE
Update trussed, cbor-smol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,8 +455,7 @@ dependencies = [
 [[package]]
 name = "cbor-smol"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d516e3e353d5fc5ee156028f43224033430fd08ef05f8d5dba18a57a4ee5df49"
+source = "git+https://github.com/Nitrokey/cbor-smol.git?tag=v0.4.0-nitrokey.1#cdedd94cc62214f99f0e4bb35f9e7a67f50a45c1"
 dependencies = [
  "delog",
  "heapless",
@@ -3241,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed.git?rev=91c59a707220b7a060ca1b390fdeca69456f8c94#91c59a707220b7a060ca1b390fdeca69456f8c94"
+source = "git+https://github.com/Nitrokey/trussed.git?tag=v0.1.0-nitrokey.16#80c471381182c5263f8037800d7faf90e8ffd6b6"
 dependencies = [
  "aes",
  "bitflags 2.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,17 @@ memory-regions = { path = "components/memory-regions" }
 
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.9" }
+cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.1" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.10" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
+trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.16" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 
 # unreleased upstream changes
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch.git", tag = "v0.1.2-nitrokey.2" }
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "7d4ad69e64ad308944c012aef5b9cfd7654d9be8" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch.git", tag = "v0.1.1-nitrokey.3" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "91c59a707220b7a060ca1b390fdeca69456f8c94" }
 usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2", rev = "e6c46e7ba5ae19129e457a2182e40a439c0322fe" }


### PR DESCRIPTION
This patch pulls in two dependency updates:
- trussed removes unused syscalls.
- cbor-smol adds an inline-never hint that reduces binary size.