### PR TITLE
Remove clock from UserPresence::check_user_presence

### DIFF
--- a/components/boards/src/nk3am/ui.rs
+++ b/components/boards/src/nk3am/ui.rs
@@ -1,5 +1,3 @@
-use core::time::Duration;
-
 use nrf52840_hal::{gpio::Level, pac, prelude::InputPin, pwm, pwm::Pwm};
 use trussed::platform::consent;
 
@@ -7,7 +5,6 @@ use super::OutPin;
 use crate::ui::{
     buttons::{Button, Press, UserPresence},
     rgb_led::{self, Color},
-    Clock,
 };
 
 pub struct HardwareButtons {
@@ -23,7 +20,7 @@ impl HardwareButtons {
 }
 
 impl UserPresence for HardwareButtons {
-    fn check_user_presence(&mut self, clock: &mut dyn Clock) -> consent::Level {
+    fn check_user_presence(&mut self) -> consent::Level {
         if self.is_pressed(Button::A) {
             consent::Level::Normal
         } else {

--- a/components/boards/src/nk3xn/button.rs
+++ b/components/boards/src/nk3xn/button.rs
@@ -1,7 +1,4 @@
-use crate::ui::{
-    buttons::{Button, Edge, Press, State, UserPresence},
-    Clock,
-};
+use crate::ui::buttons::{Button, Edge, Press, State, UserPresence};
 use core::convert::Infallible;
 use lpc55_hal::{
     drivers::{pins, timer},
@@ -80,7 +77,7 @@ impl<CTIMER> UserPresence for XpressoButtons<CTIMER>
 where
     CTIMER: ctimer::Ctimer<init_state::Enabled>,
 {
-    fn check_user_presence(&mut self, _clock: &mut dyn Clock) -> consent::Level {
+    fn check_user_presence(&mut self) -> consent::Level {
         let state = self.state();
         let press_result = self.wait_for_any_new_press();
         if press_result.is_ok() {

--- a/components/boards/src/ui.rs
+++ b/components/boards/src/ui.rs
@@ -90,7 +90,7 @@ impl<C: Clock, P: UserPresence, L: RgbLed> platform::UserInterface for UserInter
     fn check_user_presence(&mut self) -> consent::Level {
         if let Some(buttons) = &mut self.buttons {
             set_waiting(true);
-            let level = buttons.check_user_presence(&mut self.clock);
+            let level = buttons.check_user_presence();
             set_waiting(false);
             level
         } else {

--- a/components/boards/src/ui/buttons.rs
+++ b/components/boards/src/ui/buttons.rs
@@ -2,8 +2,6 @@ use core::convert::Infallible;
 
 use trussed::platform::consent;
 
-use super::Clock;
-
 /// Trio of buttons.
 ///
 /// Buttons A and B can't reliably be distinguished by user, as being top/bottom or left/right
@@ -28,7 +26,7 @@ pub struct State {
 }
 
 pub trait UserPresence {
-    fn check_user_presence(&mut self, clock: &mut dyn Clock) -> consent::Level;
+    fn check_user_presence(&mut self) -> consent::Level;
 }
 
 /// Implement on triple of buttons.


### PR DESCRIPTION
This fixes a warning due to unused code.