### PR TITLE
Use trussed-staging to provide hkdf extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.13#d55050a2491b0bd6cb6f72d1265ef038b8295c4f"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.14#db4a63dd582784c847520136da930f172330ef28"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",
@@ -3271,16 +3271,10 @@ dependencies = [
 
 [[package]]
 name = "trussed-hkdf"
-version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-hkdf-backend.git?tag=v0.1.0#4a172d88c0fd4be713a863db0cb18266acb0da43"
+version = "0.2.0"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=hkdf-v0.2.0#e016b25fbc49f3ba13272d58a9e9d47a16d8ea14"
 dependencies = [
- "heapless-bytes",
- "hkdf",
- "hmac",
- "log",
- "postcard 0.7.3",
  "serde",
- "sha2",
  "trussed",
 ]
 
@@ -3350,17 +3344,20 @@ dependencies = [
 
 [[package]]
 name = "trussed-staging"
-version = "0.2.0"
-source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=v0.2.0#5fc00717e6aa3f43d4f72fd3bd589f2de3a89b98"
+version = "0.3.0"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=v0.3.0#e016b25fbc49f3ba13272d58a9e9d47a16d8ea14"
 dependencies = [
  "chacha20poly1305",
  "delog",
+ "hkdf",
  "littlefs2",
  "rand_core",
  "serde",
  "serde-byte-array",
+ "sha2",
  "trussed",
  "trussed-chunked",
+ "trussed-hkdf",
  "trussed-manage",
  "trussed-wrap-key-to-file",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ memory-regions = { path = "components/memory-regions" }
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.11" }
 cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.1" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.13" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.14" }
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
@@ -42,9 +42,9 @@ piv-authenticator = { git = "https://github.com/trussed-dev/piv-authenticator.gi
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-manage = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "manage-v0.1.0" }
 trussed-wrap-key-to-file = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "wrap-key-to-file-v0.1.0" }
-trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.2.0" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.0" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "4b8191f248c26cb074cdac887c7f3f48f9c449a4" }
-trussed-hkdf = { git = "https://github.com/Nitrokey/trussed-hkdf-backend.git", tag = "v0.1.0" }
+trussed-hkdf = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hkdf-v0.2.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "9732a9a3e98af72112286afdc9b7174c66c2869a" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.3" }
 trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "v0.3.0" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -20,13 +20,13 @@ littlefs2 = "0.4"
 
 # Backends
 trussed-auth = { version = "0.2.2", optional = true }
-trussed-hkdf = { version = "0.1.0" }
 trussed-rsa-alloc = { version = "0.1.0", optional = true }
 trussed-se050-backend = { version = "0.3.0", optional = true }
-trussed-staging = { version = "0.2.0", features = ["wrap-key-to-file", "chunked", "manage"] }
+trussed-staging = { version = "0.3.0", features = ["wrap-key-to-file", "chunked", "hkdf", "manage"] }
 
 # Extensions
 trussed-chunked = "0.1.0"
+trussed-hkdf = "0.2.0"
 trussed-manage = "0.1.0"
 trussed-se050-manage = { version = "0.1.0", optional = true }
 trussed-wrap-key-to-file = "0.1.0"

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -659,11 +659,7 @@ impl<R: Runner> App<R> for FidoApp<R> {
     }
 
     fn backends(_runner: &R, _config: &Self::Config) -> &'static [BackendId<Backend>] {
-        &[
-            BackendId::Custom(Backend::Hkdf),
-            BackendId::Custom(Backend::Staging),
-            BackendId::Core,
-        ]
+        &[BackendId::Custom(Backend::Staging), BackendId::Core]
     }
 }
 


### PR DESCRIPTION
This patch updates fido-authenticator and trussed-hkdf to use the HkdfExtension provided by trussed-staging, getting rid of the separate trussed-hkdf backend.