### PR TITLE
Use extension crates instead of backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,16 +3313,14 @@ dependencies = [
 [[package]]
 name = "trussed-staging"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-staging.git?tag=v0.1.0-nitrokey-hmac256p256.3#c4d701ff1fe2d169ccf9c4a75c414faeb75c75db"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?rev=1240154c269cc3875552c46ddcbde2c9aeea5e51#1240154c269cc3875552c46ddcbde2c9aeea5e51"
 dependencies = [
  "chacha20poly1305",
  "delog",
- "hmac",
  "littlefs2",
  "rand_core",
  "serde",
  "serde-byte-array",
- "sha2",
  "trussed",
 ]
 
@@ -3625,7 +3623,7 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 [[package]]
 name = "webcrypt"
 version = "0.8.0"
-source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?rev=eb1898dc2e2104772f97e7c84ca77c68f18af946#eb1898dc2e2104772f97e7c84ca77c68f18af946"
+source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?rev=b1502d72035ecde0f16f9fff5c8da06139b90d11#b1502d72035ecde0f16f9fff5c8da06139b90d11"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",
@@ -3635,9 +3633,11 @@ dependencies = [
  "generic-array",
  "heapless",
  "heapless-bytes",
+ "hmac",
  "serde",
  "serde-indexed",
  "serde_bytes",
+ "sha2",
  "trussed",
  "trussed-rsa-alloc",
  "trussed-staging",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "admin-app"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/admin-app.git?tag=v0.1.0-nitrokey.10#c6c87cfad4d94c4910c87e870bae759330f6f634"
+source = "git+https://github.com/Nitrokey/admin-app.git?tag=v0.1.0-nitrokey.11#0ba0e766cba65a1fe7b0865f343de589e4202d82"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",
@@ -17,8 +17,8 @@ dependencies = [
  "serde",
  "strum_macros",
  "trussed",
- "trussed-se050-backend",
- "trussed-staging",
+ "trussed-manage",
+ "trussed-se050-manage",
 ]
 
 [[package]]
@@ -175,11 +175,15 @@ dependencies = [
  "serde",
  "trussed",
  "trussed-auth",
+ "trussed-chunked",
  "trussed-hkdf",
+ "trussed-manage",
  "trussed-rsa-alloc",
  "trussed-se050-backend",
+ "trussed-se050-manage",
  "trussed-staging",
  "trussed-usbip",
+ "trussed-wrap-key-to-file",
  "usbd-ctaphid",
  "utils",
  "webcrypt",
@@ -1175,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.12#3db1f6fdba65ede3a05e7f0e4489145e22cde3af"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.13#d55050a2491b0bd6cb6f72d1265ef038b8295c4f"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",
@@ -1188,8 +1192,8 @@ dependencies = [
  "serde_cbor",
  "sha2",
  "trussed",
+ "trussed-chunked",
  "trussed-hkdf",
- "trussed-staging",
 ]
 
 [[package]]
@@ -2107,8 +2111,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opcard"
-version = "1.3.0"
-source = "git+https://github.com/Nitrokey/opcard-rs?rev=1c844b74aa5bf245cd8223bc63b74b3a1f1f7b0f#1c844b74aa5bf245cd8223bc63b74b3a1f1f7b0f"
+version = "1.4.0"
+source = "git+https://github.com/Nitrokey/opcard-rs?tag=v1.4.0#0fec661b2d5718b97e942c229444ba6b8997ea7e"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -2124,8 +2128,9 @@ dependencies = [
  "subtle",
  "trussed",
  "trussed-auth",
+ "trussed-chunked",
  "trussed-rsa-alloc",
- "trussed-staging",
+ "trussed-wrap-key-to-file",
 ]
 
 [[package]]
@@ -2220,8 +2225,8 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piv-authenticator"
-version = "0.3.4"
-source = "git+https://github.com/Nitrokey/piv-authenticator?tag=v0.3.4#2c948a966f3e410e9a4cee3c351ca20b956383e0"
+version = "0.4.0"
+source = "git+https://github.com/trussed-dev/piv-authenticator.git?tag=v0.4.0#b69b394facdaaafcd41a5ea48dae34ed3680e9d5"
 dependencies = [
  "apdu-dispatch",
  "delog",
@@ -2235,8 +2240,8 @@ dependencies = [
  "subtle",
  "trussed",
  "trussed-auth",
+ "trussed-chunked",
  "trussed-rsa-alloc",
- "trussed-staging",
  "untrusted",
 ]
 
@@ -3252,6 +3257,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "trussed-chunked"
+version = "0.1.0"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=chunked-v0.1.0#5fc00717e6aa3f43d4f72fd3bd589f2de3a89b98"
+dependencies = [
+ "serde",
+ "serde-byte-array",
+ "trussed",
+]
+
+[[package]]
 name = "trussed-hkdf"
 version = "0.1.0"
 source = "git+https://github.com/Nitrokey/trussed-hkdf-backend.git?tag=v0.1.0#4a172d88c0fd4be713a863db0cb18266acb0da43"
@@ -3263,6 +3278,15 @@ dependencies = [
  "postcard 0.7.3",
  "serde",
  "sha2",
+ "trussed",
+]
+
+[[package]]
+name = "trussed-manage"
+version = "0.1.0"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=manage-v0.1.0#5fc00717e6aa3f43d4f72fd3bd589f2de3a89b98"
+dependencies = [
+ "serde",
  "trussed",
 ]
 
@@ -3282,8 +3306,8 @@ dependencies = [
 
 [[package]]
 name = "trussed-se050-backend"
-version = "0.2.0"
-source = "git+https://github.com/Nitrokey/trussed-se050-backend.git?tag=v0.2.0#f48a4f2bb2d3f5f9fba5d361401f91cd9c2ee8f1"
+version = "0.3.0"
+source = "git+https://github.com/Nitrokey/trussed-se050-backend.git?tag=v0.3.0#af9502a6e1d0359212101558cafa359e7f7bd5a9"
 dependencies = [
  "cbor-smol",
  "crypto-bigint",
@@ -3306,14 +3330,25 @@ dependencies = [
  "sha2",
  "trussed",
  "trussed-auth",
+ "trussed-manage",
  "trussed-rsa-alloc",
- "trussed-staging",
+ "trussed-se050-manage",
+ "trussed-wrap-key-to-file",
+]
+
+[[package]]
+name = "trussed-se050-manage"
+version = "0.1.0"
+source = "git+https://github.com/Nitrokey/trussed-se050-backend.git?tag=se050-manage-v0.1.0#d70748efbde217bb6f2a7b1ecd579d2480f7edc0"
+dependencies = [
+ "serde",
+ "trussed",
 ]
 
 [[package]]
 name = "trussed-staging"
-version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed-staging.git?rev=1240154c269cc3875552c46ddcbde2c9aeea5e51#1240154c269cc3875552c46ddcbde2c9aeea5e51"
+version = "0.2.0"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=v0.2.0#5fc00717e6aa3f43d4f72fd3bd589f2de3a89b98"
 dependencies = [
  "chacha20poly1305",
  "delog",
@@ -3322,6 +3357,9 @@ dependencies = [
  "serde",
  "serde-byte-array",
  "trussed",
+ "trussed-chunked",
+ "trussed-manage",
+ "trussed-wrap-key-to-file",
 ]
 
 [[package]]
@@ -3338,6 +3376,15 @@ dependencies = [
  "usbd-ccid",
  "usbd-ctaphid",
  "usbip-device",
+]
+
+[[package]]
+name = "trussed-wrap-key-to-file"
+version = "0.1.0"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=wrap-key-to-file-v0.1.0#5fc00717e6aa3f43d4f72fd3bd589f2de3a89b98"
+dependencies = [
+ "serde",
+ "trussed",
 ]
 
 [[package]]
@@ -3623,7 +3670,7 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 [[package]]
 name = "webcrypt"
 version = "0.8.0"
-source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?rev=b1502d72035ecde0f16f9fff5c8da06139b90d11#b1502d72035ecde0f16f9fff5c8da06139b90d11"
+source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?tag=v0.8.0-rc6#f636071c242f555318e5940c72b866e3a3a63000"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",
@@ -3640,7 +3687,6 @@ dependencies = [
  "sha2",
  "trussed",
  "trussed-rsa-alloc",
- "trussed-staging",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev =
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.13.0-rc2" }
-webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", rev = "eb1898dc2e2104772f97e7c84ca77c68f18af946" }
+webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", rev = "b1502d72035ecde0f16f9fff5c8da06139b90d11" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "1c844b74aa5bf245cd8223bc63b74b3a1f1f7b0f" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.4" }
-trussed-staging = { git = "https://github.com/Nitrokey/trussed-staging.git", tag = "v0.1.0-nitrokey-hmac256p256.3" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "1240154c269cc3875552c46ddcbde2c9aeea5e51" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "4b8191f248c26cb074cdac887c7f3f48f9c449a4" }
 trussed-hkdf = { git = "https://github.com/Nitrokey/trussed-hkdf-backend.git", tag = "v0.1.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "9732a9a3e98af72112286afdc9b7174c66c2869a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ version = "1.7.0-rc.1"
 memory-regions = { path = "components/memory-regions" }
 
 # forked
-admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.10" }
+admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.11" }
 cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.1" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.12" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.13" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
@@ -36,15 +36,19 @@ p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev =
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.13.0-rc2" }
-webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", rev = "b1502d72035ecde0f16f9fff5c8da06139b90d11" }
-opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "1c844b74aa5bf245cd8223bc63b74b3a1f1f7b0f" }
-piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator", tag = "v0.3.4" }
-trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "1240154c269cc3875552c46ddcbde2c9aeea5e51" }
+webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc6" }
+opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.4.0" }
+piv-authenticator = { git = "https://github.com/trussed-dev/piv-authenticator.git", tag = "v0.4.0" }
+trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
+trussed-manage = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "manage-v0.1.0" }
+trussed-wrap-key-to-file = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "wrap-key-to-file-v0.1.0" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.2.0" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "4b8191f248c26cb074cdac887c7f3f48f9c449a4" }
 trussed-hkdf = { git = "https://github.com/Nitrokey/trussed-hkdf-backend.git", tag = "v0.1.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "9732a9a3e98af72112286afdc9b7174c66c2869a" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.3" }
-trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "v0.2.0" }
+trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "v0.3.0" }
+trussed-se050-manage = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "se050-manage-v0.1.0" }
 
 [profile.release]
 codegen-units = 1

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -57,8 +57,7 @@ nkpk-provisioner = ["nkpk", "provisioner-app", "trussed/clients-3"]
 
 # apps
 secrets-app = ["dep:secrets-app", "backend-auth"]
-backend-staging-hmacsha256p256 = ["trussed-staging/hmacsha256p256"]
-webcrypt = ["dep:webcrypt", "backend-auth", "backend-rsa", "backend-staging-hmacsha256p256"]
+webcrypt = ["dep:webcrypt", "backend-auth", "backend-rsa"]
 fido-authenticator = ["dep:fido-authenticator", "usbd-ctaphid"]
 opcard = ["dep:opcard", "backend-rsa", "backend-auth"]
 piv-authenticator = ["dep:piv-authenticator", "backend-rsa", "backend-auth"]

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 apdu-dispatch = "0.1"
 bitflags = "2"
 ctaphid-dispatch = "0.1"
+embedded-hal = "0.2.7"
 heapless = "0.7"
+se05x = { version = "0.1.1", optional = true}
 serde = { version = "1.0.180", default-features = false }
 trussed = { version = "0.1", features = ["serde-extensions"]}
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"], optional = true }
@@ -20,7 +22,14 @@ littlefs2 = "0.4"
 trussed-auth = { version = "0.2.2", optional = true }
 trussed-hkdf = { version = "0.1.0" }
 trussed-rsa-alloc = { version = "0.1.0", optional = true }
-trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "chunked", "encrypted-chunked", "manage"] }
+trussed-se050-backend = { version = "0.3.0", optional = true }
+trussed-staging = { version = "0.2.0", features = ["wrap-key-to-file", "chunked", "manage"] }
+
+# Extensions
+trussed-chunked = "0.1.0"
+trussed-manage = "0.1.0"
+trussed-se050-manage = { version = "0.1.0", optional = true }
+trussed-wrap-key-to-file = "0.1.0"
 
 # apps
 admin-app = "0.1.0"
@@ -28,12 +37,9 @@ fido-authenticator = { version = "0.1.1", features = ["chunked", "dispatch"], op
 ndef-app = { path = "../ndef-app", optional = true }
 webcrypt = { version = "0.8.0", optional = true }
 secrets-app = { version = "0.13.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
-opcard = { version = "1.1.1", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096", "admin-app"], optional = true }
-piv-authenticator = { version = "0.3.1", features = ["apdu-dispatch", "delog", "rsa"], optional = true }
+opcard = { version = "1.4.0", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096", "admin-app"], optional = true }
+piv-authenticator = { version = "0.4.0", features = ["apdu-dispatch", "delog", "rsa"], optional = true }
 provisioner-app = { path = "../provisioner-app", optional = true }
-se05x = { version = "0.1.1", optional = true}
-trussed-se050-backend = { version = "0.2.0", optional = true }
-embedded-hal = "0.2.7"
 
 [dev-dependencies]
 cbor-smol = "0.4"
@@ -61,7 +67,7 @@ webcrypt = ["dep:webcrypt", "backend-auth", "backend-rsa"]
 fido-authenticator = ["dep:fido-authenticator", "usbd-ctaphid"]
 opcard = ["dep:opcard", "backend-rsa", "backend-auth"]
 piv-authenticator = ["dep:piv-authenticator", "backend-rsa", "backend-auth"]
-se050 = ["dep:se05x", "trussed-se050-backend", "admin-app/se050"]
+se050 = ["dep:se05x", "trussed-se050-backend", "trussed-se050-manage", "admin-app/se050"]
 
 # backends
 backend-auth = ["trussed-auth"]

--- a/components/apps/src/dispatch.rs
+++ b/components/apps/src/dispatch.rs
@@ -24,9 +24,9 @@ use embedded_hal::blocking::delay::DelayUs;
 #[cfg(feature = "se050")]
 use se05x::{se05x::Se05X, t1::I2CForT1};
 #[cfg(feature = "se050")]
-use trussed_se050_backend::{
-    manage::ManageExtension as Se050ManageExtension, Context as Se050Context, Se050Backend,
-};
+use trussed_se050_backend::{Context as Se050Context, Se050Backend};
+#[cfg(feature = "se050")]
+use trussed_se050_manage::Se050ManageExtension;
 
 #[cfg(feature = "backend-auth")]
 use trussed_auth::{AuthBackend, AuthContext, AuthExtension, MAX_HW_KEY_LEN};
@@ -34,11 +34,11 @@ use trussed_auth::{AuthBackend, AuthContext, AuthExtension, MAX_HW_KEY_LEN};
 #[cfg(feature = "backend-rsa")]
 use trussed_rsa_alloc::SoftwareRsa;
 
+use trussed_chunked::ChunkedExtension;
 use trussed_hkdf::{HkdfBackend, HkdfExtension};
-use trussed_staging::{
-    manage::ManageExtension, streaming::ChunkedExtension, wrap_key_to_file::WrapKeyToFileExtension,
-    StagingBackend, StagingContext,
-};
+use trussed_manage::ManageExtension;
+use trussed_staging::{StagingBackend, StagingContext};
+use trussed_wrap_key_to_file::WrapKeyToFileExtension;
 
 #[cfg(feature = "webcrypt")]
 use webcrypt::hmacsha256p256::{
@@ -328,15 +328,15 @@ impl<T: Twi, D: Delay> ExtensionDispatch for Dispatch<T, D> {
                         resources,
                     )
                 }
-                Extension::Se050Manage => ExtensionImpl::<
-                    trussed_se050_backend::manage::ManageExtension,
-                >::extension_request_serialized(
-                    self.se050.as_mut().ok_or(TrussedError::GeneralError)?,
-                    &mut ctx.core,
-                    &mut ctx.backends.se050,
-                    request,
-                    resources,
-                ),
+                Extension::Se050Manage => {
+                    ExtensionImpl::<Se050ManageExtension>::extension_request_serialized(
+                        self.se050.as_mut().ok_or(TrussedError::GeneralError)?,
+                        &mut ctx.core,
+                        &mut ctx.backends.se050,
+                        request,
+                        resources,
+                    )
+                }
                 _ => Err(TrussedError::RequestNotAvailable),
             },
             _ => Err(TrussedError::RequestNotAvailable),


### PR DESCRIPTION
This PR adapts to these changes that separate Trussed backends and extensions:
- https://github.com/Nitrokey/nitrokey-websmartcard-rust/pull/16
- https://github.com/trussed-dev/trussed-staging/pull/19
- https://github.com/Nitrokey/trussed-se050-backend/pull/13

Also depends on updated applications:
- https://github.com/Nitrokey/admin-app/pull/22
- https://github.com/Nitrokey/fido-authenticator/pull/72
- https://github.com/Nitrokey/opcard-rs/pull/199
- https://github.com/trussed-dev/piv-authenticator/pull/10
- https://github.com/Nitrokey/nitrokey-websmartcard-rust/pull/18