### PR TITLE
update nitrokey-hardware-test to v1.2.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,7 +209,7 @@ hardware-tests:
       - MODEL: [ nrf52, lpc55, nkpk ]
   stage: test
   script:
-    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@git.nitrokey.com/nitrokey/nitrokey-hardware-test.git --recursive --branch v1.2.3
+    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@git.nitrokey.com/nitrokey/nitrokey-hardware-test.git --recursive --branch v1.2.4
     - make -C nitrokey-hardware-test ci FW=../artifacts MODEL=$MODEL TESTS=pynitrokey,nk3test
     - cp nitrokey-hardware-test/artifacts/Nitrokey3TestSuite/report-junit.xml nitrokey-hardware-test/artifacts/report-junit.xml || true
   artifacts:


### PR DESCRIPTION
fixes:
fix openpgp-card-tools to version 0.9.5
ignore pipenv-rm errors