### PR TITLE
Fix nrf-builder version

### DIFF
--- a/utils/gen-commands-bd/src/main.rs
+++ b/utils/gen-commands-bd/src/main.rs
@@ -1,7 +1,27 @@
 use memory_regions::MemoryRegions;
-use utils::VERSION;
+use std::env;
+use utils::{VERSION, VERSION_STRING};
 
 fn main() {
+    let version_to_check = VERSION.encode();
+
+    let mut args = env::args();
+    args.next();
+    match args.next().as_deref() {
+        None => {}
+        Some("-O") => {
+            println!("{version_to_check}");
+            return;
+        }
+        Some("-o") => {
+            println!("{VERSION_STRING}");
+            return;
+        }
+        Some(s) => {
+            panic!("Cannot parse arguments: {s}");
+        }
+    }
+
     println!(
         "\
 options {{
@@ -25,7 +45,6 @@ section (0) {{
         major = VERSION.major,
         minor = VERSION.minor,
         patch = VERSION.patch,
-        version_to_check = VERSION.encode(),
         filesystem_start = MemoryRegions::LPC55.filesystem.start,
     );
 }

--- a/utils/nrf-builder/Makefile
+++ b/utils/nrf-builder/Makefile
@@ -26,7 +26,7 @@ SH_SIGN := $(NK3_BL_DIR)/sign.sh
 SH_UPLOAD := $(NK3_BL_DIR)/upload.sh
 SH_BL_SIGN := $(NK3_BL_DIR)/sign-bootloader.sh
 
-GEN_COMMANDS_RUN := cd ../gen-commands-bd && cargo run -- ../../runners/embedded/Cargo.toml ../../runners/embedded/profiles/nrf52-bootloader.toml
+GEN_COMMANDS_RUN := cd ../gen-commands-bd && cargo run --
 
 FW_VERSION := $(shell $(GEN_COMMANDS_RUN) -o)
 SIGN_VERSION := $(shell $(GEN_COMMANDS_RUN) -O)


### PR DESCRIPTION
The nrf-builder util still used the gen-command-bd to determine the versions of the firmware.