### PR TITLE
Update fido-authenticator to v0.1.1-nitrokey.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - fido-authenticator: Implement the largeBlobKey extension and the largeBlobs command ([fido-authenticator#38][])
 - piv: Fix crash when changing PUK ([piv-authenticator#38][])
 
+### Bugfixes
+
+- fido-authenticator: Fix incompatibility when enumerating resident keys with libfido2/ssh-agent ([#496][])
+
+[#496]: https://github.com/Nitrokey/nitrokey-3-firmware/issues/496
 [fido-authenticator#38]: https://github.com/Nitrokey/fido-authenticator/issues/38
 [piv-authenticator#38]: https://github.com/Nitrokey/piv-authenticator/issues/38
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.14#db4a63dd582784c847520136da930f172330ef28"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.15#07ff03b4edb0c6ba3563917d13308ee8d4518843"
 dependencies = [
  "apdu-dispatch",
  "ctap-types",
@@ -1188,7 +1188,6 @@ dependencies = [
  "iso7816",
  "serde",
  "serde-indexed",
- "serde_cbor",
  "sha2",
  "trussed",
  "trussed-chunked",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ memory-regions = { path = "components/memory-regions" }
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", rev = "c257432dbe2efb53424d6847d82d90ddb527c53b" }
 cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.3"}
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.14" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.15" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.19" }


### PR DESCRIPTION
This patch updates fido-authenticator to v0.1.1-nitrokey.15 to add support for scoped PIN tokens when enumerating credentials.  This fixes an incompatibility with libfido2, affecting ssh-agent.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/496