### PR TITLE
Refactor Soc trait, part II (storage)

### DIFF
--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -14,7 +14,6 @@ use ctaphid_dispatch::app::App as CtaphidApp;
 #[cfg(feature = "se050")]
 use embedded_hal::blocking::delay::DelayUs;
 use heapless::Vec;
-use littlefs2::path;
 use serde::{Deserialize, Serialize};
 use trussed::{
     backend::BackendId, client::ClientBuilder, interrupt::InterruptFlag, platform::Syscall,
@@ -147,9 +146,9 @@ impl admin_app::Config for OpcardConfig {
     ) -> Option<(&'static Path, &'static ResetSignalAllocation)> {
         match key {
             #[cfg(feature = "factory-reset")]
-            "" => Some((path!("opcard"), &OPCARD_RESET_SIGNAL)),
+            "" => Some((littlefs2::path!("opcard"), &OPCARD_RESET_SIGNAL)),
             #[cfg(feature = "se050")]
-            "use_se050_backend" => Some((path!("opcard"), &OPCARD_RESET_SIGNAL)),
+            "use_se050_backend" => Some((littlefs2::path!("opcard"), &OPCARD_RESET_SIGNAL)),
             _ => None,
         }
     }

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -260,30 +260,6 @@ mod app {
         });
     }
 
-    #[task(binds = MAILBOX, shared = [usb_classes], priority = 5)]
-    #[allow(unused_mut, unused_variables)]
-    fn mailbox(mut c: mailbox::Context) {
-        // debug_now!("mailbox: remaining stack size: {} bytes", super::msp() - 0x2000_0000);
-        #[cfg(feature = "log-serial")]
-        c.shared.usb_classes.lock(|usb_classes_maybe| {
-            match usb_classes_maybe.as_mut() {
-                Some(usb_classes) => {
-                    // usb_classes.serial.write(logs.as_bytes()).ok();
-                    usb_classes.serial.write(b"dummy test string\n").ok();
-                    // app::drain_log_to_serial(&mut usb_classes.serial);
-                }
-                _ => {}
-            }
-        });
-        // // let usb_classes = c.shared.usb_classes.as_mut().unwrap();
-
-        // let mailbox::Resources { usb_classes } = c.shared;
-        // let x: () = usb_classes;
-        // // if let Some(usb_classes) = usb_classes.as_mut() {
-        // //     usb_classes.serial.write(b"dummy test string\n").ok();
-        // // }
-    }
-
     #[task(binds = OS_EVENT, shared = [trussed], priority = 5)]
     fn os_event(mut c: os_event::Context) {
         // debug_now!("os event: remaining stack size: {} bytes", super::msp() - 0x2000_0000);

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -125,7 +125,7 @@ mod app {
             res.unwrap()
         };
 
-        let store = ERL::init_store(internal_flash, extflash, false, &mut init_status);
+        let store = ERL::store::init_store(internal_flash, extflash, false, &mut init_status);
 
         static NFC_CHANNEL: CcidChannel = Channel::new();
         let (_nfc_rq, nfc_rp) = NFC_CHANNEL.split().unwrap();

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -7,30 +7,26 @@ use apdu_dispatch::{
 use apps::InitStatus;
 use ctaphid_dispatch::{dispatch::Dispatch as CtaphidDispatch, types::Channel as CtapChannel};
 use interchange::Channel;
-use littlefs2::fs::Filesystem;
 use nfc_device::Iso14443;
 use ref_swap::OptionRefSwap;
-use soc::types::Soc as SocT;
 use trussed::interrupt::InterruptFlag;
-use types::{
-    usbnfc::{UsbClasses, UsbNfcInit},
-    Soc,
-};
 use usb_device::{
     bus::UsbBusAllocator,
     device::{UsbDeviceBuilder, UsbVidPid},
 };
 
-#[cfg(feature = "board-nk3am")]
-use soc::migrations::ftl_journal;
-#[cfg(feature = "board-nk3am")]
-use soc::migrations::ftl_journal::ifs_flash_old::FlashStorage as OldFlashStorage;
+use store::RunnerStore;
+use types::{
+    usbnfc::{UsbClasses, UsbNfcInit},
+    Soc,
+};
 
 extern crate delog;
 delog::generate_macros!();
 
 pub mod flash;
 pub mod runtime;
+pub mod store;
 pub mod traits;
 pub mod types;
 pub mod ui;
@@ -61,128 +57,6 @@ pub fn init_alloc() {
     const HEAP_SIZE: usize = 32 * 1024;
     static mut HEAP: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
     unsafe { ALLOCATOR.init(HEAP.as_ptr() as usize, HEAP_SIZE) }
-}
-
-pub fn init_store(
-    int_flash: <SocT as Soc>::InternalFlashStorage,
-    ext_flash: <SocT as Soc>::ExternalFlashStorage,
-    simulated_efs: bool,
-    status: &mut InitStatus,
-) -> types::RunnerStore {
-    let volatile_storage = types::VolatileStorage::new();
-
-    /* Step 1: let our stack-based filesystem objects transcend into higher
-    beings by blessing them with static lifetime
-    */
-    macro_rules! transcend {
-        ($global:expr, $content:expr) => {
-            unsafe {
-                $global.replace($content);
-                $global.as_mut().unwrap()
-            }
-        };
-    }
-
-    let ifs_storage = transcend!(types::INTERNAL_STORAGE, int_flash);
-    let ifs_alloc = transcend!(types::INTERNAL_FS_ALLOC, Filesystem::allocate());
-    let efs_storage = transcend!(types::EXTERNAL_STORAGE, ext_flash);
-    let efs_alloc = transcend!(types::EXTERNAL_FS_ALLOC, Filesystem::allocate());
-    let vfs_storage = transcend!(types::VOLATILE_STORAGE, volatile_storage);
-    let vfs_alloc = transcend!(types::VOLATILE_FS_ALLOC, Filesystem::allocate());
-
-    /* Step 2: try mounting each FS in turn */
-    if !Filesystem::is_mountable(ifs_storage) {
-        // handle provisioner
-        if cfg!(feature = "provisioner") {
-            info_now!("IFS mount failed - provisioner => formatting");
-            let _fmt_int = Filesystem::format(ifs_storage);
-        } else {
-            status.insert(InitStatus::INTERNAL_FLASH_ERROR);
-
-            // handle lpc55 boards
-            #[cfg(feature = "board-nk3xn")]
-            {
-                let _fmt_int = Filesystem::format(ifs_storage);
-                error_now!("IFS (lpc55) mount-fail");
-            }
-
-            // handle nRF42 boards
-            #[cfg(feature = "board-nk3am")]
-            {
-                error_now!("IFS (nrf42) mount-fail");
-
-                // regular mount failed, try mounting "old" (pre-journaling) IFS
-                let pac = unsafe { nrf52840_pac::Peripherals::steal() };
-                let mut old_ifs_storage = OldFlashStorage::new(pac.NVMC);
-                let mut old_ifs_alloc: littlefs2::fs::Allocation<OldFlashStorage> =
-                    Filesystem::allocate();
-                let old_mountable = Filesystem::is_mountable(&mut old_ifs_storage);
-
-                // we can mount the old ifs filesystem, thus we need to migrate
-                if old_mountable {
-                    let mounted_ifs = ftl_journal::migrate(
-                        &mut old_ifs_storage,
-                        &mut old_ifs_alloc,
-                        ifs_alloc,
-                        ifs_storage,
-                        efs_storage,
-                    );
-                    // migration went fine => use its resulting IFS
-                    if let Ok(()) = mounted_ifs {
-                        info_now!("migration ok, mounting IFS");
-                    // migration failed => format IFS
-                    } else {
-                        error_now!("failed migration, formatting IFS");
-                        let _fmt_ifs = Filesystem::format(ifs_storage);
-                    }
-                } else {
-                    info_now!("recovering from journal");
-                    // IFS and old-IFS cannot be mounted, try to recover from journal
-                    ifs_storage.recover_from_journal();
-                }
-            }
-        }
-    }
-
-    #[cfg(feature = "board-nk3am")]
-    ifs_storage.format_journal_blocks();
-
-    let ifs_ = Filesystem::mount(ifs_alloc, ifs_storage).expect("Could not bring up IFS!");
-    let ifs = transcend!(types::INTERNAL_FS, ifs_);
-
-    if !littlefs2::fs::Filesystem::is_mountable(efs_storage) {
-        let fmt_ext = littlefs2::fs::Filesystem::format(efs_storage);
-        if simulated_efs && fmt_ext == Err(littlefs2::io::Error::NoSpace) {
-            info_now!("Formatting simulated EFS failed as expected");
-        } else {
-            error_now!("EFS Mount Error, Reformat {:?}", fmt_ext);
-            status.insert(InitStatus::EXTERNAL_FLASH_ERROR);
-        }
-    };
-    let efs = match littlefs2::fs::Filesystem::mount(efs_alloc, efs_storage) {
-        Ok(efs_) => {
-            transcend!(types::EXTERNAL_FS, efs_)
-        }
-        Err(_e) => {
-            error!("EFS Mount Error {:?}", _e);
-            panic!("store");
-        }
-    };
-
-    if !littlefs2::fs::Filesystem::is_mountable(vfs_storage) {
-        littlefs2::fs::Filesystem::format(vfs_storage).ok();
-    }
-    let vfs = match littlefs2::fs::Filesystem::mount(vfs_alloc, vfs_storage) {
-        Ok(vfs_) => {
-            transcend!(types::VOLATILE_FS, vfs_)
-        }
-        Err(_e) => {
-            error!("VFS Mount Error {:?}", _e);
-            panic!("store");
-        }
-    };
-
-    types::RunnerStore::init_raw(ifs, efs, vfs)
 }
 
 pub fn init_usb_nfc<S: Soc>(
@@ -246,7 +120,7 @@ pub fn init_usb_nfc<S: Soc>(
 pub fn init_apps<S: Soc>(
     trussed: &mut types::Trussed<S>,
     init_status: InitStatus,
-    store: &types::RunnerStore,
+    store: &RunnerStore,
     nfc_powered: bool,
 ) -> types::Apps<S> {
     use trussed::platform::Store as _;
@@ -269,7 +143,7 @@ pub fn init_apps<S: Soc>(
     #[cfg(feature = "provisioner")]
     let provisioner = {
         let store = store.clone();
-        let int_flash_ref = unsafe { types::INTERNAL_STORAGE.as_mut().unwrap() };
+        let int_flash_ref = unsafe { store::INTERNAL_STORAGE.as_mut().unwrap() };
         let rebooter: fn() -> ! = S::reboot_to_firmware_update;
 
         apps::ProvisionerData {

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -120,7 +120,7 @@ pub fn init_usb_nfc<S: Soc>(
 pub fn init_apps<S: Soc>(
     trussed: &mut types::Trussed<S>,
     init_status: InitStatus,
-    store: &RunnerStore,
+    store: &RunnerStore<S>,
     nfc_powered: bool,
 ) -> types::Apps<S> {
     use trussed::platform::Store as _;
@@ -143,7 +143,7 @@ pub fn init_apps<S: Soc>(
     #[cfg(feature = "provisioner")]
     let provisioner = {
         let store = store.clone();
-        let int_flash_ref = unsafe { store::steal_internal_storage() };
+        let int_flash_ref = unsafe { store::steal_internal_storage::<S>() };
         let rebooter: fn() -> ! = S::reboot_to_firmware_update;
 
         apps::ProvisionerData {

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -143,7 +143,7 @@ pub fn init_apps<S: Soc>(
     #[cfg(feature = "provisioner")]
     let provisioner = {
         let store = store.clone();
-        let int_flash_ref = unsafe { store::INTERNAL_STORAGE.as_mut().unwrap() };
+        let int_flash_ref = unsafe { store::steal_internal_storage() };
         let rebooter: fn() -> ! = S::reboot_to_firmware_update;
 
         apps::ProvisionerData {

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -26,6 +26,7 @@ delog::generate_macros!();
 
 pub mod flash;
 pub mod runtime;
+#[macro_use]
 pub mod store;
 pub mod traits;
 pub mod types;

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![warn(trivial_casts, unused, unused_qualifications)]
 
 use apdu_dispatch::{
     dispatch::ApduDispatch,
@@ -21,7 +22,6 @@ use types::{
     Soc,
 };
 
-extern crate delog;
 delog::generate_macros!();
 
 pub mod flash;

--- a/runners/embedded/src/soc_lpc55/clock_controller.rs
+++ b/runners/embedded/src/soc_lpc55/clock_controller.rs
@@ -37,7 +37,7 @@ impl DynamicClockController {
         config
     }
     pub fn new(
-        adc: Adc<lpc55_hal::typestates::init_state::Enabled>,
+        adc: Adc<Enabled>,
         clocks: Clocks,
         pmc: Pmc,
         syscon: Syscon,

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -44,7 +44,7 @@ use super::{
     clock_controller::DynamicClockController,
     nfc::{self, NfcChip},
     spi::{self, FlashCs, FlashCsPin, Spi, SpiConfig},
-    types::I2C,
+    types::{Soc, I2C},
 };
 use crate::{
     flash::ExtFlashStorage,
@@ -57,7 +57,7 @@ use crate::{
     ui::UserInterface,
 };
 
-type UsbBusType = usb_device::bus::UsbBusAllocator<<super::types::Soc as types::Soc>::UsbBus>;
+type UsbBusType = usb_device::bus::UsbBusAllocator<<Soc as types::Soc>::UsbBus>;
 
 struct Peripherals {
     syscon: hal::Syscon,
@@ -493,8 +493,8 @@ impl Stage3 {
     #[inline(never)]
     pub fn next(
         mut self,
-        rng: hal::peripherals::rng::Rng<Unknown>,
-        prince: hal::peripherals::prince::Prince<Unknown>,
+        rng: Rng<Unknown>,
+        prince: Prince<Unknown>,
         flash: hal::peripherals::flash::Flash<Unknown>,
     ) -> Stage4 {
         info_now!("making flash");
@@ -683,7 +683,7 @@ pub struct Stage5 {
     nfc: Option<Iso14443<NfcChip>>,
     nfc_rp: CcidResponder<'static>,
     rng: Rng<hal::Enabled>,
-    store: RunnerStore<super::types::Soc>,
+    store: RunnerStore<Soc>,
     se050_timer: Timer<ctimer::Ctimer2<hal::Enabled>>,
     se050_i2c: Option<I2C>,
 }
@@ -769,8 +769,8 @@ pub struct Stage6 {
     basic: Basic,
     nfc: Option<Iso14443<NfcChip>>,
     nfc_rp: CcidResponder<'static>,
-    store: RunnerStore<super::types::Soc>,
-    trussed: Trussed<super::types::Soc>,
+    store: RunnerStore<Soc>,
+    trussed: Trussed<Soc>,
 }
 
 impl Stage6 {
@@ -866,9 +866,9 @@ impl Stage6 {
 
 pub struct All {
     pub basic: Basic,
-    pub usb_nfc: UsbNfc<super::types::Soc>,
-    pub trussed: Trussed<super::types::Soc>,
-    pub apps: Apps<super::types::Soc>,
+    pub usb_nfc: UsbNfc<Soc>,
+    pub trussed: Trussed<Soc>,
+    pub apps: Apps<Soc>,
     pub clock_controller: Option<DynamicClockController>,
 }
 

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -683,7 +683,7 @@ pub struct Stage5 {
     nfc: Option<Iso14443<NfcChip>>,
     nfc_rp: CcidResponder<'static>,
     rng: Rng<hal::Enabled>,
-    store: RunnerStore,
+    store: RunnerStore<super::types::Soc>,
     se050_timer: Timer<ctimer::Ctimer2<hal::Enabled>>,
     se050_i2c: Option<I2C>,
 }
@@ -769,7 +769,7 @@ pub struct Stage6 {
     basic: Basic,
     nfc: Option<Iso14443<NfcChip>>,
     nfc_rp: CcidResponder<'static>,
-    store: RunnerStore,
+    store: RunnerStore<super::types::Soc>,
     trussed: Trussed<super::types::Soc>,
 }
 

--- a/runners/embedded/src/soc_lpc55/init.rs
+++ b/runners/embedded/src/soc_lpc55/init.rs
@@ -48,11 +48,12 @@ use super::{
 };
 use crate::{
     flash::ExtFlashStorage,
+    store::RunnerStore,
     traits::{
         buttons::{self, Press},
         rgb_led::RgbLed,
     },
-    types::{self, usbnfc::UsbNfcInit as UsbNfc, Apps, RunnerStore, Trussed},
+    types::{self, usbnfc::UsbNfcInit as UsbNfc, Apps, Trussed},
     ui::UserInterface,
 };
 
@@ -606,7 +607,7 @@ impl Stage4 {
         );
         // TODO: poll iso14443
         let simulated_efs = external.is_ram();
-        let store = crate::init_store(internal, external, simulated_efs, &mut self.status);
+        let store = crate::store::init_store(internal, external, simulated_efs, &mut self.status);
         info!("mount end {} ms", self.basic.perf_timer.elapsed().0 / 1000);
 
         // return to slow freq

--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -1,10 +1,3 @@
-use littlefs2::{
-    fs::{Allocation, Filesystem},
-    io::Result as LfsResult,
-};
-
-use types::{ExternalFlashStorage, InternalFlashStorage};
-
 pub mod clock_controller;
 pub mod init;
 pub mod monotonic;
@@ -73,14 +66,4 @@ pub fn init(
         .next()
         .next(hal.rtc)
         .next(hal.usbhs)
-}
-
-pub fn prepare_ifs(_ifs: &mut types::InternalFilesystem) {}
-
-pub fn recover_ifs(
-    ifs_storage: &mut InternalFlashStorage,
-    _ifs_alloc: &mut Allocation<InternalFlashStorage>,
-    _efs_storage: &mut ExternalFlashStorage,
-) -> LfsResult<()> {
-    Filesystem::format(ifs_storage)
 }

--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -11,10 +11,8 @@ pub mod types;
 #[cfg_attr(feature = "board-nk3xn", path = "board_nk3xn/mod.rs")]
 pub mod board;
 
-use delog::delog;
-
 #[cfg(not(feature = "no-delog"))]
-delog!(Delogger, 3 * 1024, 512, crate::types::DelogFlusher);
+delog::delog!(Delogger, 3 * 1024, 512, crate::types::DelogFlusher);
 
 const SECURE_FIRMWARE_VERSION: u32 = utils::VERSION.encode();
 
@@ -25,11 +23,7 @@ pub fn init(
     #[cfg(feature = "log-rtt")]
     rtt_target::rtt_init_print!();
 
-    #[cfg(any(
-        feature = "log-rtt",
-        feature = "log-semihosting",
-        feature = "log-serial"
-    ))]
+    #[cfg(not(feature = "no-delog"))]
     Delogger::init_default(delog::LevelFilter::Debug, &crate::types::DELOG_FLUSHER).ok();
 
     crate::banner::<types::Soc>();

--- a/runners/embedded/src/soc_lpc55/mod.rs
+++ b/runners/embedded/src/soc_lpc55/mod.rs
@@ -1,3 +1,10 @@
+use littlefs2::{
+    fs::{Allocation, Filesystem},
+    io::Result as LfsResult,
+};
+
+use types::{ExternalFlashStorage, InternalFlashStorage};
+
 pub mod clock_controller;
 pub mod init;
 pub mod monotonic;
@@ -66,4 +73,14 @@ pub fn init(
         .next()
         .next(hal.rtc)
         .next(hal.usbhs)
+}
+
+pub fn prepare_ifs(_ifs: &mut types::InternalFilesystem) {}
+
+pub fn recover_ifs(
+    ifs_storage: &mut InternalFlashStorage,
+    _ifs_alloc: &mut Allocation<InternalFlashStorage>,
+    _efs_storage: &mut ExternalFlashStorage,
+) -> LfsResult<()> {
+    Filesystem::format(ifs_storage)
 }

--- a/runners/embedded/src/soc_lpc55/types.rs
+++ b/runners/embedded/src/soc_lpc55/types.rs
@@ -83,8 +83,6 @@ pub type ExternalFlashStorage = OptionalStorage<ExtFlashStorage<Spi, FlashCs>>;
 
 pub struct Soc {}
 impl crate::types::Soc for Soc {
-    type InternalFlashStorage = InternalFlashStorage;
-    type ExternalFlashStorage = ExternalFlashStorage;
     type UsbBus = lpc55_hal::drivers::UsbBus<UsbPeripheral>;
     type NfcDevice = super::nfc::NfcChip;
     type TrussedUI = UserInterface<RtcClock, ThreeButtons, RgbLed>;
@@ -109,47 +107,13 @@ impl crate::types::Soc for Soc {
     fn device_uuid() -> &'static Uuid {
         unsafe { &DEVICE_UUID }
     }
-
-    unsafe fn ifs_ptr() -> *mut Fs<Self::InternalFlashStorage> {
-        static mut IFS: MaybeUninit<Fs<InternalFlashStorage>> = MaybeUninit::uninit();
-        IFS.as_mut_ptr()
-    }
-
-    unsafe fn efs_ptr() -> *mut Fs<Self::ExternalFlashStorage> {
-        static mut EFS: MaybeUninit<Fs<ExternalFlashStorage>> = MaybeUninit::uninit();
-        EFS.as_mut_ptr()
-    }
-
-    unsafe fn ifs_storage() -> &'static mut Option<Self::InternalFlashStorage> {
-        static mut IFS_STORAGE: Option<InternalFlashStorage> = None;
-        &mut IFS_STORAGE
-    }
-
-    unsafe fn ifs_alloc() -> &'static mut Option<Allocation<Self::InternalFlashStorage>> {
-        static mut IFS_ALLOC: Option<Allocation<InternalFlashStorage>> = None;
-        &mut IFS_ALLOC
-    }
-
-    unsafe fn ifs() -> &'static mut Option<Filesystem<'static, Self::InternalFlashStorage>> {
-        static mut IFS: Option<Filesystem<InternalFlashStorage>> = None;
-        &mut IFS
-    }
-
-    unsafe fn efs_storage() -> &'static mut Option<Self::ExternalFlashStorage> {
-        static mut EFS_STORAGE: Option<ExternalFlashStorage> = None;
-        &mut EFS_STORAGE
-    }
-
-    unsafe fn efs_alloc() -> &'static mut Option<Allocation<Self::ExternalFlashStorage>> {
-        static mut EFS_ALLOC: Option<Allocation<ExternalFlashStorage>> = None;
-        &mut EFS_ALLOC
-    }
-
-    unsafe fn efs() -> &'static mut Option<Filesystem<'static, Self::ExternalFlashStorage>> {
-        static mut EFS: Option<Filesystem<ExternalFlashStorage>> = None;
-        &mut EFS
-    }
 }
+
+impl_storage_pointers!(
+    Soc,
+    Internal = InternalFlashStorage,
+    External = ExternalFlashStorage,
+);
 
 impl apps::Reboot for Soc {
     fn reboot() -> ! {

--- a/runners/embedded/src/soc_lpc55/types.rs
+++ b/runners/embedded/src/soc_lpc55/types.rs
@@ -76,10 +76,13 @@ where
 
 pub const MEMORY_REGIONS: &'static MemoryRegions = &MemoryRegions::LPC55;
 
+pub type InternalFlashStorage = InternalFilesystem;
+pub type ExternalFlashStorage = OptionalStorage<ExtFlashStorage<Spi, FlashCs>>;
+
 pub struct Soc {}
 impl crate::types::Soc for Soc {
-    type InternalFlashStorage = InternalFilesystem;
-    type ExternalFlashStorage = OptionalStorage<ExtFlashStorage<Spi, FlashCs>>;
+    type InternalFlashStorage = InternalFlashStorage;
+    type ExternalFlashStorage = ExternalFlashStorage;
     type UsbBus = lpc55_hal::drivers::UsbBus<UsbPeripheral>;
     type NfcDevice = super::nfc::NfcChip;
     type TrussedUI = UserInterface<RtcClock, ThreeButtons, RgbLed>;

--- a/runners/embedded/src/soc_lpc55/types.rs
+++ b/runners/embedded/src/soc_lpc55/types.rs
@@ -1,4 +1,4 @@
-use core::time::Duration;
+use core::{mem::MaybeUninit, time::Duration};
 
 use super::board::{button::ThreeButtons, led::RgbLed};
 use super::prince;
@@ -10,6 +10,7 @@ use embedded_hal::{blocking::delay::DelayUs, timer::CountDown};
 #[cfg(feature = "se050")]
 use embedded_time::duration::Microseconds;
 use embedded_time::duration::Milliseconds;
+use littlefs2::fs::{Allocation, Filesystem};
 #[cfg(feature = "se050")]
 use lpc55_hal::drivers::Timer;
 use lpc55_hal::{
@@ -29,6 +30,7 @@ use lpc55_hal::{
     },
     I2cMaster,
 };
+use trussed::store::Fs;
 
 use memory_regions::MemoryRegions;
 use utils::OptionalStorage;
@@ -106,6 +108,46 @@ impl crate::types::Soc for Soc {
 
     fn device_uuid() -> &'static Uuid {
         unsafe { &DEVICE_UUID }
+    }
+
+    unsafe fn ifs_ptr() -> *mut Fs<Self::InternalFlashStorage> {
+        static mut IFS: MaybeUninit<Fs<InternalFlashStorage>> = MaybeUninit::uninit();
+        IFS.as_mut_ptr()
+    }
+
+    unsafe fn efs_ptr() -> *mut Fs<Self::ExternalFlashStorage> {
+        static mut EFS: MaybeUninit<Fs<ExternalFlashStorage>> = MaybeUninit::uninit();
+        EFS.as_mut_ptr()
+    }
+
+    unsafe fn ifs_storage() -> &'static mut Option<Self::InternalFlashStorage> {
+        static mut IFS_STORAGE: Option<InternalFlashStorage> = None;
+        &mut IFS_STORAGE
+    }
+
+    unsafe fn ifs_alloc() -> &'static mut Option<Allocation<Self::InternalFlashStorage>> {
+        static mut IFS_ALLOC: Option<Allocation<InternalFlashStorage>> = None;
+        &mut IFS_ALLOC
+    }
+
+    unsafe fn ifs() -> &'static mut Option<Filesystem<'static, Self::InternalFlashStorage>> {
+        static mut IFS: Option<Filesystem<InternalFlashStorage>> = None;
+        &mut IFS
+    }
+
+    unsafe fn efs_storage() -> &'static mut Option<Self::ExternalFlashStorage> {
+        static mut EFS_STORAGE: Option<ExternalFlashStorage> = None;
+        &mut EFS_STORAGE
+    }
+
+    unsafe fn efs_alloc() -> &'static mut Option<Allocation<Self::ExternalFlashStorage>> {
+        static mut EFS_ALLOC: Option<Allocation<ExternalFlashStorage>> = None;
+        &mut EFS_ALLOC
+    }
+
+    unsafe fn efs() -> &'static mut Option<Filesystem<'static, Self::ExternalFlashStorage>> {
+        static mut EFS: Option<Filesystem<ExternalFlashStorage>> = None;
+        &mut EFS
     }
 }
 

--- a/runners/embedded/src/soc_lpc55/types.rs
+++ b/runners/embedded/src/soc_lpc55/types.rs
@@ -11,18 +11,16 @@ use embedded_hal::{blocking::delay::DelayUs, timer::CountDown};
 use embedded_time::duration::Microseconds;
 use embedded_time::duration::Milliseconds;
 use littlefs2::fs::{Allocation, Filesystem};
-#[cfg(feature = "se050")]
-use lpc55_hal::drivers::Timer;
 use lpc55_hal::{
     drivers::{
         pins::{Pio0_9, Pio1_14},
-        timer,
+        timer::Timer,
     },
     peripherals::{ctimer, flash, flexcomm::I2c5, rtc::Rtc, syscon},
     raw::{Interrupt, SCB},
     traits::flash::WriteErase,
     typestates::{
-        init_state,
+        init_state::Enabled,
         pin::{
             function::{FC5_CTS_SDA_SSEL0, FC5_TXD_SCL_MISO_WS},
             state::Special,
@@ -87,7 +85,7 @@ impl crate::types::Soc for Soc {
     type NfcDevice = super::nfc::NfcChip;
     type TrussedUI = UserInterface<RtcClock, ThreeButtons, RgbLed>;
     #[cfg(feature = "se050")]
-    type Se050Timer = TimerDelay<Timer<ctimer::Ctimer2<lpc55_hal::Enabled>>>;
+    type Se050Timer = TimerDelay<Timer<ctimer::Ctimer2<Enabled>>>;
     #[cfg(feature = "se050")]
     type Twi = I2C;
     #[cfg(not(feature = "se050"))]
@@ -141,12 +139,10 @@ impl apps::Reboot for Soc {
 }
 
 pub type DynamicClockController = super::clock_controller::DynamicClockController;
-pub type NfcWaitExtender =
-    timer::Timer<ctimer::Ctimer0<lpc55_hal::typestates::init_state::Enabled>>;
-pub type PerformanceTimer =
-    timer::Timer<ctimer::Ctimer4<lpc55_hal::typestates::init_state::Enabled>>;
+pub type NfcWaitExtender = Timer<ctimer::Ctimer0<Enabled>>;
+pub type PerformanceTimer = Timer<ctimer::Ctimer4<Enabled>>;
 
-pub type RtcClock = Rtc<init_state::Enabled>;
+pub type RtcClock = Rtc<Enabled>;
 
 impl Clock for RtcClock {
     fn uptime(&mut self) -> Duration {

--- a/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/backends.rs
+++ b/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/backends.rs
@@ -3,22 +3,17 @@ use littlefs2::driver::Storage;
 
 use lfs_backup::{BackupBackend, FSBackupError, Result, MAX_DUMP_BLOB_LENGTH};
 
-use crate::soc::types::Soc as SocT;
-use crate::types::Soc;
+use crate::soc::types::ExternalFlashStorage;
 
 pub struct EFSBackupBackend<'a> {
-    extflash: &'a mut <SocT as Soc>::ExternalFlashStorage,
+    extflash: &'a mut ExternalFlashStorage,
     initial_offset: usize,
     offset: usize,
     len: usize,
 }
 
 impl<'a> EFSBackupBackend<'a> {
-    pub fn new(
-        extflash: &'a mut <SocT as Soc>::ExternalFlashStorage,
-        offset: usize,
-        len: usize,
-    ) -> Self {
+    pub fn new(extflash: &'a mut ExternalFlashStorage, offset: usize, len: usize) -> Self {
         Self {
             extflash,
             initial_offset: offset.clone(),

--- a/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/migrations/ftl_journal/mod.rs
@@ -7,15 +7,14 @@ use backends::EFSBackupBackend;
 use ifs_flash_old::FlashStorage as OldFlashStorage;
 use lfs_backup::{BackupBackend, FSBackupError, Result};
 
-use crate::soc::{flash::FlashStorage, types::Soc as SocT};
-use crate::types::Soc;
+use crate::soc::{flash::FlashStorage, types::ExternalFlashStorage};
 
 pub fn migrate<'a>(
     old_ifs_storage: &mut OldFlashStorage,
     old_ifs_alloc: &mut littlefs2::fs::Allocation<OldFlashStorage>,
     ifs_alloc: &mut littlefs2::fs::Allocation<FlashStorage>,
     ifs_storage: &mut FlashStorage,
-    efs_storage: &mut <SocT as Soc>::ExternalFlashStorage,
+    efs_storage: &mut ExternalFlashStorage,
 ) -> Result<()> {
     let old_mounted = littlefs2::fs::Filesystem::mount(old_ifs_alloc, old_ifs_storage)
         .map_err(|_| FSBackupError::LittleFs2Err)?;

--- a/runners/embedded/src/soc_nrf52840/mod.rs
+++ b/runners/embedded/src/soc_nrf52840/mod.rs
@@ -1,4 +1,11 @@
+use littlefs2::{
+    fs::{Allocation, Filesystem},
+    io::Result as LfsResult,
+};
 use nrf52840_hal::clocks::Clocks;
+
+use migrations::ftl_journal::{self, ifs_flash_old::FlashStorage as OldFlashStorage};
+use types::{ExternalFlashStorage, InternalFlashStorage};
 
 #[cfg(not(any(feature = "board-nk3am")))]
 compile_error!("No NRF52840 board chosen!");
@@ -119,4 +126,47 @@ pub fn setup_usb_bus(
     let usbd_ref = unsafe { USBD.as_ref().unwrap() };
 
     usbd_ref
+}
+
+pub fn prepare_ifs(ifs: &mut flash::FlashStorage) {
+    ifs.format_journal_blocks();
+}
+
+pub fn recover_ifs(
+    ifs_storage: &mut InternalFlashStorage,
+    ifs_alloc: &mut Allocation<InternalFlashStorage>,
+    efs_storage: &mut ExternalFlashStorage,
+) -> LfsResult<()> {
+    error_now!("IFS (nrf42) mount-fail");
+
+    // regular mount failed, try mounting "old" (pre-journaling) IFS
+    let pac = unsafe { nrf52840_pac::Peripherals::steal() };
+    let mut old_ifs_storage = OldFlashStorage::new(pac.NVMC);
+    let mut old_ifs_alloc: littlefs2::fs::Allocation<OldFlashStorage> = Filesystem::allocate();
+    let old_mountable = Filesystem::is_mountable(&mut old_ifs_storage);
+
+    // we can mount the old ifs filesystem, thus we need to migrate
+    if old_mountable {
+        let mounted_ifs = ftl_journal::migrate(
+            &mut old_ifs_storage,
+            &mut old_ifs_alloc,
+            ifs_alloc,
+            ifs_storage,
+            efs_storage,
+        );
+        // migration went fine => use its resulting IFS
+        if let Ok(()) = mounted_ifs {
+            info_now!("migration ok, mounting IFS");
+            Ok(())
+        // migration failed => format IFS
+        } else {
+            error_now!("failed migration, formatting IFS");
+            Filesystem::format(ifs_storage)
+        }
+    } else {
+        info_now!("recovering from journal");
+        // IFS and old-IFS cannot be mounted, try to recover from journal
+        ifs_storage.recover_from_journal();
+        Ok(())
+    }
 }

--- a/runners/embedded/src/soc_nrf52840/types.rs
+++ b/runners/embedded/src/soc_nrf52840/types.rs
@@ -21,10 +21,13 @@ pub static mut DEVICE_UUID: Uuid = [0u8; 16];
 
 pub const MEMORY_REGIONS: &'static MemoryRegions = &MemoryRegions::NRF52;
 
+pub type InternalFlashStorage = super::flash::FlashStorage;
+pub type ExternalFlashStorage = ExtFlashStorage<Spim<SPIM3>, OutPin>;
+
 pub struct Soc {}
 impl crate::types::Soc for Soc {
-    type InternalFlashStorage = super::flash::FlashStorage;
-    type ExternalFlashStorage = ExtFlashStorage<Spim<SPIM3>, OutPin>;
+    type InternalFlashStorage = InternalFlashStorage;
+    type ExternalFlashStorage = ExternalFlashStorage;
     type UsbBus = Usbd<UsbPeripheral<'static>>;
     type NfcDevice = DummyNfc;
     type TrussedUI = super::board::TrussedUI;

--- a/runners/embedded/src/store.rs
+++ b/runners/embedded/src/store.rs
@@ -1,0 +1,152 @@
+use apps::InitStatus;
+use littlefs2::fs::{Allocation, Filesystem};
+use trussed::store;
+
+use crate::{
+    soc::types::Soc as SocT,
+    types::{Soc, VolatileStorage},
+};
+
+#[cfg(feature = "board-nk3am")]
+use crate::soc::migrations::ftl_journal;
+#[cfg(feature = "board-nk3am")]
+use crate::soc::migrations::ftl_journal::ifs_flash_old::FlashStorage as OldFlashStorage;
+
+pub static mut INTERNAL_STORAGE: Option<<SocT as Soc>::InternalFlashStorage> = None;
+pub static mut INTERNAL_FS_ALLOC: Option<Allocation<<SocT as Soc>::InternalFlashStorage>> = None;
+pub static mut INTERNAL_FS: Option<Filesystem<<SocT as Soc>::InternalFlashStorage>> = None;
+pub static mut EXTERNAL_STORAGE: Option<<SocT as Soc>::ExternalFlashStorage> = None;
+pub static mut EXTERNAL_FS_ALLOC: Option<Allocation<<SocT as Soc>::ExternalFlashStorage>> = None;
+pub static mut EXTERNAL_FS: Option<Filesystem<<SocT as Soc>::ExternalFlashStorage>> = None;
+pub static mut VOLATILE_STORAGE: Option<VolatileStorage> = None;
+pub static mut VOLATILE_FS_ALLOC: Option<Allocation<VolatileStorage>> = None;
+pub static mut VOLATILE_FS: Option<Filesystem<VolatileStorage>> = None;
+
+store!(
+    RunnerStore,
+    Internal: <SocT as Soc>::InternalFlashStorage,
+    External: <SocT as Soc>::ExternalFlashStorage,
+    Volatile: VolatileStorage
+);
+
+pub fn init_store(
+    int_flash: <SocT as Soc>::InternalFlashStorage,
+    ext_flash: <SocT as Soc>::ExternalFlashStorage,
+    simulated_efs: bool,
+    status: &mut InitStatus,
+) -> RunnerStore {
+    let volatile_storage = VolatileStorage::new();
+
+    /* Step 1: let our stack-based filesystem objects transcend into higher
+    beings by blessing them with static lifetime
+    */
+    macro_rules! transcend {
+        ($global:expr, $content:expr) => {
+            unsafe {
+                $global.replace($content);
+                $global.as_mut().unwrap()
+            }
+        };
+    }
+
+    let ifs_storage = transcend!(INTERNAL_STORAGE, int_flash);
+    let ifs_alloc = transcend!(INTERNAL_FS_ALLOC, Filesystem::allocate());
+    let efs_storage = transcend!(EXTERNAL_STORAGE, ext_flash);
+    let efs_alloc = transcend!(EXTERNAL_FS_ALLOC, Filesystem::allocate());
+    let vfs_storage = transcend!(VOLATILE_STORAGE, volatile_storage);
+    let vfs_alloc = transcend!(VOLATILE_FS_ALLOC, Filesystem::allocate());
+
+    /* Step 2: try mounting each FS in turn */
+    if !Filesystem::is_mountable(ifs_storage) {
+        // handle provisioner
+        if cfg!(feature = "provisioner") {
+            info_now!("IFS mount failed - provisioner => formatting");
+            let _fmt_int = Filesystem::format(ifs_storage);
+        } else {
+            status.insert(InitStatus::INTERNAL_FLASH_ERROR);
+
+            // handle lpc55 boards
+            #[cfg(feature = "board-nk3xn")]
+            {
+                let _fmt_int = Filesystem::format(ifs_storage);
+                error_now!("IFS (lpc55) mount-fail");
+            }
+
+            // handle nRF42 boards
+            #[cfg(feature = "board-nk3am")]
+            {
+                error_now!("IFS (nrf42) mount-fail");
+
+                // regular mount failed, try mounting "old" (pre-journaling) IFS
+                let pac = unsafe { nrf52840_pac::Peripherals::steal() };
+                let mut old_ifs_storage = OldFlashStorage::new(pac.NVMC);
+                let mut old_ifs_alloc: littlefs2::fs::Allocation<OldFlashStorage> =
+                    Filesystem::allocate();
+                let old_mountable = Filesystem::is_mountable(&mut old_ifs_storage);
+
+                // we can mount the old ifs filesystem, thus we need to migrate
+                if old_mountable {
+                    let mounted_ifs = ftl_journal::migrate(
+                        &mut old_ifs_storage,
+                        &mut old_ifs_alloc,
+                        ifs_alloc,
+                        ifs_storage,
+                        efs_storage,
+                    );
+                    // migration went fine => use its resulting IFS
+                    if let Ok(()) = mounted_ifs {
+                        info_now!("migration ok, mounting IFS");
+                    // migration failed => format IFS
+                    } else {
+                        error_now!("failed migration, formatting IFS");
+                        let _fmt_ifs = Filesystem::format(ifs_storage);
+                    }
+                } else {
+                    info_now!("recovering from journal");
+                    // IFS and old-IFS cannot be mounted, try to recover from journal
+                    ifs_storage.recover_from_journal();
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "board-nk3am")]
+    ifs_storage.format_journal_blocks();
+
+    let ifs_ = Filesystem::mount(ifs_alloc, ifs_storage).expect("Could not bring up IFS!");
+    let ifs = transcend!(INTERNAL_FS, ifs_);
+
+    if !littlefs2::fs::Filesystem::is_mountable(efs_storage) {
+        let fmt_ext = littlefs2::fs::Filesystem::format(efs_storage);
+        if simulated_efs && fmt_ext == Err(littlefs2::io::Error::NoSpace) {
+            info_now!("Formatting simulated EFS failed as expected");
+        } else {
+            error_now!("EFS Mount Error, Reformat {:?}", fmt_ext);
+            status.insert(InitStatus::EXTERNAL_FLASH_ERROR);
+        }
+    };
+    let efs = match littlefs2::fs::Filesystem::mount(efs_alloc, efs_storage) {
+        Ok(efs_) => {
+            transcend!(EXTERNAL_FS, efs_)
+        }
+        Err(_e) => {
+            error!("EFS Mount Error {:?}", _e);
+            panic!("store");
+        }
+    };
+
+    if !littlefs2::fs::Filesystem::is_mountable(vfs_storage) {
+        littlefs2::fs::Filesystem::format(vfs_storage).ok();
+    }
+    let vfs = match littlefs2::fs::Filesystem::mount(vfs_alloc, vfs_storage) {
+        Ok(vfs_) => {
+            transcend!(VOLATILE_FS, vfs_)
+        }
+        Err(_e) => {
+            error!("VFS Mount Error {:?}", _e);
+            panic!("store");
+        }
+    };
+
+    RunnerStore::init_raw(ifs, efs, vfs)
+}

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -185,11 +185,6 @@ impl delog::Flusher for DelogFlusher {
 
         #[cfg(feature = "log-semihosting")]
         cortex_m_semihosting::hprint!(_msg).ok();
-
-        // TODO: re-enable?
-        // #[cfg(feature = "log-serial")]
-        // see https://git.io/JLARR for the plan on how to improve this once we switch to RTIC 0.6
-        // rtic::pend(hal::raw::Interrupt::MAILBOX);
     }
 }
 

--- a/runners/embedded/src/types.rs
+++ b/runners/embedded/src/types.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::soc::types::Soc as SocT;
+use crate::store::RunnerStore;
 pub use apdu_dispatch::{
     command::SIZE as ApduCommandSize, response::SIZE as ApduResponseSize, App as ApduApp,
 };
@@ -10,12 +10,11 @@ pub use ctaphid_dispatch::app::App as CtaphidApp;
 #[cfg(feature = "se050")]
 use embedded_hal::blocking::delay::DelayUs;
 use embedded_time::duration::Milliseconds;
-use littlefs2::{const_ram_storage, fs::Allocation, fs::Filesystem};
+use littlefs2::const_ram_storage;
 use nfc_device::traits::nfc::Device as NfcDevice;
 use rand_chacha::ChaCha8Rng;
 use trussed::{
     platform::UserInterface,
-    store,
     types::{LfsResult, LfsStorage},
     Platform,
 };
@@ -82,7 +81,7 @@ impl<S: Soc> apps::Runner for Runner<S> {
     type Reboot = S;
     type Store = RunnerStore;
     #[cfg(feature = "provisioner")]
-    type Filesystem = <SocT as Soc>::InternalFlashStorage;
+    type Filesystem = <crate::soc::types::Soc as Soc>::InternalFlashStorage;
     type Twi = S::Twi;
     type Se050Timer = S::Se050Timer;
 
@@ -111,23 +110,6 @@ const_ram_storage!(
     path_max_plus_one_ty = littlefs2::consts::U256,
     result = LfsResult,
 );
-
-store!(
-    RunnerStore,
-    Internal: <SocT as Soc>::InternalFlashStorage,
-    External: <SocT as Soc>::ExternalFlashStorage,
-    Volatile: VolatileStorage
-);
-
-pub static mut INTERNAL_STORAGE: Option<<SocT as Soc>::InternalFlashStorage> = None;
-pub static mut INTERNAL_FS_ALLOC: Option<Allocation<<SocT as Soc>::InternalFlashStorage>> = None;
-pub static mut INTERNAL_FS: Option<Filesystem<<SocT as Soc>::InternalFlashStorage>> = None;
-pub static mut EXTERNAL_STORAGE: Option<<SocT as Soc>::ExternalFlashStorage> = None;
-pub static mut EXTERNAL_FS_ALLOC: Option<Allocation<<SocT as Soc>::ExternalFlashStorage>> = None;
-pub static mut EXTERNAL_FS: Option<Filesystem<<SocT as Soc>::ExternalFlashStorage>> = None;
-pub static mut VOLATILE_STORAGE: Option<VolatileStorage> = None;
-pub static mut VOLATILE_FS_ALLOC: Option<Allocation<VolatileStorage>> = None;
-pub static mut VOLATILE_FS: Option<Filesystem<VolatileStorage>> = None;
 
 pub struct RunnerPlatform<S: Soc> {
     pub rng: ChaCha8Rng,


### PR DESCRIPTION
This is a follow-up to:
- https://github.com/Nitrokey/nitrokey-3-firmware/pull/412

It makes the store implementation generic over the `Soc` implementation, meaning that we no longer use any `Soc as SocT` typedef constructs and that the library part of the embedded runner is fully generic over the `Soc`.  This also makes the storage initialization much easier to read, partly by moving the Soc-specific code like the NRF52 IFS migration out of the common implementation and into the soc module.

The downside is that the `static mut`s holding the storage components need concrete types and cannot be defined using generics, so they have to be provided by every `Soc` implementation.  I introduced a helper trait and a macro so it is not necessary to manually write the required boilerplate code.

I also tested a much nicer implementation using a single struct that gathers all statics used for storage and provides nice and safe(r) abstractions around them.   Unfortunately, it significantly increased binary size by several hundred bytes so I decided to stick with the plain `static mut`s for the time being.