### PR TITLE
Add basic file size metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Cargo.lock
 /license.txt
 /commands.bd
 /manifest.json
+metrics.toml
 utils/nrf-debugging/binary
 utils/nrf-debugging/symbols.txt
 utils/nrf-debugging/ocd.conf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+binaries
 target
 **/.gdb_history
 ctap-2-1-pre.pdf

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ include:
 stages:
   - pull-github
   - build
+  - metrics
   - test
   - deploy
 
@@ -45,18 +46,6 @@ metadata:
   artifacts:
     paths:
       - artifacts
-
-check-firmware:
-  image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "push"'
-  tags:
-    - docker
-  stage: build
-  script:
-    - make -C runners/embedded check-all
-    - make -C runners/embedded check-all FEATURES=provisioner
-    - make -C runners/embedded check-all FEATURES=test
 
 check-usbip:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
@@ -104,7 +93,7 @@ build-nightly:
     - cargo build --release --manifest-path runners/usbip/Cargo.toml --features test
     - cargo build --release --manifest-path runners/usbip/Cargo.toml --features provisioner
 
-build-firmware:
+build-release-firmware:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "web"'
@@ -148,9 +137,7 @@ build-usbip:
     paths:
       - artifacts
 
-# This is a copy of build-firmware, but without the strict tag check guard and NK3AM build temporarily removed
-# FIXME Either this or build-firmware should be removed
-build-firmware-for-tests:
+build-firmware:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
@@ -158,19 +145,16 @@ build-firmware-for-tests:
     - docker
   stage: build
   script:
-    - git describe
-    - export VERSION=`git describe`
+    # Generate normal binaries
+    - make binaries
+    # Generate no-buttons firmware binaries for HIL
     - mkdir -p artifacts
     - make -C runners/embedded build-nk3xn FEATURES=no-buttons
     - cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/firmware-lpc55.bin
-    - make -C runners/embedded build-nk3xn FEATURES=test
-    - cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/firmware-test-lpc55.bin
     - make -C runners/embedded build-nk3xn FEATURES=provisioner,no-buttons
     - cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin artifacts/provisioner-lpc55.bin
     - make -C runners/embedded build-nk3am.bl FEATURES=no-buttons
     - cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex artifacts/firmware-nrf52.hex
-    - make -C runners/embedded build-nk3am.bl FEATURES=test
-    - cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex artifacts/firmware-test-nrf52.hex
     - make -C runners/embedded build-nk3am.bl FEATURES=provisioner,no-buttons
     - cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex artifacts/provisioner-nrf52.hex
     - make -C runners/nkpk build FEATURES=no-buttons
@@ -180,6 +164,22 @@ build-firmware-for-tests:
   artifacts:
     paths:
       - artifacts
+      - binaries
+
+# metrics stage
+
+metrics:
+  image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+  tags:
+    - docker
+  stage: metrics
+  script:
+    - repometrics generate > metrics.toml
+  artifacts:
+    paths:
+      - metrics.toml
 
 ###############################################################################
 # test stage
@@ -207,10 +207,6 @@ hardware-tests:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@git.nitrokey.com/nitrokey/nitrokey-hardware-test.git --recursive --branch v1.2.2
     - make -C nitrokey-hardware-test ci FW=../artifacts MODEL=$MODEL TESTS=pynitrokey,nk3test
     - cp nitrokey-hardware-test/artifacts/Nitrokey3TestSuite/report-junit.xml nitrokey-hardware-test/artifacts/report-junit.xml || true
-  dependencies:
-    - build-firmware-for-tests
-  needs:
-    - build-firmware-for-tests
   artifacts:
     when: always
     paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ RUN apt-get update && \
 RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
+RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 73d8bf0e8834b04182dc0dbb6019d998b4decf81
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,22 @@ lint:
 	$(MAKE) -C runners/nkpk lint
 	$(MAKE) -C runners/usbip lint
 
+.PHONY: binaries
+binaries:
+	mkdir -p binaries
+	$(MAKE) -C runners/embedded build-all FEATURES=
+	cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin binaries/firmware-nk3xn.bin
+	cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex binaries/firmware-nk3am.ihex
+	$(MAKE) -C runners/embedded build-all FEATURES=provisioner
+	cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin binaries/provisioner-nk3xn.bin
+	cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex binaries/provisioner-nk3am.ihex
+	$(MAKE) -C runners/embedded build-all FEATURES=test
+	cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin binaries/firmware-nk3xn-test.bin
+	cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex binaries/firmware-nk3am-test.ihex
+	$(MAKE) -C runners/nkpk build
+	cp runners/nkpk/artifacts/runner-nkpk.bin.ihex binaries/firmware-nkpk.ihex
+	$(MAKE) -C runners/nkpk build FEATURES=provisioner
+	cp runners/nkpk/artifacts/runner-nkpk.bin.ihex binaries/provisioner-nkpk.ihex
 
 license.txt:
 	cargo run --release --manifest-path utils/collect-license-info/Cargo.toml -- runners/embedded/Cargo.toml "Nitrokey 3" > license.txt

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ binaries:
 	$(MAKE) -C runners/nkpk build FEATURES=provisioner
 	cp runners/nkpk/artifacts/runner-nkpk.bin.ihex binaries/provisioner-nkpk.ihex
 
+.PHONY: metrics
+metrics: binaries
+	repometrics generate > metrics.toml
+
 license.txt:
 	cargo run --release --manifest-path utils/collect-license-info/Cargo.toml -- runners/embedded/Cargo.toml "Nitrokey 3" > license.txt
 

--- a/repometrics.toml
+++ b/repometrics.toml
@@ -1,0 +1,25 @@
+[gitlab]
+host = "git.nitrokey.com"
+project = "nitrokey/nitrokey-3-firmware"
+job = "metrics"
+artifact = "metrics.toml"
+
+[metrics.binary-size-nk3am]
+type = "file-size"
+input = "binaries/firmware-nk3am.ihex"
+
+[metrics.binary-size-nk3am-test]
+type = "file-size"
+input = "binaries/firmware-nk3am-test.ihex"
+
+[metrics.binary-size-nk3xn]
+type = "file-size"
+input = "binaries/firmware-nk3xn.bin"
+
+[metrics.binary-size-nk3xn-test]
+type = "file-size"
+input = "binaries/firmware-nk3xn-test.bin"
+
+[metrics.binary-size-nkpk]
+type = "file-size"
+input = "binaries/firmware-nkpk.ihex"


### PR DESCRIPTION
This is a first step to add metrics to this repository.  It uses [repometrics](https://github.com/Nitrokey/repometrics) to generate a `metrics.toml` file that lists the file size of the stable and test binaries of nk3am, nk3xn and nkpk.  Of course this should be expanded in the future to include additional metrics.  The `metrics.toml` file is stored as a Gitlab artifact, so it will be possible to compare the metrics of a PR against the current main once this is merged.

Currently, the `metrics.toml` file is subject to the regular artifact expiration rules.  I would vote for not expiring it because its size is less than 1 kB and it can potentially be useful in the future to be able to analyze changes over time.

This PR also combines the firmware compilation into one step so that cached compilation artifacts can be reused.  This means that the overall CI time should be slightly less with this change as we previously had duplicated work done in the `check-firmware` and `build-firmware-for-tests` steps.