### PR TITLE
Mount EFS only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@
 - admin-app: Add command to list all supported config fields ([admin-app#28][])
 - admin-app: Add `opcard.disabled` configuration option to disable OpenPGP ([#539][])
 - piv: Use SE050 and encrypt data on external flash ([#534][])
+- Improve external flash mounting to decrease startup time ([#440][])
 
 [admin-app#28]: https://github.com/Nitrokey/admin-app/issues/28
 [fido-authenticator#38]: https://github.com/Nitrokey/fido-authenticator/issues/38
 [piv-authenticator#38]: https://github.com/Nitrokey/piv-authenticator/issues/38
+[#440]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/440
 [#524]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/524
 [#534]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/534
 [#539]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/539


### PR DESCRIPTION
With this patch, the EFS is only mounted once if it is mountable.  This significantly reduces bootup time by approximately 0.5 s.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/440