### PR TITLE
Remove static device UUID

### DIFF
--- a/components/boards/src/init.rs
+++ b/components/boards/src/init.rs
@@ -139,6 +139,7 @@ pub fn init_usb_nfc<B: Board>(
 }
 
 pub fn init_apps<B: Board>(
+    soc: &B::Soc,
     trussed: &mut Trussed<B>,
     init_status: InitStatus,
     store: &RunnerStore<B>,
@@ -177,6 +178,7 @@ pub fn init_apps<B: Board>(
     };
 
     let runner = Runner {
+        uuid: *soc.uuid(),
         is_efs_available: !nfc_powered,
         _marker: Default::default(),
     };

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -33,7 +33,7 @@ use rand_chacha::ChaCha8Rng;
 use trussed::{client::Syscall, Platform};
 
 use crate::{
-    soc::Soc,
+    soc::{Soc, Uuid},
     store::{RunnerStore, StoragePointers},
     ui::{buttons::UserPresence, rgb_led::RgbLed, UserInterface},
 };
@@ -76,6 +76,7 @@ pub trait Board: StoragePointers {
 }
 
 pub struct Runner<B> {
+    pub uuid: Uuid,
     pub is_efs_available: bool,
     pub _marker: PhantomData<B>,
 }
@@ -90,7 +91,7 @@ impl<B: Board> apps::Runner for Runner<B> {
     type Se050Timer = B::Se050Timer;
 
     fn uuid(&self) -> [u8; 16] {
-        *B::Soc::device_uuid()
+        self.uuid
     }
 
     fn is_efs_available(&self) -> bool {

--- a/components/boards/src/soc.rs
+++ b/components/boards/src/soc.rs
@@ -25,5 +25,5 @@ pub trait Soc: Reboot + 'static {
     const SOC_NAME: &'static str;
     const VARIANT: Variant;
 
-    fn device_uuid() -> &'static Uuid;
+    fn uuid(&self) -> &Uuid;
 }

--- a/components/boards/src/soc/lpc55.rs
+++ b/components/boards/src/soc/lpc55.rs
@@ -15,11 +15,19 @@ use lpc55_hal::{
 pub mod clock_controller;
 pub mod monotonic;
 
-pub static mut DEVICE_UUID: Uuid = [0u8; 16];
-
 type UsbPeripheral = lpc55_hal::peripherals::usbhs::EnabledUsbhsDevice;
 
-pub struct Lpc55;
+pub struct Lpc55 {
+    uuid: Uuid,
+}
+
+impl Lpc55 {
+    pub fn new() -> Self {
+        Self {
+            uuid: lpc55_hal::uuid(),
+        }
+    }
+}
 
 impl Soc for Lpc55 {
     type UsbBus = lpc55_hal::drivers::UsbBus<UsbPeripheral>;
@@ -33,11 +41,8 @@ impl Soc for Lpc55 {
     const SOC_NAME: &'static str = "lpc55";
     const VARIANT: Variant = Variant::Lpc55;
 
-    fn device_uuid() -> &'static Uuid {
-        #[allow(static_mut_refs)]
-        unsafe {
-            &DEVICE_UUID
-        }
+    fn uuid(&self) -> &Uuid {
+        &self.uuid
     }
 }
 

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -55,7 +55,7 @@ mod app {
 
         boards::init::init_logger::<Board>(VERSION_STRING);
 
-        nrf52::init_bootup(&ctx.device.FICR, &ctx.device.UICR, &mut ctx.device.POWER);
+        let soc = nrf52::init_bootup(&ctx.device.FICR, &ctx.device.UICR, &mut ctx.device.POWER);
 
         let mut board_gpio = nk3am::init_pins(ctx.device.GPIOTE, ctx.device.P0, ctx.device.P1);
 
@@ -103,6 +103,7 @@ mod app {
         );
 
         let apps = boards::init::init_apps(
+            &soc,
             &mut trussed,
             init_status,
             &store,

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -16,7 +16,7 @@ use boards::{
         ButtonsTimer, InternalFlashStorage, NK3xN, PwmTimer, I2C,
     },
     soc::{
-        lpc55::{clock_controller::DynamicClockController, Lpc55, DEVICE_UUID},
+        lpc55::{clock_controller::DynamicClockController, Lpc55},
         Soc,
     },
     store::{self, RunnerStore},
@@ -141,15 +141,6 @@ impl Stage0 {
 
     #[inline(never)]
     pub fn next(mut self, iocon: hal::Iocon<Unknown>, gpio: hal::Gpio<Unknown>) -> Stage1 {
-        unsafe {
-            DEVICE_UUID.copy_from_slice(&hal::uuid());
-            #[cfg(feature = "alpha")]
-            {
-                DEVICE_UUID[14] = 0xa1;
-                DEVICE_UUID[15] = 0xfa;
-            }
-        };
-
         let mut iocon = iocon.enabled(&mut self.peripherals.syscon);
         let mut gpio = gpio.enabled(&mut self.peripherals.syscon);
 
@@ -801,6 +792,7 @@ impl Stage6 {
     pub fn next(mut self, usbhs: Usbhs<Unknown>) -> All {
         self.perform_data_migrations();
         let apps = init::init_apps(
+            &Lpc55::new(),
             &mut self.trussed,
             self.status,
             &self.store,

--- a/runners/nkpk/src/main.rs
+++ b/runners/nkpk/src/main.rs
@@ -54,7 +54,7 @@ mod app {
 
         boards::init::init_logger::<Board>(VERSION_STRING);
 
-        nrf52::init_bootup(&ctx.device.FICR, &ctx.device.UICR, &mut ctx.device.POWER);
+        let soc = nrf52::init_bootup(&ctx.device.FICR, &ctx.device.UICR, &mut ctx.device.POWER);
 
         let board_gpio = nkpk::init_pins(ctx.device.GPIOTE, ctx.device.P0, ctx.device.P1);
 
@@ -92,6 +92,7 @@ mod app {
             boards::init::init_trussed(&mut dev_rng, store, user_interface, &mut init_status);
 
         let apps = boards::init::init_apps(
+            &soc,
             &mut trussed,
             init_status,
             &store,


### PR DESCRIPTION
This patch removes the static mut device UUID.  This has multiple benefits:  It removes some unsafe code, it makes the initialization order explicit and it makes the code compatible with Rust edition 2024.