### PR TITLE
Print metrics difference in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,10 +179,8 @@ metrics:
     - repometrics generate --cache > metrics.toml
   after_script:
     - !reference [notify_github, script] # use notify_github from include
-    - echo '```' > metrics-comment.txt
-    - repometrics run --base origin/main | tee --append metrics-comment.txt
-    - echo -n '```' >> metrics-comment.txt
-    - github-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.txt
+    - repometrics run --base origin/main --output-format markdown | tee --append metrics-comment.md
+    - github-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.md
   artifacts:
     paths:
       - metrics.toml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,10 +176,12 @@ metrics:
     - docker
   stage: metrics
   script:
-    - repometrics generate > metrics.toml
+    - repometrics generate --cache > metrics.toml
+    - repometrics run --base origin/main || true
   artifacts:
     paths:
       - metrics.toml
+    expire_in: never
 
 ###############################################################################
 # test stage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,12 @@ metrics:
   stage: metrics
   script:
     - repometrics generate --cache > metrics.toml
-    - repometrics run --base origin/main || true
+  after_script:
+    - !reference [notify_github, script] # use notify_github from include
+    - echo '```' > metrics-comment.txt
+    - repometrics run --base origin/main | tee --append metrics-comment.txt
+    - echo -n '```' >> metrics-comment.txt
+    - github-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.txt
   artifacts:
     paths:
       - metrics.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
 RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 73d8bf0e8834b04182dc0dbb6019d998b4decf81
+RUN cargo install --git https://github.com/Nitrokey/github-comment --rev ac9713f9d6d04ed03fb67d0199ebffc78ba5dcab --locked
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get update && \
 RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
-RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 73d8bf0e8834b04182dc0dbb6019d998b4decf81
 RUN cargo install --git https://github.com/Nitrokey/github-comment --rev ac9713f9d6d04ed03fb67d0199ebffc78ba5dcab --locked
+RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 5af5b7ccba820ec9a56bd21c4b4f00fd93534689 --locked
 WORKDIR /app

--- a/repometrics.toml
+++ b/repometrics.toml
@@ -1,3 +1,6 @@
+[defaults]
+significance_threshold = 0.01
+
 [gitlab]
 host = "git.nitrokey.com"
 project = "nitrokey/nitrokey-3-firmware"


### PR DESCRIPTION
Previously, we added some basic metrics to the CI.  This patch adds a comparison with the branch base to the CI output.  It also changes the expiry settings so that the metrics are always kept as artifacts.