### PR TITLE
Only validate tags for the relevant project in CI

### DIFF
--- a/components/utils/src/build.rs
+++ b/components/utils/src/build.rs
@@ -19,11 +19,11 @@ use semver::{BuildMetadata, Prerelease, Version};
 
 const PATTERN_PRE: &str = r"rc\.\d+";
 
-pub fn version_string(cargo_pkg_version: &str) -> String {
+pub fn version_string(project: &str, cargo_pkg_version: &str) -> String {
     let mut version = crate_version(cargo_pkg_version);
     let test_prerelease = test_prerelease();
 
-    if let Some(tag_version) = tag_version() {
+    if let Some(tag_version) = tag_version(project) {
         assert_eq!(
             tag_version.major, version.major,
             "bad major component in tag"
@@ -80,7 +80,10 @@ fn crate_version(cargo_pkg_version: &str) -> Version {
     version
 }
 
-fn tag_version() -> Option<Version> {
+fn tag_version(project: &str) -> Option<Version> {
+    if option_env!("CI_PROJECT_NAME")? != project {
+        return None;
+    }
     option_env!("CI_COMMIT_TAG")
         .map(|s| s.strip_prefix('v').expect("tag must start with v"))
         .map(|s| Version::parse(s).expect("failed to parse version from tag"))

--- a/runners/embedded/build.rs
+++ b/runners/embedded/build.rs
@@ -62,7 +62,7 @@ fn generate_memory_x(outpath: &Path, template: &str, regions: &MemoryRegions) {
 fn main() -> Result<(), Box<dyn error::Error>> {
     println!(
         "cargo:rustc-env=NK3_FIRMWARE_VERSION={}",
-        utils::version_string(env!("CARGO_PKG_VERSION"))
+        utils::version_string("nitrokey-3-firmware", env!("CARGO_PKG_VERSION"))
     );
 
     // @todo: add profile 'platform' items and cross-check them here ...

--- a/runners/nkpk/build.rs
+++ b/runners/nkpk/build.rs
@@ -27,7 +27,7 @@ fn generate_memory_x(outpath: &Path, template: &str, regions: &MemoryRegions) {
 fn main() -> Result<(), Box<dyn error::Error>> {
     println!(
         "cargo:rustc-env=NKPK_FIRMWARE_VERSION={}",
-        utils::version_string(env!("CARGO_PKG_VERSION"))
+        utils::version_string("nitrokey-passkey-firmware", env!("CARGO_PKG_VERSION"))
     );
 
     if MEMORY_REGIONS.filesystem.start & 0x3ff != 0 {

--- a/runners/usbip/build.rs
+++ b/runners/usbip/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!(
         "cargo:rustc-env=USBIP_FIRMWARE_VERSION={}",
-        utils::version_string(env!("CARGO_PKG_VERSION"))
+        utils::version_string("nitrokey-3-firmware", env!("CARGO_PKG_VERSION"))
     );
 }


### PR DESCRIPTION
With this patch, we ignore tags when checking the version string in the CI unless we are currently building the relevant project for the runner. This means that the NKPK build does no longer fail the CI when running on a release tag for the NK3 firmware.