### PR TITLE
Update apdu-dispatch to fix GPG being locked when factory-reset is interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 - piv: Fix crash when changing PUK ([piv-authenticator#38][])
 - Fix LED during user presence check for NK3AM ([#93][])
 - fido-authenticator: Implement CTAP 2.1
+- OpenPGP: fix locking out after an aborted factory-reset operation ([#443][])
 
 [#93]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/93
 [#394]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/394
+[#443]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/443
 [fido-authenticator#38]: https://github.com/Nitrokey/fido-authenticator/issues/38
 [piv-authenticator#38]: https://github.com/Nitrokey/piv-authenticator/issues/38
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "apdu-dispatch"
 version = "0.1.2"
-source = "git+https://github.com/Nitrokey/apdu-dispatch.git?tag=v0.1.2-nitrokey.2#647029550ea204b7a714ddf8852b93e644f4a429"
+source = "git+https://github.com/Nitrokey/apdu-dispatch.git?tag=v0.1.2-nitrokey.3#3d4e2f67bacf93a9815fbdffb4149f91df7088d6"
 dependencies = [
  "delog",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "
 trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.18" }
 
 # unreleased upstream changes
-apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch.git", tag = "v0.1.2-nitrokey.2" }
+apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch.git", tag = "v0.1.2-nitrokey.3" }
 ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "a9f8003a1d9f05f9eea39e615b9159bc0613fcb5" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch.git", tag = "v0.1.1-nitrokey.3" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }


### PR DESCRIPTION
We cannot actually use trussed-dev main because there was a bump in version number making the patch incompatible with all the dependencies