### PR TITLE
Revert the use of the nightly compiler

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,6 +82,7 @@ build-nightly:
       - RUSTUP_TOOLCHAIN: [stable, nightly]
   script:
     - cargo --version
+    - rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
     - make -C runners/embedded build-nk3am.bl
     - make -C runners/embedded build-nk3am.bl FEATURES=test
     - make -C runners/embedded build-nk3am.bl FEATURES=provisioner

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,4 @@ RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
 RUN cargo install --git https://github.com/Nitrokey/github-comment --rev ac9713f9d6d04ed03fb67d0199ebffc78ba5dcab --locked
 RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 5af5b7ccba820ec9a56bd21c4b4f00fd93534689 --locked
-RUN rustup install nightly-2024-04-01
-RUN rustup component add rust-src --toolchain nightly-2024-04-01
 WORKDIR /app

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -44,9 +44,6 @@ systick-monotonic = { version = "1.0.0", optional = true }
 ### Allocator
 alloc-cortex-m = { version = "0.4.3", optional = true }
 
-# littlefs2-sys for intrinsics feature
-littlefs2-sys = { version = "0.1.7", optional = true }
-
 [build-dependencies]
 cargo-lock = "7"
 memory-regions = "1"
@@ -62,9 +59,6 @@ develop-no-press = ["develop", "no-buttons"]
 provisioner = ["apps/nk3-provisioner", "boards/provisioner", "write-undefined-flash", "no-buttons", "apps/no-reset-time-window", "lpc55-hardware-checks"]
 
 no-delog = ["boards/no-delog", "delog/knock-it-off"]
-
-# Disable littlefs use of compiler intrinsics
-littlefs-software-intrinsics = ["dep:littlefs2-sys", "littlefs2-sys/software-intrinsics"]
 
 # Do not use encryption for the filesystem
 no-encrypted-storage = ["boards/no-encrypted-storage"]

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -32,10 +32,10 @@ CUSTOM_PROFILE=$(shell python3 -c "p = 'release-thin-lto' if '$(BOARD)' == 'nk3a
 NO_DELOG_FEATURE=$(shell python3 -c "print('no-delog') if 'no-delog' not in '$(FEATURES)'.split(',') and 'log-semihosting' not in '$(FEATURES)'.split(',') and 'log-rtt' not in '$(FEATURES)'.split(',') else None; ")
 
 SHOULD_BUILD_STD=$(shell python3 -c "p = True if '$(BOARD)' == 'nk3xn' and 'test' in '$(FEATURES)'.split(',') else False; print(p)")
-ifeq ($(SHOULD_BUILD_STD), True)
-	BUILD_STD=-Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort
-	export RUSTUP_TOOLCHAIN=nightly-2024-04-01
-	LITTLEFS_INTRINSICS_FEATURE=littlefs-software-intrinsics
+ifeq ($(SHOULD_BUILD_STD), "True")
+	BUILD_STD='-Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort'
+	TOOLCHAIN='RUSTUP_TOOLCHAIN=nightly-2024-04-01'
+	LITTLEFS_INTRINSICS_FEATURE='littlefs-software-intrinsics'
 endif
 
 RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
@@ -113,7 +113,7 @@ build: build-banner check-var-BOARD check-var-SOC
 	cargo --version
 
 	# NRF52/test -> "release-thin-lto", use "release" otherwise
-	cargo build --target $(TARGET) \
+	$(TOOLCHAIN) cargo build --target $(TARGET) \
 		--features $(BUILD_FEATURES) \
 		$(BUILD_STD) \
 		--quiet --profile $(CUSTOM_PROFILE)

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -35,13 +35,15 @@ SHOULD_BUILD_STD=$(shell python3 -c "p = True if '$(BOARD)' == 'nk3xn' and 'test
 ifeq ($(SHOULD_BUILD_STD), "True")
 	BUILD_STD='-Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort'
 	TOOLCHAIN='RUSTUP_TOOLCHAIN=nightly-2024-04-01'
-	LITTLEFS_INTRINSICS_FEATURE='littlefs-software-intrinsics'
+else
+	BUILD_STD=''
+	TOOLCHAIN=''
 endif
 
 RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
 
 # feature definition
-BUILD_FEATURES := board-$(BOARD),$(FEATURES),$(NO_DELOG_FEATURE),$(LITTLEFS_INTRINSICS_FEATURE)
+BUILD_FEATURES := board-$(BOARD),$(FEATURES),$(NO_DELOG_FEATURE)
 
 .PHONY: list build build-all reset program check doc check-all clean clean-all check-env set-vars lint-all lint
 

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -30,16 +30,6 @@ OUT_ELF = $(ARTIFACTS)/runner-$(BUILD_ID).elf
 OUT_IHEX = $(OUT_BIN).ihex
 CUSTOM_PROFILE=$(shell python3 -c "p = 'release-thin-lto' if '$(BOARD)' == 'nk3am' and 'test' in '$(FEATURES)'.split(',')  else 'release'; print(p); " )
 NO_DELOG_FEATURE=$(shell python3 -c "print('no-delog') if 'no-delog' not in '$(FEATURES)'.split(',') and 'log-semihosting' not in '$(FEATURES)'.split(',') and 'log-rtt' not in '$(FEATURES)'.split(',') else None; ")
-
-SHOULD_BUILD_STD=$(shell python3 -c "p = True if '$(BOARD)' == 'nk3xn' and 'test' in '$(FEATURES)'.split(',') else False; print(p)")
-ifeq ($(SHOULD_BUILD_STD), "True")
-	BUILD_STD='-Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort'
-	TOOLCHAIN='RUSTUP_TOOLCHAIN=nightly-2024-04-01'
-else
-	BUILD_STD=''
-	TOOLCHAIN=''
-endif
-
 RAW_OUT = $(CARGO_TARGET_DIR)/$(TARGET)/$(CUSTOM_PROFILE)/$(SOC)_runner
 
 # feature definition
@@ -114,10 +104,8 @@ build: build-banner check-var-BOARD check-var-SOC
 
 	cargo --version
 
-	# NRF52/test -> "release-thin-lto", use "release" otherwise
-	$(TOOLCHAIN) cargo build --target $(TARGET) \
+	cargo build --target $(TARGET) \
 		--features $(BUILD_FEATURES) \
-		$(BUILD_STD) \
 		--quiet --profile $(CUSTOM_PROFILE)
 
 	cp $(RAW_OUT) ./$(OUT_ELF)


### PR DESCRIPTION
Thanks to https://github.com/Nitrokey/cbor-smol/pull/4 this is not required anymore.