### PR TITLE
Make check: add nkpk check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: check
 check:
 	$(MAKE) -C runners/embedded check-all
+	$(MAKE) -C runners/nkpk check
 	$(MAKE) -C runners/usbip check
 
 .PHONY: doc


### PR DESCRIPTION
I realized in #431 that `make check` didn't check the nkpk runner.