### PR TITLE
Update fido-authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - Note that the actual number of discoverable credentials that can be stored on a device depends on the model and the space used by other applications.
 - piv-authenticator: Update to [v0.5.0](https://github.com/trussed-dev/piv-authenticator/releases/tag/v0.5.0)
   - Add support for RSA 3072, RSA 4096 and NIST P-384
+- fido-authenticator: Improve compliance with CTAP 2.1 specification:
+  - Forbid up = false when using the hmac-secret extension ([fido-authenticator#19](https://github.com/Nitrokey/fido-authenticator/issues/19))
+  - Allow creating credentials without PIN (`makeCredUvNotRqd`, [fido-authenticator#34](https://github.com/Nitrokey/fido-authenticator/issues/34))
+  - Support clientPin getRetries without PIN protocol ([fido-authenticator#118](https://github.com/Nitrokey/fido-authenticator/issues/118))
 
 ## v1.8.1 (2025-02-11)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,6 @@ dependencies = [
  "trussed-wrap-key-to-file",
  "usbd-ctaphid",
  "utils",
- "webcrypt",
 ]
 
 [[package]]
@@ -376,7 +375,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "cortex-m-semihosting",
- "ctaphid-dispatch 0.3.0",
+ "ctaphid-dispatch",
  "delog",
  "embedded-hal",
  "embedded-storage",
@@ -882,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "ctap-types"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1beeb5a05e42c7cbfb788ce3e9fd6ce7d0aa214893b5ca6cd38d09ac9afe722"
+checksum = "bb8b105c5e728afd373e99874f0c1911c170b3a56848456cc16feb4506321606"
 dependencies = [
  "bitflags 1.3.2",
  "cbor-smol",
@@ -906,20 +905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fe93489fe96c998488d0843dffea35c02ed9add2585e55228e1d45988727ecc"
 dependencies = [
  "heapless-bytes",
- "trussed-core",
-]
-
-[[package]]
-name = "ctaphid-dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27caf0a07de6b0af58ba69562c1834ddf7aa27bc1d1687fed3b18fea1501e59e"
-dependencies = [
- "ctaphid-app",
- "delog",
- "heapless-bytes",
- "interchange",
- "ref-swap",
  "trussed-core",
 ]
 
@@ -1222,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.26#443eca178726f6de29ec86cbf70a92f47d385853"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.27#5ebb4a48302e4c80a2abe1c2d86201a3df2a1d2d"
 dependencies = [
  "apdu-app",
  "cbor-smol",
@@ -1968,7 +1953,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
- "ctaphid-dispatch 0.3.0",
+ "ctaphid-dispatch",
  "delog",
  "interchange",
  "memory-regions",
@@ -3456,7 +3441,7 @@ version = "0.0.1"
 source = "git+https://github.com/trussed-dev/pc-usbip-runner.git?rev=504674453c9573a30aa2f155101df49eb2af1ba7#504674453c9573a30aa2f155101df49eb2af1ba7"
 dependencies = [
  "apdu-dispatch",
- "ctaphid-dispatch 0.3.0",
+ "ctaphid-dispatch",
  "interchange",
  "littlefs2-core",
  "log",
@@ -3606,7 +3591,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82f5a2aa6898726b4eeb3fa3796fb8dc49e76e2a16bd683db103f63bc8ceca97"
 dependencies = [
- "ctaphid-dispatch 0.3.0",
+ "ctaphid-dispatch",
  "delog",
  "embedded-time",
  "heapless-bytes",
@@ -3636,7 +3621,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "clap-num",
- "ctaphid-dispatch 0.3.0",
+ "ctaphid-dispatch",
  "delog",
  "dialoguer",
  "littlefs2",
@@ -3760,32 +3745,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
-name = "webcrypt"
-version = "0.8.0"
-source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?tag=v0.8.0-rc11#539ca26b1e045e27b1489d71784524640119db8b"
-dependencies = [
- "apdu-app",
- "cbor-smol",
- "ctap-types",
- "ctaphid-app",
- "ctaphid-dispatch 0.2.0",
- "delog",
- "generic-array",
- "heapless",
- "heapless-bytes",
- "hmac",
- "iso7816",
- "littlefs2-core",
- "serde",
- "serde-indexed",
- "serde_bytes",
- "sha2",
- "trussed",
- "trussed-core",
- "trussed-rsa-alloc",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed.git?rev=024e0eca5fb7dbd2457831f7c7bffe4341e08775#024e0eca5fb7dbd2457831f7c7bffe4341e08775"
+source = "git+https://github.com/trussed-dev/trussed.git?rev=e107ed315a07dc6c992fac39d542e847cc3a1b6c#e107ed315a07dc6c992fac39d542e847cc3a1b6c"
 dependencies = [
  "aes",
  "bitflags 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,10 @@ trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", re
 
 # applications
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.20" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git",tag = "v0.1.1-nitrokey.26" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git",tag = "v0.1.1-nitrokey.27" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "39ec4c37f808c0cfeb84e0a8493bbee06f02c8e2" }
 piv-authenticator = { git = "https://github.com/trussed-dev/piv-authenticator.git", tag = "v0.5.1" }
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "700863bdfa90a3616cbb695d6638c7aea7730c03" }
-webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc11" }
 
 # backends
 trussed-auth-backend = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ memory-regions = { path = "components/memory-regions" }
 
 # unreleased libraries
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "024e0eca5fb7dbd2457831f7c7bffe4341e08775" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "e107ed315a07dc6c992fac39d542e847cc3a1b6c" }
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "504674453c9573a30aa2f155101df49eb2af1ba7" }
 
 # applications

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -42,7 +42,6 @@ trussed-hpke = "0.2.0"
 admin-app = "0.1.0"
 fido-authenticator = { version = "0.1.1", features = ["chunked", "dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
-webcrypt = { version = "0.8.0", optional = true }
 secrets-app = { version = "0.13.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.4.0", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096", "admin-app"], optional = true }
 piv-authenticator = { version = "0.5.0", features = ["apdu-dispatch", "delog", "rsa"], optional = true }
@@ -64,7 +63,6 @@ nkpk-provisioner = ["nkpk", "provisioner-app"]
 
 # apps
 secrets-app = ["dep:secrets-app", "backend-auth", "trussed/chacha8-poly1305", "trussed/hmac-sha1", "trussed/hmac-sha256", "trussed/sha256"]
-webcrypt = ["dep:webcrypt", "backend-auth", "backend-rsa"]
 fido-authenticator = ["dep:fido-authenticator", "usbd-ctaphid", "trussed/aes256-cbc", "trussed/certificate-client", "trussed/chacha8-poly1305", "trussed/ed255", "trussed/hmac-sha256", "trussed/p256", "trussed/sha256"]
 opcard = ["dep:opcard", "backend-rsa", "backend-auth", "trussed/aes256-cbc", "trussed/chacha8-poly1305", "trussed/ed255", "trussed/p256", "trussed/shared-secret", "trussed/x255"]
 piv-authenticator = ["dep:piv-authenticator", "backend-rsa", "backend-auth", "trussed/aes256-cbc", "trussed/chacha8-poly1305", "trussed/ed255", "trussed/p256", "trussed/shared-secret", "trussed/tdes", "trussed/x255"]
@@ -75,7 +73,7 @@ backend-auth = ["trussed-auth", "trussed-auth-backend"]
 backend-rsa = ["trussed-rsa-alloc"]
 backend-software-hpke = ["trussed-staging/hpke"]
 
-log-all = ["admin-app/log-all", "fido-authenticator?/log-all", "secrets-app?/log-all", "webcrypt?/log-all", "opcard?/log-all", "provisioner-app?/log-all"]
+log-all = ["admin-app/log-all", "fido-authenticator?/log-all", "secrets-app?/log-all", "opcard?/log-all", "provisioner-app?/log-all"]
 log-error = []
 log-warn = []
 log-info = []


### PR DESCRIPTION
This PR updates fido-authenticator to improve compliance with the CTAP 2.1 specification:
- https://github.com/Nitrokey/fido-authenticator/issues/19
- https://github.com/Nitrokey/fido-authenticator/issues/34
- https://github.com/Nitrokey/fido-authenticator/issues/118

To avoid additional maintenance efforts, webcrypt is removed from the `apps` component.