### PR TITLE
Simplify and fix embedded runner Makefile

### DIFF
--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -114,7 +114,6 @@ build: build-banner check-var-BOARD check-var-SOC
 
 	$(GNU_TARGET)-objcopy -O binary ./$(OUT_ELF) ./$(OUT_BIN)
 	$(GNU_TARGET)-objcopy -O ihex ./$(OUT_ELF) ./$(OUT_IHEX)
-	$(GNU_TARGET)-readelf -l ./$(OUT_ELF) | grep LOAD
 
 check: check-banner check-var-BOARD check-var-SOC
 

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -25,7 +25,6 @@ LOG ?= build-$(BUILD_ID).err.log
 SYMBOLS ?= symbols-$(BUILD_ID).txt
 
 # input files and outputs
-SRCS = $(shell find src -name "*.rs" )
 OUT_BIN = $(ARTIFACTS)/runner-$(BUILD_ID).bin
 OUT_ELF = $(ARTIFACTS)/runner-$(BUILD_ID).elf
 OUT_IHEX = $(OUT_BIN).ihex
@@ -70,10 +69,6 @@ GET_TARGET = $(shell echo $(@) | cut -d '-' -f 1)
 %-nk3xn: $(ARTIFACTS)
 	$(MAKE) $(GET_TARGET) BOARD=nk3xn FEATURES=$(FEATURES)
 
-$(OUT_ELF): $(SRCS) build
-$(OUT_BIN): $(OUT_ELF)
-$(OUT_IHEX): $(OUT_ELF)
-
 check-var-%:
 	@if [ -z '${${*}}' ]; then echo 'FAIL: var: $* required!!!' && exit 1; fi
 
@@ -103,11 +98,10 @@ clean-all:
 #### actual build, clean, reset, program targets
 ###############################################################################
 
-build: build-banner $(SRCS) check-var-BOARD check-var-SOC
+build: build-banner check-var-BOARD check-var-SOC
 
 	cargo --version
 
-	# NRF52/test -> "release-thin-lto", use "release" otherwise
 	cargo build --target $(TARGET) \
 		--features $(BUILD_FEATURES) \
 		--quiet --profile $(CUSTOM_PROFILE)
@@ -122,7 +116,7 @@ build: build-banner $(SRCS) check-var-BOARD check-var-SOC
 	$(GNU_TARGET)-objcopy -O ihex ./$(OUT_ELF) ./$(OUT_IHEX)
 	$(GNU_TARGET)-readelf -l ./$(OUT_ELF) | grep LOAD
 
-check: check-banner $(SRCS) check-var-BOARD check-var-SOC
+check: check-banner check-var-BOARD check-var-SOC
 
 	cargo --version
 
@@ -130,7 +124,7 @@ check: check-banner $(SRCS) check-var-BOARD check-var-SOC
 		--features $(BUILD_FEATURES) \
 		--quiet --profile $(CUSTOM_PROFILE)
 
-doc: check-banner $(SRCS) check-var-BOARD check-var-SOC
+doc: check-banner check-var-BOARD check-var-SOC
 
 	cargo --version
 

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -29,17 +29,12 @@ SRCS = $(shell find src -name "*.rs" )
 OUT_BIN = $(ARTIFACTS)/runner-$(BUILD_ID).bin
 OUT_ELF = $(ARTIFACTS)/runner-$(BUILD_ID).elf
 OUT_IHEX = $(OUT_BIN).ihex
-CUSTOM_PROFILE=$(shell python3 -c "p = 'release-thin-lto' if '$(BOARD)' == 'nk3am' and 'test' in '$(COMMA_FEATURES)'.split(',')  else 'release'; print(p); " )
-NO_DELOG_FEATURE=$(shell python3 -c "print('no-delog') if 'no-delog' not in '$(BUILD_FEATURES)'.split(',') and 'log-semihosting' not in '$(BUILD_FEATURES)'.split(',') and 'log-rtt' not in '$(BUILD_FEATURES)'.split(',') else None; ")
+CUSTOM_PROFILE=$(shell python3 -c "p = 'release-thin-lto' if '$(BOARD)' == 'nk3am' and 'test' in '$(FEATURES)'.split(',')  else 'release'; print(p); " )
+NO_DELOG_FEATURE=$(shell python3 -c "print('no-delog') if 'no-delog' not in '$(FEATURES)'.split(',') and 'log-semihosting' not in '$(FEATURES)'.split(',') and 'log-rtt' not in '$(FEATURES)'.split(',') else None; ")
 RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
 
 # feature definition
-BUILD_FEATURES := board-$(BOARD) $(FEATURES)
-ALL_FEATURES = $(BUILD_FEATURES) $(NO_DELOG_FEATURE)
-# assemble comma-seperated list to pass to `cargo build`
-delim = ,
-space := $(null) #
-COMMA_FEATURES = $(subst $(space),$(delim),$(ALL_FEATURES))
+BUILD_FEATURES := board-$(BOARD),$(FEATURES),$(NO_DELOG_FEATURE)
 
 .PHONY: list build build-all reset program check doc check-all clean clean-all check-env set-vars
 
@@ -114,7 +109,7 @@ build: build-banner $(SRCS) check-var-BOARD check-var-SOC
 
 	# NRF52/test -> "release-thin-lto", use "release" otherwise
 	cargo build --target $(TARGET) \
-		--features $(COMMA_FEATURES) \
+		--features $(BUILD_FEATURES) \
 		--quiet --profile $(CUSTOM_PROFILE)
 
 	cp $(RAW_OUT) ./$(OUT_ELF)
@@ -132,7 +127,7 @@ check: check-banner $(SRCS) check-var-BOARD check-var-SOC
 	cargo --version
 
 	cargo check --target $(TARGET) \
-		--features $(COMMA_FEATURES) \
+		--features $(BUILD_FEATURES) \
 		--quiet --profile $(CUSTOM_PROFILE)
 
 doc: check-banner $(SRCS) check-var-BOARD check-var-SOC
@@ -140,7 +135,7 @@ doc: check-banner $(SRCS) check-var-BOARD check-var-SOC
 	cargo --version
 
 	cargo doc --target $(TARGET) \
-		--features $(COMMA_FEATURES) \
+		--features $(BUILD_FEATURES) \
 		--verbose
 
 clean: clean-banner check-var-BOARD

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -41,10 +41,12 @@ delim = ,
 space := $(null) #
 COMMA_FEATURES = $(subst $(space),$(delim),$(ALL_FEATURES))
 
-.PHONY: list build reset program check doc check-all clean clean-all check-env set-vars
+.PHONY: list build build-all reset program check doc check-all clean clean-all check-env set-vars
 
 # default target -> just build all "shortcuts"
-all: build-nk3am.bl build-nk3xn $(ARTIFACTS)
+all: build-all $(ARTIFACTS)
+
+build-all: build-nk3am.bl build-nk3xn
 
 check-all: check-nk3am.bl check-nk3xn
 

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -152,7 +152,7 @@ mod app {
 
             #[cfg(not(feature = "no-delog"))]
             if time > 1_200_000 {
-                lpc55::Delogger::flush();
+                embedded_runner_lib::Delogger::flush();
             }
 
             let (usb_activity, nfc_activity) = apps.lock(|apps| {

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -219,7 +219,7 @@ mod app {
 
         loop {
             #[cfg(not(feature = "no-delog"))]
-            Delogger::flush();
+            embedded_runner_lib::Delogger::flush();
 
             let (usb_activity, _nfc_activity) = apps.lock(|apps| {
                 apdu_dispatch.lock(|apdu_dispatch| {

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -30,7 +30,9 @@ pub mod types;
 compile_error!("No SoC chosen!");
 
 #[cfg(not(feature = "no-delog"))]
-delog::delog!(Delogger, 3 * 1024, 512, crate::types::DelogFlusher);
+use delog::delog;
+#[cfg(not(feature = "no-delog"))]
+delog!(Delogger, 3 * 1024, 512, crate::types::DelogFlusher);
 
 #[cfg(feature = "alloc")]
 #[global_allocator]


### PR DESCRIPTION
The automatic activation of the `no-delog` feature introduced in https://github.com/Nitrokey/nitrokey-3-firmware/pull/399 does not work properly because it tries to access the feature variable before it is defined.  This patch simplifies the Makefile by removing unused targets and redundant variables, fixes the feature computation, fixes compilation if the `no-delog` feature is not set and adds a `build-all` target similar to `check-all` etc.