### PR TITLE
Update fido2 dependencies for CTAP 2.0 interoperability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,18 +867,15 @@ dependencies = [
 [[package]]
 name = "ctap-types"
 version = "0.1.2"
-source = "git+https://github.com/trussed-dev/ctap-types.git?rev=7d4ad69e64ad308944c012aef5b9cfd7654d9be8#7d4ad69e64ad308944c012aef5b9cfd7654d9be8"
+source = "git+https://github.com/trussed-dev/ctap-types.git?rev=885bcebdb2683e7514fabc88e6df642d4f30eb3a#885bcebdb2683e7514fabc88e6df642d4f30eb3a"
 dependencies = [
  "bitflags 1.3.2",
  "cbor-smol",
- "cosey",
  "delog",
  "heapless",
  "heapless-bytes",
- "interchange 0.2.2",
  "iso7816",
  "serde",
- "serde-byte-array",
  "serde-indexed",
  "serde_bytes",
  "serde_repr",
@@ -1178,14 +1175,13 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.10#8c26ab39201191296ec6cc95c7409410bf12ee32"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?branch=ctap-2.0#ba0765ab4dd9e8c9581df183a21c38741c64a1c2"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",
  "ctaphid-dispatch",
  "delog",
  "heapless",
- "interchange 0.2.2",
  "iso7816",
  "serde",
  "serde-indexed",
@@ -3453,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/usbd-ctaphid.git?tag=v0.1.0-nitrokey.2#3f24df2f8b799eb203539c0e723854e8f7739f79"
+source = "git+https://github.com/Nitrokey/usbd-ctaphid.git?branch=cancel#d095946fdac80bead1f4c7185797d811bd88def4"
 dependencies = [
  "ctap-types",
  "ctaphid-dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ memory-regions = { path = "components/memory-regions" }
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.9" }
 cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.1" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.10" }
+# fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.10" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", branch = "ctap-2.0" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.17" }
@@ -28,9 +29,10 @@ p256-cortex-m4  = { git = "https://github.com/sosthene-nitrokey/p256-cortex-m4.g
 
 # unreleased upstream changes
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch.git", tag = "v0.1.2-nitrokey.2" }
-ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "7d4ad69e64ad308944c012aef5b9cfd7654d9be8" }
+ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "885bcebdb2683e7514fabc88e6df642d4f30eb3a" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch.git", tag = "v0.1.1-nitrokey.3" }
-usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }
+# usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", tag = "v0.1.0-nitrokey.2" }
+usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid.git", branch = "cancel" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }
 

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -23,7 +23,7 @@ trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked"
 
 # apps
 admin-app = "0.1.0"
-fido-authenticator = { version = "0.1.1", features = ["chunked", "dispatch"], optional = true }
+fido-authenticator = { version = "0.1.1", features = ["chunked", "ctap20", "dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
 webcrypt = { version = "0.8.0", optional = true }
 secrets-app = { version = "0.13.0", features = ["apdu-dispatch", "ctaphid"], optional = true }


### PR DESCRIPTION
This PR includes all required changes for the CTAP 2.0 interoperability tests with the NK3AN and the following metadata:

[metadata-nk3xn-ctap-2.0.test.json](https://github.com/Nitrokey/nitrokey-3-firmware/files/14385243/metadata-nk3xn-ctap-2.0.test.json)
