### PR TITLE
Use upstream flexiber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,7 +1213,8 @@ dependencies = [
 [[package]]
 name = "flexiber"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/flexiber?tag=0.1.1.nitrokey#26f2c8047472cffde13d0be280a001733cbf44c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72c28a2ada3f3db32168659a9322b13e88bced18d8c9e5aeb217e56515cffce"
 dependencies = [
  "delog",
  "flexiber_derive",
@@ -1223,7 +1224,8 @@ dependencies = [
 [[package]]
 name = "flexiber_derive"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/flexiber?tag=0.1.1.nitrokey#26f2c8047472cffde13d0be280a001733cbf44c7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500c147f43e74e711720769dd7f37bc90dc6e0798621bfe5e3acb8239fd2f826"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ memory-regions = { path = "components/memory-regions" }
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.11" }
 cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.1" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.14" }
-flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.18" }


### PR DESCRIPTION
flexiber v0.1.1 has been released and contains all changes from our fork:
  https://github.com/Nitrokey/flexiber/releases/tag/0.1.1.nitrokey

```
$ git describe --contains 0.1.1.nitrokey --exclude 0.1.1.nitrokey
0.1.1~2^2
```