### PR TITLE
fido2-mds: Update dependencies

### DIFF
--- a/utils/fido2-mds/requirements.txt
+++ b/utils/fido2-mds/requirements.txt
@@ -7,18 +7,18 @@ cffi==1.16.0
     # via
     #   cairocffi
     #   cryptography
-cryptography==42.0.4
+cryptography==42.0.5
     # via fido2
 cssselect2==0.7.0
     # via cairosvg
 defusedxml==0.7.1
     # via cairosvg
-fido2==1.1.2
-pillow==10.2.0
+fido2==1.1.3
+pillow==10.3.0
     # via cairosvg
-pycparser==2.21
+pycparser==2.22
     # via cffi
-tinycss2==1.2.1
+tinycss2==1.3.0
     # via
     #   cairosvg
     #   cssselect2


### PR DESCRIPTION
Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/security/dependabot/9