### PR TITLE
Make lint: add clippy lints and fix them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ RUN apt-get update && \
     apt-get install -y python3 python3-toml git curl llvm clang libclang-dev gcc-arm-none-eabi libc6-dev-i386 make wget zip
 RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
-RUN rustup component add llvm-tools-preview clippy
+RUN rustup component add llvm-tools-preview clippy rustfmt
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.72
+FROM rust:1.74
 RUN apt-get update && \
     apt-get install -y python3 python3-toml git curl llvm clang libclang-dev gcc-arm-none-eabi libc6-dev-i386 make wget zip
 RUN cargo install flip-link cargo-binutils

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ RUN apt-get update && \
     apt-get install -y python3 python3-toml git curl llvm clang libclang-dev gcc-arm-none-eabi libc6-dev-i386 make wget zip
 RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
-RUN rustup component add llvm-tools-preview
+RUN rustup component add llvm-tools-preview clippy
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: check
 check:
 	$(MAKE) -C runners/embedded check-all
+	$(MAKE) -C runners/nkpk check
 	$(MAKE) -C runners/usbip check
 
 .PHONY: doc

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ doc:
 .PHONY: lint
 lint:
 	cargo fmt -- --check
+	$(MAKE) -C runners/embedded lint-all
+	$(MAKE) -C runners/nkpk lint
+	$(MAKE) -C runners/usbip lint
+
 
 license.txt:
 	cargo run --release --manifest-path utils/collect-license-info/Cargo.toml -- runners/embedded/Cargo.toml "Nitrokey 3" > license.txt

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -71,7 +71,7 @@ impl admin_app::Config for Config {
         #[cfg(not(feature = "factory-reset"))]
         {
             _ = key;
-            return None;
+            None
         }
     }
 }

--- a/components/boards/src/init.rs
+++ b/components/boards/src/init.rs
@@ -240,6 +240,8 @@ pub fn init_trussed<B: Board, R: CryptoRng + RngCore>(
     #[cfg(not(feature = "se050"))]
     let seed = None;
 
+    // False positive due to cfg
+    #[allow(clippy::unnecessary_literal_unwrap)]
     let rng = ChaCha8Rng::from_seed(seed.unwrap_or_else(|| dev_rng.gen()));
     let _ = init_status;
 
@@ -253,7 +255,7 @@ pub fn init_trussed<B: Board, R: CryptoRng + RngCore>(
     let dispatch = if let Some(hw_key) = hw_key {
         Dispatch::with_hw_key(
             Location::Internal,
-            trussed::types::Bytes::from_slice(&hw_key).unwrap(),
+            trussed::types::Bytes::from_slice(hw_key).unwrap(),
             #[cfg(feature = "se050")]
             se050,
         )

--- a/components/boards/src/nk3am.rs
+++ b/components/boards/src/nk3am.rs
@@ -31,7 +31,7 @@ mod migrations;
 
 type OutPin = Pin<Output<PushPull>>;
 
-const MEMORY_REGIONS: &'static MemoryRegions = &MemoryRegions::NK3AM;
+const MEMORY_REGIONS: &MemoryRegions = &MemoryRegions::NK3AM;
 
 pub struct NK3AM;
 
@@ -183,7 +183,7 @@ pub fn init_pins(gpiote: GPIOTE, p0: P0, p1: P1) -> BoardGPIO {
     BoardGPIO {
         gpiote,
         rgb_led: [led_r, led_g, led_b],
-        touch: touch,
+        touch,
         se_pins: Some(se_pins),
         se_power: Some(se_pwr),
         flashnfc_spi: Some(flash_spi),

--- a/components/boards/src/nk3am/migrations/ftl_journal/backends.rs
+++ b/components/boards/src/nk3am/migrations/ftl_journal/backends.rs
@@ -16,7 +16,7 @@ impl<'a> EFSBackupBackend<'a> {
     pub fn new(extflash: &'a mut ExternalFlashStorage, offset: usize, len: usize) -> Self {
         Self {
             extflash,
-            initial_offset: offset.clone(),
+            initial_offset: offset,
             offset,
             len,
         }
@@ -68,7 +68,7 @@ impl<'a> BackupBackend for EFSBackupBackend<'a> {
         self.extflash
             .erase(self.initial_offset, self.len)
             .map_err(|_| FSBackupError::BackendEraseErr)?;
-        self.offset = self.initial_offset.clone();
+        self.offset = self.initial_offset;
         Ok(self.len)
     }
 

--- a/components/boards/src/nk3am/migrations/ftl_journal/mod.rs
+++ b/components/boards/src/nk3am/migrations/ftl_journal/mod.rs
@@ -9,7 +9,7 @@ use lfs_backup::{BackupBackend, FSBackupError, Result};
 
 use crate::nk3am::{ExternalFlashStorage, InternalFlashStorage};
 
-pub fn migrate<'a>(
+pub fn migrate(
     old_ifs_storage: &mut OldFlashStorage,
     old_ifs_alloc: &mut Allocation<OldFlashStorage>,
     ifs_alloc: &mut Allocation<InternalFlashStorage>,

--- a/components/boards/src/nk3xn.rs
+++ b/components/boards/src/nk3xn.rs
@@ -39,7 +39,7 @@ use prince::InternalFilesystem;
 use nfc::NfcChip;
 use spi::{FlashCs, Spi};
 
-pub const MEMORY_REGIONS: &'static MemoryRegions = &MemoryRegions::NK3XN;
+pub const MEMORY_REGIONS: &MemoryRegions = &MemoryRegions::NK3XN;
 
 pub type PwmTimer = ctimer::Ctimer3<Unknown>;
 pub type ButtonsTimer = ctimer::Ctimer1<Unknown>;

--- a/components/boards/src/nk3xn/button.rs
+++ b/components/boards/src/nk3xn/button.rs
@@ -54,10 +54,10 @@ where
             middle: user_button.is_high().ok().unwrap(),
         };
         Self {
-            user_button: user_button,
+            user_button,
             // wakeup_button: wakeup_button,
             last_state: buts,
-            timer: timer,
+            timer,
         }
     }
 }

--- a/components/boards/src/nk3xn/nfc.rs
+++ b/components/boards/src/nk3xn/nfc.rs
@@ -39,6 +39,8 @@ pub fn try_setup(
 
     let mut fm = FM11NC08::new(spi, nfc_cs, nfc_irq).enabled();
 
+    #[allow(clippy::eq_op, clippy::identity_op)]
+    // FIXME: use bitlfags to document what is being configured
     //                      no limit      2mA resistor    3.3V
     const REGU_CONFIG: u8 = (0b11 << 4) | (0b10 << 2) | (0b11 << 0);
     let current_regu_config = fm.read_reg(fm11nc08::Register::ReguCfg);
@@ -79,7 +81,7 @@ pub fn try_setup(
                 // (FWI[b4], SFGI[b4]), (256 * 16 / fc) * 2 ^ value
                 tb: 0x78,
                 tc: 0x00,
-                #[allow(clippy::eq_op)]
+                #[allow(clippy::eq_op, clippy::identity_op)]
                 // enable P-on IRQ    14443-4 mode
                 // FIXME: use bitlfags to document what is being configured
                 nfc: (0b0 << 1) | (0b00 << 2),

--- a/components/boards/src/nk3xn/nfc.rs
+++ b/components/boards/src/nk3xn/nfc.rs
@@ -79,7 +79,9 @@ pub fn try_setup(
                 // (FWI[b4], SFGI[b4]), (256 * 16 / fc) * 2 ^ value
                 tb: 0x78,
                 tc: 0x00,
+                #[allow(clippy::eq_op)]
                 // enable P-on IRQ    14443-4 mode
+                // FIXME: use bitlfags to document what is being configured
                 nfc: (0b0 << 1) | (0b00 << 2),
             },
             timer,

--- a/components/boards/src/nkpk.rs
+++ b/components/boards/src/nkpk.rs
@@ -15,7 +15,7 @@ use crate::{
 
 pub use nk3am::{init_pins, init_ui, power_handler};
 
-const MEMORY_REGIONS: &'static MemoryRegions = &MemoryRegions::NKPK;
+const MEMORY_REGIONS: &MemoryRegions = &MemoryRegions::NKPK;
 
 pub struct NKPK;
 

--- a/components/boards/src/soc/lpc55/clock_controller.rs
+++ b/components/boards/src/soc/lpc55/clock_controller.rs
@@ -36,9 +36,9 @@ const ADC_VOLTAGE_HIGH: u16 = 12_700;
 
 impl DynamicClockController {
     pub fn adc_configuration() -> adc::Config {
-        let mut config: adc::Config = Default::default();
-        config.conversion_delay = 96;
-        config
+        adc::Config {
+            conversion_delay: 96,
+        }
     }
     pub fn new(
         adc: Adc<Enabled>,
@@ -96,11 +96,11 @@ impl DynamicClockController {
         });
 
         DynamicClockController {
-            adc: adc,
-            signal_button: signal_button,
-            pmc: pmc,
-            clocks: clocks,
-            syscon: syscon,
+            adc,
+            signal_button,
+            pmc,
+            clocks,
+            syscon,
             decrease_count: 0,
         }
     }

--- a/components/boards/src/soc/nrf52.rs
+++ b/components/boards/src/soc/nrf52.rs
@@ -100,6 +100,7 @@ pub fn init_bootup(
         error!("REGOUT0 is not at 3.3V - external flash will fail!");
     }
 
+    #[allow(clippy::if_same_then_else)]
     if uicr.approtect.read().pall().is_enabled() {
         info!("UICR APPROTECT is ENABLED!");
     } else {

--- a/components/boards/src/soc/nrf52/flash.rs
+++ b/components/boards/src/soc/nrf52/flash.rs
@@ -110,7 +110,7 @@ impl<const START: usize, const END: usize> FlashStorage<START, END> {
 
         // erase journal block
         self.nvmc
-            .erase(addr as u32, addr + REAL_BLOCK_SIZE as u32)
+            .erase(addr, addr + REAL_BLOCK_SIZE as u32)
             .unwrap();
 
         // write meta-data
@@ -123,9 +123,7 @@ impl<const START: usize, const END: usize> FlashStorage<START, END> {
 
         // write lhs + rhs for journaled block
         if lhs_len > 0 {
-            self.nvmc
-                .write((addr + 16) as u32, &data[..lhs_len])
-                .unwrap();
+            self.nvmc.write(addr + 16, &data[..lhs_len]).unwrap();
         }
 
         let rhs_len = (REAL_BLOCK_SIZE - rhs_off) as u32;
@@ -178,7 +176,7 @@ impl<const START: usize, const END: usize> FlashStorage<START, END> {
 
         // erase target block inside littlefs2 space
         self.nvmc
-            .erase(src_addr as u32, (src_addr + REAL_BLOCK_SIZE as u32) as u32)
+            .erase(src_addr, src_addr + REAL_BLOCK_SIZE as u32)
             .unwrap();
 
         // write back journaled lhs + rhs
@@ -191,7 +189,7 @@ impl<const START: usize, const END: usize> FlashStorage<START, END> {
             self.nvmc
                 .write(
                     src_addr + rhs_off,
-                    &buf[((lhs_len + 16) as usize)..((rhs_len + 16 + lhs_len as usize) as usize)],
+                    &buf[((lhs_len + 16) as usize)..(rhs_len + 16 + lhs_len as usize)],
                 )
                 .unwrap();
         }

--- a/components/boards/src/store.rs
+++ b/components/boards/src/store.rs
@@ -33,11 +33,15 @@ const_ram_storage!(
     result = LfsResult,
 );
 
+// FIXME: document safety
+#[allow(clippy::missing_safety_doc)]
 #[cfg(feature = "provisioner")]
 pub unsafe fn steal_internal_storage<S: StoragePointers>() -> &'static mut S::InternalStorage {
     S::ifs_storage().as_mut().unwrap()
 }
 
+// FIXME: document safety
+#[allow(clippy::missing_safety_doc)]
 pub trait StoragePointers: 'static {
     type InternalStorage: Storage;
     type ExternalStorage: Storage;
@@ -149,9 +153,7 @@ impl<S: StoragePointers> RunnerStore<S> {
 
 impl<S> Clone for RunnerStore<S> {
     fn clone(&self) -> Self {
-        Self {
-            _marker: self._marker,
-        }
+        *self
     }
 }
 

--- a/components/lfs-backup/src/lfs_backup.rs
+++ b/components/lfs-backup/src/lfs_backup.rs
@@ -3,7 +3,6 @@ use littlefs2::fs::{Attribute, DirEntry, Filesystem};
 
 use littlefs2::path::{Path, PathBuf};
 
-use postcard;
 use serde::{Deserialize, Serialize};
 
 use heapless::Vec;
@@ -189,7 +188,7 @@ pub trait BackupBackend {
 
             // 'None' => no next item inside this directory, continue w/o adding 'current'
             // back to 'path_stack' implicitly means this subtree is done
-            if next_path == None {
+            if next_path.is_none() {
                 continue;
             }
 

--- a/components/ndef-app/src/ndef.rs
+++ b/components/ndef-app/src/ndef.rs
@@ -36,6 +36,12 @@ impl<'a> App<'a> {
     }
 }
 
+impl<'a> Default for App<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> iso7816::App for App<'a> {
     fn aid(&self) -> iso7816::Aid {
         iso7816::Aid::new(&[0xD2u8, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01])
@@ -80,14 +86,12 @@ impl<'a> app::App<CommandSize, ResponseSize> for App<'a> {
             }
             Instruction::ReadBinary => {
                 let offset = (((p1 & 0xef) as usize) << 8) | p2 as usize;
-                let len_to_read = if expected as usize > (self.reader.len() - offset) {
+                let len_to_read = if expected > (self.reader.len() - offset) {
                     self.reader.len() - offset
+                } else if expected > 0 {
+                    expected
                 } else {
-                    if expected > 0 {
-                        expected as usize
-                    } else {
-                        self.reader.len() - offset
-                    }
+                    self.reader.len() - offset
                 };
 
                 reply

--- a/components/nfc-device/src/iso14443.rs
+++ b/components/nfc-device/src/iso14443.rs
@@ -245,6 +245,7 @@ where
             }
             Block::SBlock(_cid, wtxgranted) => {
                 if wtxgranted {
+                    #[allow(clippy::if_same_then_else)]
                     if self.wtx_requested {
                         info!("wtx accepted");
                     } else {

--- a/components/utils/src/build.rs
+++ b/components/utils/src/build.rs
@@ -82,7 +82,7 @@ fn crate_version(cargo_pkg_version: &str) -> Version {
 
 fn tag_version() -> Option<Version> {
     option_env!("CI_COMMIT_TAG")
-        .map(|s| s.strip_prefix("v").expect("tag must start with v"))
+        .map(|s| s.strip_prefix('v').expect("tag must start with v"))
         .map(|s| Version::parse(s).expect("failed to parse version from tag"))
 }
 

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -44,6 +44,8 @@ build-all: build-nk3am.bl build-nk3xn
 
 check-all: check-nk3am.bl check-nk3xn
 
+lint-all: lint-nk3am.bl lint-nk3xn
+
 $(ARTIFACTS):
 	mkdir -p $@
 
@@ -122,6 +124,15 @@ check: check-banner check-var-BOARD check-var-SOC
 	cargo check --target $(TARGET) \
 		--features $(BUILD_FEATURES) \
 		--quiet --profile $(CUSTOM_PROFILE)
+
+lint: check-banner check-var-BOARD check-var-SOC
+
+	cargo --version
+
+	cargo clippy --target $(TARGET) \
+		--features $(BUILD_FEATURES) \
+		--quiet --profile $(CUSTOM_PROFILE)
+
 
 doc: check-banner check-var-BOARD check-var-SOC
 

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -35,7 +35,7 @@ RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
 # feature definition
 BUILD_FEATURES := board-$(BOARD),$(FEATURES),$(NO_DELOG_FEATURE)
 
-.PHONY: list build build-all reset program check doc check-all clean clean-all check-env set-vars
+.PHONY: list build build-all reset program check doc check-all clean clean-all check-env set-vars lint-all lint
 
 # default target -> just build all "shortcuts"
 all: build-all $(ARTIFACTS)

--- a/runners/embedded/build.rs
+++ b/runners/embedded/build.rs
@@ -83,7 +83,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let memory_x_dir =
         Path::new(&env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR not set"))
-            .join(&memory_x_infix);
+            .join(memory_x_infix);
     std::fs::create_dir_all(&memory_x_dir).ok();
     let memory_x = memory_x_dir.join("custom_memory.x");
 

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -226,7 +226,7 @@ mod app {
         let mask = inten & intstat;
         if mask != 0 {
             for i in 0..5 {
-                if mask & (1 << 2 * i) != 0 {
+                if mask & (1 << (2 * i)) != 0 {
                     // debug!("EP{}OUT", i);
                 }
                 if mask & (1 << (2 * i + 1)) != 0 {
@@ -269,9 +269,7 @@ mod app {
     #[task(binds = OS_EVENT, shared = [trussed], priority = 5)]
     fn os_event(mut c: os_event::Context) {
         // debug_now!("os event: remaining stack size: {} bytes", super::msp() - 0x2000_0000);
-        c.shared
-            .trussed
-            .lock(|trussed| runtime::run_trussed(trussed));
+        c.shared.trussed.lock(runtime::run_trussed);
     }
 
     #[task(shared = [trussed], priority = 1)]

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -264,6 +264,7 @@ impl Stage1 {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[inline(never)]
     pub fn next(
         mut self,
@@ -285,11 +286,10 @@ impl Stage1 {
         #[allow(unused_mut)]
         let mut adc = Some(if self.clocks.is_nfc_passive {
             // important to start Adc early in passive mode
-            hal::Adc::from(adc)
-                .configure(DynamicClockController::adc_configuration())
+            adc.configure(DynamicClockController::adc_configuration())
                 .enabled(pmc, syscon)
         } else {
-            hal::Adc::from(adc).enabled(pmc, syscon)
+            adc.enabled(pmc, syscon)
         });
 
         let mut delay_timer = Timer::new(
@@ -512,7 +512,7 @@ impl Stage3 {
         #[allow(unused_mut)]
         let mut rng = rng.enabled(syscon);
 
-        let mut prince = prince.enabled(&mut rng);
+        let mut prince = prince.enabled(&rng);
         prince::disable(&mut prince);
 
         let flash_gordon = FlashGordon::new(flash.enabled(syscon));
@@ -579,8 +579,7 @@ impl Stage4 {
 
         let external = if let Some(spi) = self.spi.take() {
             info_now!("using external flash");
-            let external_flash = self.setup_external_flash(spi);
-            OptionalStorage::from(external_flash)
+            self.setup_external_flash(spi)
         } else {
             info_now!("simulating external flash with RAM");
             OptionalStorage::default()

--- a/runners/nkpk/Makefile
+++ b/runners/nkpk/Makefile
@@ -24,3 +24,7 @@ build:
 .PHONY: check
 check:
 	cargo check --features $(ALL_FEATURES)
+
+.PHONY: lint
+lint:
+	cargo clippy --features $(ALL_FEATURES)

--- a/runners/nkpk/build.rs
+++ b/runners/nkpk/build.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let memory_x_dir =
         Path::new(&env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR not set"))
-            .join(&memory_x_infix);
+            .join(memory_x_infix);
     std::fs::create_dir_all(&memory_x_dir).ok();
     let memory_x = memory_x_dir.join("custom_memory.x");
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.74.1"
 components = ["rustfmt", "llvm-tools-preview"]
 targets = ["thumbv7em-none-eabihf", "thumbv8m.main-none-eabi"]


### PR DESCRIPTION
Following #438, I realized that `make lint` didn't run clippy. 
I added a clippy pass to `make lint` and fixed the warnings.

Some lints where deny-by-default, but they didn't seem to be the cause of any bug, and some were false positives due to our may possible `cfg` combinations.

It's very well possible that there are also some lints that affect features that are off by default and are not fixed here.