### PR TITLE
Replace store statics 

### DIFF
--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -241,8 +241,6 @@ pub trait Runner {
 
     type Reboot: Reboot;
     type Store: trussed::store::Store;
-    #[cfg(feature = "provisioner-app")]
-    type Filesystem: trussed::types::LfsStorage + 'static;
     #[cfg(feature = "se050")]
     type Twi: se05x::t1::I2CForT1 + 'static;
     #[cfg(feature = "se050")]
@@ -284,8 +282,7 @@ type OpcardApp<R> = opcard::Card<Client<R>>;
 #[cfg(feature = "piv-authenticator")]
 type PivApp<R> = piv_authenticator::Authenticator<Client<R>>;
 #[cfg(feature = "provisioner-app")]
-type ProvisionerApp<R> =
-    provisioner_app::Provisioner<<R as Runner>::Store, <R as Runner>::Filesystem, Client<R>>;
+type ProvisionerApp<R> = provisioner_app::Provisioner<<R as Runner>::Store, Client<R>>;
 
 #[repr(u8)]
 pub enum CustomStatus {
@@ -959,8 +956,6 @@ impl<R: Runner> App<R> for PivApp<R> {
 #[cfg(feature = "provisioner-app")]
 pub struct ProvisionerData<R: Runner> {
     pub store: R::Store,
-    pub stolen_filesystem: &'static mut R::Filesystem,
-    pub nfc_powered: bool,
     pub rebooter: fn() -> !,
 }
 
@@ -973,14 +968,7 @@ impl<R: Runner> App<R> for ProvisionerApp<R> {
 
     fn with_client(runner: &R, trussed: Client<R>, data: Self::Data, _: &()) -> Self {
         let uuid = runner.uuid();
-        Self::new(
-            trussed,
-            data.store,
-            data.stolen_filesystem,
-            data.nfc_powered,
-            uuid,
-            data.rebooter,
-        )
+        Self::new(trussed, data.store, uuid, data.rebooter)
     }
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();

--- a/components/boards/src/init.rs
+++ b/components/boards/src/init.rs
@@ -166,15 +166,9 @@ pub fn init_apps<B: Board>(
     let provisioner = {
         use apps::Reboot as _;
         let store = store.clone();
-        let int_flash_ref = unsafe { crate::store::steal_internal_storage::<B>() };
         let rebooter: fn() -> ! = B::Soc::reboot_to_firmware_update;
 
-        apps::ProvisionerData {
-            store,
-            stolen_filesystem: int_flash_ref,
-            nfc_powered,
-            rebooter,
-        }
+        apps::ProvisionerData { store, rebooter }
     };
 
     let runner = Runner {

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -25,6 +25,7 @@ use apps::Dispatch;
 #[cfg(feature = "se050")]
 use embedded_hal::blocking::delay::DelayUs;
 use littlefs2::{
+    driver::Storage,
     fs::{Allocation, Filesystem},
     io::Result as LfsResult,
 };
@@ -34,7 +35,7 @@ use trussed::{client::Syscall, Platform};
 
 use crate::{
     soc::{Soc, Uuid},
-    store::{RunnerStore, StoragePointers},
+    store::RunnerStore,
     ui::{buttons::UserPresence, rgb_led::RgbLed, UserInterface},
 };
 
@@ -42,8 +43,11 @@ pub type Trussed<B> =
     trussed::Service<RunnerPlatform<B>, Dispatch<<B as Board>::Twi, <B as Board>::Se050Timer>>;
 pub type Apps<B> = apps::Apps<Runner<B>>;
 
-pub trait Board: StoragePointers {
+pub trait Board {
     type Soc: Soc;
+
+    type InternalStorage: Storage + 'static;
+    type ExternalStorage: Storage + 'static;
 
     type NfcDevice: NfcDevice;
     type Buttons: UserPresence;

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -85,8 +85,6 @@ impl<B: Board> apps::Runner for Runner<B> {
     type Syscall = RunnerSyscall<B::Soc>;
     type Reboot = B::Soc;
     type Store = RunnerStore<B>;
-    #[cfg(feature = "provisioner")]
-    type Filesystem = B::InternalStorage;
     type Twi = B::Twi;
     type Se050Timer = B::Se050Timer;
 

--- a/components/boards/src/nk3am.rs
+++ b/components/boards/src/nk3am.rs
@@ -17,7 +17,6 @@ use nrf52840_pac::{FICR, GPIOTE, P0, P1, POWER, PWM0, PWM1, PWM2, SPIM3, TIMER1,
 use crate::{
     flash::ExtFlashStorage,
     soc::nrf52::{flash::FlashStorage, rtic_monotonic::RtcMonotonic, Nrf52},
-    store::impl_storage_pointers,
     ui::UserInterface,
     Board,
 };
@@ -37,6 +36,9 @@ pub struct NK3AM;
 
 impl Board for NK3AM {
     type Soc = Nrf52;
+
+    type InternalStorage = InternalFlashStorage;
+    type ExternalStorage = ExternalFlashStorage;
 
     type NfcDevice = DummyNfc;
     type Buttons = HardwareButtons;
@@ -101,12 +103,6 @@ impl Board for NK3AM {
 pub type InternalFlashStorage =
     FlashStorage<{ MEMORY_REGIONS.filesystem.start }, { MEMORY_REGIONS.filesystem.end }>;
 pub type ExternalFlashStorage = ExtFlashStorage<Spim<SPIM3>, OutPin>;
-
-impl_storage_pointers!(
-    NK3AM,
-    Internal = InternalFlashStorage,
-    External = ExternalFlashStorage,
-);
 
 pub struct DummyNfc;
 

--- a/components/boards/src/nk3xn.rs
+++ b/components/boards/src/nk3xn.rs
@@ -20,7 +20,7 @@ use lpc55_hal::{
 use memory_regions::MemoryRegions;
 use utils::OptionalStorage;
 
-use crate::{flash::ExtFlashStorage, soc::lpc55::Lpc55, store::impl_storage_pointers, Board};
+use crate::{flash::ExtFlashStorage, soc::lpc55::Lpc55, Board};
 
 pub mod button;
 pub mod led;
@@ -59,6 +59,9 @@ pub struct NK3xN;
 impl Board for NK3xN {
     type Soc = Lpc55;
 
+    type InternalStorage = InternalFlashStorage;
+    type ExternalStorage = ExternalFlashStorage;
+
     type NfcDevice = NfcChip;
     type Buttons = button::ThreeButtons;
     type Led = led::RgbLed;
@@ -78,12 +81,6 @@ impl Board for NK3xN {
 
 pub type InternalFlashStorage = InternalFilesystem;
 pub type ExternalFlashStorage = OptionalStorage<ExtFlashStorage<Spi, FlashCs>>;
-
-impl_storage_pointers!(
-    NK3xN,
-    Internal = InternalFlashStorage,
-    External = ExternalFlashStorage,
-);
 
 #[cfg(feature = "se050")]
 pub struct TimerDelay<T>(pub T);

--- a/components/boards/src/nkpk.rs
+++ b/components/boards/src/nkpk.rs
@@ -9,7 +9,6 @@ use super::nk3am::{
 };
 use crate::{
     soc::nrf52::{flash::FlashStorage, Nrf52},
-    store::impl_storage_pointers,
     Board,
 };
 
@@ -21,6 +20,9 @@ pub struct NKPK;
 
 impl Board for NKPK {
     type Soc = Nrf52;
+
+    type InternalStorage = InternalFlashStorage;
+    type ExternalStorage = ExternalFlashStorage;
 
     type NfcDevice = DummyNfc;
     type Buttons = HardwareButtons;
@@ -52,9 +54,3 @@ pub type InternalFlashStorage =
     FlashStorage<{ MEMORY_REGIONS.filesystem.start }, { MEMORY_REGIONS.filesystem.end }>;
 // TODO: Do we want to mirror the NK3AM EFS?
 pub type ExternalFlashStorage = RamStorage<nk3am::ExternalFlashStorage, 256>;
-
-impl_storage_pointers!(
-    NKPK,
-    Internal = InternalFlashStorage,
-    External = ExternalFlashStorage,
-);

--- a/components/boards/src/store.rs
+++ b/components/boards/src/store.rs
@@ -35,13 +35,6 @@ const_ram_storage!(
 
 // FIXME: document safety
 #[allow(clippy::missing_safety_doc)]
-#[cfg(feature = "provisioner")]
-pub unsafe fn steal_internal_storage<S: StoragePointers>() -> &'static mut S::InternalStorage {
-    S::ifs_storage().as_mut().unwrap()
-}
-
-// FIXME: document safety
-#[allow(clippy::missing_safety_doc)]
 pub trait StoragePointers: 'static {
     type InternalStorage: Storage;
     type ExternalStorage: Storage;

--- a/components/boards/src/store.rs
+++ b/components/boards/src/store.rs
@@ -1,8 +1,4 @@
-use core::{
-    marker::PhantomData,
-    mem::MaybeUninit,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use core::mem::MaybeUninit;
 
 use apps::InitStatus;
 use littlefs2::{
@@ -33,198 +29,129 @@ const_ram_storage!(
     result = LfsResult,
 );
 
-// FIXME: document safety
-#[allow(clippy::missing_safety_doc)]
-pub trait StoragePointers: 'static {
-    type InternalStorage: Storage;
-    type ExternalStorage: Storage;
-
-    unsafe fn ifs_storage() -> &'static mut Option<Self::InternalStorage>;
-    unsafe fn ifs_alloc() -> &'static mut Option<Allocation<Self::InternalStorage>>;
-    unsafe fn ifs() -> &'static mut Option<Filesystem<'static, Self::InternalStorage>>;
-    unsafe fn ifs_ptr() -> *mut Fs<Self::InternalStorage>;
-
-    unsafe fn efs_storage() -> &'static mut Option<Self::ExternalStorage>;
-    unsafe fn efs_alloc() -> &'static mut Option<Allocation<Self::ExternalStorage>>;
-    unsafe fn efs() -> &'static mut Option<Filesystem<'static, Self::ExternalStorage>>;
-    unsafe fn efs_ptr() -> *mut Fs<Self::ExternalStorage>;
+pub struct StoreResources<B: Board> {
+    initialized: bool,
+    ifs: StorageResources<B::InternalStorage>,
+    efs: StorageResources<B::ExternalStorage>,
+    vfs: StorageResources<VolatileStorage>,
 }
 
-#[cfg_attr(
-    not(any(feature = "board-nk3am", feature = "board-nk3xn")),
-    allow(unused)
-)]
-macro_rules! impl_storage_pointers {
-    ($name:ident, Internal = $I:ty, External = $E:ty,) => {
-        impl $crate::store::StoragePointers for $name {
-            type InternalStorage = $I;
-            type ExternalStorage = $E;
-
-            unsafe fn ifs_storage() -> &'static mut Option<Self::InternalStorage> {
-                static mut IFS_STORAGE: Option<$I> = None;
-                #[allow(static_mut_refs)]
-                &mut IFS_STORAGE
-            }
-
-            unsafe fn ifs_alloc(
-            ) -> &'static mut Option<::littlefs2::fs::Allocation<Self::InternalStorage>> {
-                static mut IFS_ALLOC: Option<::littlefs2::fs::Allocation<$I>> = None;
-                #[allow(static_mut_refs)]
-                &mut IFS_ALLOC
-            }
-
-            unsafe fn ifs(
-            ) -> &'static mut Option<::littlefs2::fs::Filesystem<'static, Self::InternalStorage>>
-            {
-                static mut IFS: Option<::littlefs2::fs::Filesystem<$I>> = None;
-                #[allow(static_mut_refs)]
-                &mut IFS
-            }
-
-            unsafe fn ifs_ptr() -> *mut ::trussed::store::Fs<Self::InternalStorage> {
-                use ::core::mem::MaybeUninit;
-                static mut IFS: MaybeUninit<::trussed::store::Fs<$I>> = MaybeUninit::uninit();
-                IFS.as_mut_ptr()
-            }
-
-            unsafe fn efs_storage() -> &'static mut Option<Self::ExternalStorage> {
-                static mut EFS_STORAGE: Option<$E> = None;
-                #[allow(static_mut_refs)]
-                &mut EFS_STORAGE
-            }
-
-            unsafe fn efs_alloc(
-            ) -> &'static mut Option<::littlefs2::fs::Allocation<Self::ExternalStorage>> {
-                static mut EFS_ALLOC: Option<::littlefs2::fs::Allocation<$E>> = None;
-                #[allow(static_mut_refs)]
-                &mut EFS_ALLOC
-            }
-
-            unsafe fn efs(
-            ) -> &'static mut Option<::littlefs2::fs::Filesystem<'static, Self::ExternalStorage>>
-            {
-                static mut EFS: Option<::littlefs2::fs::Filesystem<$E>> = None;
-                #[allow(static_mut_refs)]
-                &mut EFS
-            }
-
-            unsafe fn efs_ptr() -> *mut ::trussed::store::Fs<Self::ExternalStorage> {
-                use ::core::mem::MaybeUninit;
-                static mut EFS: MaybeUninit<::trussed::store::Fs<$E>> = MaybeUninit::uninit();
-                EFS.as_mut_ptr()
-            }
-        }
-    };
-}
-
-#[cfg_attr(
-    not(any(feature = "board-nk3am", feature = "board-nk3xn")),
-    allow(unused)
-)]
-pub(crate) use impl_storage_pointers;
-
-pub struct RunnerStore<S> {
-    _marker: PhantomData<*mut S>,
-}
-
-impl<S: StoragePointers> RunnerStore<S> {
-    fn new(
-        ifs: &'static Filesystem<'static, S::InternalStorage>,
-        efs: &'static Filesystem<'static, S::ExternalStorage>,
-        vfs: &'static Filesystem<'static, VolatileStorage>,
-    ) -> Self {
-        unsafe {
-            S::ifs_ptr().write(Fs::new(ifs));
-            S::efs_ptr().write(Fs::new(efs));
-            Self::vfs_ptr().write(Fs::new(vfs));
-        }
-
+impl<B: Board> StoreResources<B> {
+    pub const fn new() -> Self {
         Self {
-            _marker: Default::default(),
+            initialized: false,
+            ifs: StorageResources::new(),
+            efs: StorageResources::new(),
+            vfs: StorageResources::new(),
         }
-    }
-
-    unsafe fn vfs_ptr() -> *mut Fs<VolatileStorage> {
-        static mut VFS: MaybeUninit<Fs<VolatileStorage>> = MaybeUninit::uninit();
-        VFS.as_mut_ptr()
     }
 }
 
-impl<S> Clone for RunnerStore<S> {
+struct StorageResources<S: Storage + 'static> {
+    storage: MaybeUninit<(S, Allocation<S>)>,
+    fs: MaybeUninit<Filesystem<'static, S>>,
+    fs_ptr: MaybeUninit<Fs<S>>,
+}
+
+impl<S: Storage + 'static> StorageResources<S> {
+    const fn new() -> Self {
+        Self {
+            storage: MaybeUninit::uninit(),
+            fs: MaybeUninit::uninit(),
+            fs_ptr: MaybeUninit::uninit(),
+        }
+    }
+}
+
+pub struct RunnerStore<B: Board> {
+    ifs: &'static Fs<B::InternalStorage>,
+    efs: &'static Fs<B::ExternalStorage>,
+    vfs: &'static Fs<VolatileStorage>,
+}
+
+impl<B: Board> Clone for RunnerStore<B> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<S> Copy for RunnerStore<S> {}
+impl<B: Board> Copy for RunnerStore<B> {}
 
-unsafe impl<S: StoragePointers> Store for RunnerStore<S> {
-    type I = S::InternalStorage;
-    type E = S::ExternalStorage;
+unsafe impl<B: Board> Store for RunnerStore<B> {
+    type I = B::InternalStorage;
+    type E = B::ExternalStorage;
     type V = VolatileStorage;
 
     fn ifs(self) -> &'static Fs<Self::I> {
-        unsafe { &*S::ifs_ptr() }
+        self.ifs
     }
 
     fn efs(self) -> &'static Fs<Self::E> {
-        unsafe { &*S::efs_ptr() }
+        self.efs
     }
 
     fn vfs(self) -> &'static Fs<Self::V> {
-        unsafe { &*Self::vfs_ptr() }
+        self.vfs
     }
 }
 
 pub fn init_store<B: Board>(
+    resources: &'static mut StoreResources<B>,
     int_flash: B::InternalStorage,
     ext_flash: B::ExternalStorage,
     simulated_efs: bool,
     status: &mut InitStatus,
 ) -> RunnerStore<B> {
-    static CLAIMED: AtomicBool = AtomicBool::new(false);
-    CLAIMED
-        .compare_exchange_weak(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .expect("multiple instances of RunnerStore are not allowed");
-
-    static mut VOLATILE_STORAGE: Option<VolatileStorage> = None;
-    static mut VOLATILE_FS_ALLOC: Option<Allocation<VolatileStorage>> = None;
-    static mut VOLATILE_FS: Option<Filesystem<VolatileStorage>> = None;
-
-    unsafe {
-        let ifs_storage = B::ifs_storage().insert(int_flash);
-        let ifs_alloc = B::ifs_alloc().insert(Filesystem::allocate());
-        let efs_storage = B::efs_storage().insert(ext_flash);
-        let efs_alloc = B::efs_alloc().insert(Filesystem::allocate());
-        let vfs_storage = VOLATILE_STORAGE.insert(VolatileStorage::new());
-        let vfs_alloc = VOLATILE_FS_ALLOC.insert(Filesystem::allocate());
-
-        let ifs = match init_ifs::<B>(ifs_storage, ifs_alloc, efs_storage, status) {
-            Ok(ifs) => B::ifs().insert(ifs),
-            Err(_e) => {
-                error!("IFS Mount Error {:?}", _e);
-                panic!("IFS");
-            }
-        };
-
-        let efs = match init_efs::<B>(efs_storage, efs_alloc, simulated_efs, status) {
-            Ok(efs) => B::efs().insert(efs),
-            Err(_e) => {
-                error!("EFS Mount Error {:?}", _e);
-                panic!("EFS");
-            }
-        };
-
-        let vfs = match init_vfs(vfs_storage, vfs_alloc) {
-            Ok(vfs) => VOLATILE_FS.insert(vfs),
-            Err(_e) => {
-                error!("VFS Mount Error {:?}", _e);
-                panic!("VFS");
-            }
-        };
-
-        RunnerStore::new(ifs, efs, vfs)
+    if resources.initialized {
+        panic!("multiple instances of RunnerStore are not allowed");
     }
+    resources.initialized = true;
+
+    let ifs_resources = resources
+        .ifs
+        .storage
+        .write((int_flash, Filesystem::allocate()));
+    let (ifs_storage, ifs_alloc) = (&mut ifs_resources.0, &mut ifs_resources.1);
+    let efs_resources = resources
+        .efs
+        .storage
+        .write((ext_flash, Filesystem::allocate()));
+    let (efs_storage, efs_alloc) = (&mut efs_resources.0, &mut efs_resources.1);
+    let vfs_resources = resources
+        .vfs
+        .storage
+        .write((VolatileStorage::new(), Filesystem::allocate()));
+    let (vfs_storage, vfs_alloc) = (&mut vfs_resources.0, &mut vfs_resources.1);
+
+    let ifs = match init_ifs::<B>(ifs_storage, ifs_alloc, efs_storage, status) {
+        Ok(ifs) => resources.ifs.fs.write(ifs),
+        Err(_e) => {
+            error!("IFS Mount Error {:?}", _e);
+            panic!("IFS");
+        }
+    };
+
+    let efs = match init_efs::<B>(efs_storage, efs_alloc, simulated_efs, status) {
+        Ok(efs) => resources.efs.fs.write(efs),
+        Err(_e) => {
+            error!("EFS Mount Error {:?}", _e);
+            panic!("EFS");
+        }
+    };
+
+    let vfs = match init_vfs(vfs_storage, vfs_alloc) {
+        Ok(vfs) => resources.vfs.fs.write(vfs),
+        Err(_e) => {
+            error!("VFS Mount Error {:?}", _e);
+            panic!("VFS");
+        }
+    };
+
+    let ifs = resources.ifs.fs_ptr.write(Fs::new(ifs));
+    let efs = resources.efs.fs_ptr.write(Fs::new(efs));
+    let vfs = resources.vfs.fs_ptr.write(Fs::new(vfs));
+
+    RunnerStore { ifs, efs, vfs }
 }
 
 #[inline(always)]

--- a/components/provisioner-app/src/apdu.rs
+++ b/components/provisioner-app/src/apdu.rs
@@ -8,7 +8,7 @@ use apdu_dispatch::{
     Command,
 };
 use core::convert::{TryFrom, TryInto};
-use trussed::{client, store::Store, types::LfsStorage, Client};
+use trussed::{client, store::Store, Client};
 
 const SOLO_PROVISIONER_AID: &[u8] = &[0xA0, 0x00, 0x00, 0x08, 0x47, 0x01, 0x00, 0x00, 0x01];
 
@@ -36,10 +36,9 @@ impl From<Error> for Status {
     }
 }
 
-impl<S, FS, T> iso7816::App for Provisioner<S, FS, T>
+impl<S, T> iso7816::App for Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: Client + client::X255 + client::HmacSha256,
 {
     fn aid(&self) -> Aid {
@@ -47,10 +46,9 @@ where
     }
 }
 
-impl<S, FS, T> App<CommandSize, ResponseSize> for Provisioner<S, FS, T>
+impl<S, T> App<CommandSize, ResponseSize> for Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: Client + client::X255 + client::HmacSha256,
 {
     fn select(

--- a/components/provisioner-app/src/ctaphid.rs
+++ b/components/provisioner-app/src/ctaphid.rs
@@ -5,14 +5,13 @@ use ctaphid_dispatch::{
     command::{Command, VendorCommand},
     types::{Error, Message},
 };
-use trussed::{client, store::Store, types::LfsStorage, Client};
+use trussed::{client, store::Store, Client};
 
 const COMMAND_PROVISIONER: VendorCommand = VendorCommand::H71;
 
-impl<S, FS, T> App<'static> for Provisioner<S, FS, T>
+impl<S, T> App<'static> for Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: Client + client::X255 + client::HmacSha256,
 {
     fn commands(&self) -> &'static [Command] {

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -22,6 +22,7 @@ mod app {
         nk3xn::{nfc::NfcChip, NK3xN},
         runtime,
         soc::lpc55::{self, monotonic::SystickMonotonic},
+        store::StoreResources,
         Apps, Trussed,
     };
     use ctaphid_dispatch::dispatch::Dispatch as CtaphidDispatch;
@@ -99,7 +100,11 @@ mod app {
     #[monotonic(binds = SysTick, default = true)]
     type Monotonic = SystickMonotonic;
 
-    #[init()]
+    #[init(
+        local = [
+          store_resources: StoreResources<Board> = StoreResources::new(),
+        ]
+    )]
     fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
         #[cfg(feature = "alloc")]
         embedded_runner_lib::init_alloc();
@@ -110,7 +115,7 @@ mod app {
             trussed,
             apps,
             clock_controller,
-        } = nk3xn::init(c.device, c.core);
+        } = nk3xn::init(c.device, c.core, c.local.store_resources);
         let perf_timer = basic.perf_timer;
         let wait_extender = basic.delay_timer;
 

--- a/runners/embedded/src/nk3xn.rs
+++ b/runners/embedded/src/nk3xn.rs
@@ -1,12 +1,13 @@
 pub mod init;
 
-use boards::nk3xn::NK3xN;
+use boards::{nk3xn::NK3xN, store::StoreResources};
 
 use crate::{VERSION, VERSION_STRING};
 
 pub fn init(
     device_peripherals: lpc55_hal::raw::Peripherals,
     core_peripherals: rtic::export::Peripherals,
+    store_resources: &'static mut StoreResources<NK3xN>,
 ) -> init::All {
     const SECURE_FIRMWARE_VERSION: u32 = VERSION.encode();
 
@@ -41,7 +42,7 @@ pub fn init(
             nfc_enabled,
         )
         .next(hal.rng, hal.prince, hal.flash)
-        .next()
+        .next(store_resources)
         .next(hal.rtc)
         .next(hal.usbhs)
 }

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -19,7 +19,7 @@ use boards::{
         lpc55::{clock_controller::DynamicClockController, Lpc55},
         Soc,
     },
-    store::{self, RunnerStore},
+    store::{self, RunnerStore, StoreResources},
     ui::{
         buttons::{self, Press},
         rgb_led::RgbLed as _,
@@ -565,7 +565,7 @@ impl Stage4 {
     }
 
     #[inline(never)]
-    pub fn next(mut self) -> Stage5 {
+    pub fn next(mut self, store_resources: &'static mut StoreResources<NK3xN>) -> Stage5 {
         info_now!("making fs");
 
         let external = if let Some(spi) = self.spi.take() {
@@ -606,7 +606,13 @@ impl Stage4 {
         );
         // TODO: poll iso14443
         let simulated_efs = external.is_ram();
-        let store = store::init_store(internal, external, simulated_efs, &mut self.status);
+        let store = store::init_store(
+            store_resources,
+            internal,
+            external,
+            simulated_efs,
+            &mut self.status,
+        );
         info!("mount end {} ms", self.basic.perf_timer.elapsed().0 / 1000);
 
         // return to slow freq

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -114,9 +114,6 @@ impl apps::Runner for Runner {
 
     type Store = store::Store;
 
-    #[cfg(feature = "provisioner")]
-    type Filesystem = <store::Store as trussed::store::Store>::I;
-
     type Twi = ();
     type Se050Timer = ();
 
@@ -201,8 +198,6 @@ fn exec(
                 #[cfg(feature = "provisioner")]
                 provisioner: apps::ProvisionerData {
                     store,
-                    stolen_filesystem: unsafe { FilesystemOrRam::ifs() },
-                    nfc_powered: false,
                     rebooter: || unimplemented!(),
                 },
                 _marker: Default::default(),


### PR DESCRIPTION
This patch moves the statics storing the various storage components into
the local resources for the init tasks.  This makes them sound and safe
to use.  Unfortunately, this leads to a significant increase in binary
size.

-----

Based on:
- https://github.com/Nitrokey/nitrokey-3-firmware/pull/481