### PR TITLE
Fix remaining NK3_FW_DIR in makefile depenencies.

### DIFF
--- a/utils/nrf-builder/Makefile
+++ b/utils/nrf-builder/Makefile
@@ -141,7 +141,7 @@ clean:
 $(NK3_BL_KEY_DIR): $(KEY_DIR)
 	cp -r $< $(NK3_BL_KEY_DIR)
 
-$(BL_OUTPUT): $(NK3_FW_DIR) $(NK3_BL_KEY_DIR)
+$(BL_OUTPUT): $(NK3_BL_KEY_DIR)
 	$(MAKE) -C $(NK3_BL_DIR) build-bootloader TARGET=nk3am
 	cp $(NK3_BL_DIR)/mbr.hex mbr.hex
 	cp $(NK3_BL_DIR)/bootloader.hex bootloader.hex


### PR DESCRIPTION
Missed as part of https://github.com/Nitrokey/nitrokey-3-firmware/pull/448