### PR TITLE
Update to rust 1.77.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.74
+FROM rust:1.77.1
 RUN apt-get update && \
     apt-get install -y python3 python3-toml git curl llvm clang libclang-dev gcc-arm-none-eabi libc6-dev-i386 make wget zip
 RUN cargo install flip-link cargo-binutils

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.77.1"
 components = ["rustfmt", "llvm-tools-preview"]
 targets = ["thumbv7em-none-eabihf", "thumbv8m.main-none-eabi"]


### PR DESCRIPTION
This gives us C string literals (for future littlefs2 updates) and also the chunk_first api, which is very very nice for parsing.