### PR TITLE
Update ctap-types and fido-authenticator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "cosey"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb743c2c58b69b970e02f5ba7f552f75fcfc8393768e3ae4316e055aabacfdaa"
+checksum = "39323fe531b92e7acad90b8550b58cec63d29a6c5a56e02de4b25b6aeedbf82e"
 dependencies = [
  "heapless-bytes",
  "serde",
@@ -868,11 +868,13 @@ dependencies = [
 
 [[package]]
 name = "ctap-types"
-version = "0.1.2"
-source = "git+https://github.com/trussed-dev/ctap-types.git?rev=a9f8003a1d9f05f9eea39e615b9159bc0613fcb5#a9f8003a1d9f05f9eea39e615b9159bc0613fcb5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb60d898980133d08bc1c5f3fc3facecf18833bf4ff3d962871bb43607ac0b81"
 dependencies = [
  "bitflags 1.3.2",
  "cbor-smol",
+ "cosey",
  "delog",
  "heapless",
  "heapless-bytes",
@@ -1178,9 +1180,10 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.15#07ff03b4edb0c6ba3563917d13308ee8d4518843"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.16#79b05b576863236fe54750b18e862ce0801f2040"
 dependencies = [
  "apdu-dispatch",
+ "cosey",
  "ctap-types",
  "ctaphid-dispatch",
  "delog",
@@ -1188,6 +1191,7 @@ dependencies = [
  "iso7816",
  "serde",
  "serde-indexed",
+ "serde_bytes",
  "sha2",
  "trussed",
  "trussed-chunked",
@@ -2700,8 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "serde-indexed"
-version = "0.1.0"
-source = "git+https://github.com/nitrokey/serde-indexed.git?tag=v0.1.0-nitrokey.2#5005d23cb4ee8622e62188ea0f9466146f851f0d"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca2da10b1f1623f47130256065e05e94fd7a98dbd26a780a4c5de831b21e5c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3465,9 +3470,8 @@ dependencies = [
 [[package]]
 name = "usbd-ctaphid"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/usbd-ctaphid.git?rev=1db2e014f28669bc484c81ab0406c54b16bba33c#1db2e014f28669bc484c81ab0406c54b16bba33c"
+source = "git+https://github.com/trussed-dev/usbd-ctaphid.git?rev=dcff9009c3cd1ef9e5b09f8f307aca998fc9a8c8#dcff9009c3cd1ef9e5b09f8f307aca998fc9a8c8"
 dependencies = [
- "ctap-types",
  "ctaphid-dispatch",
  "delog",
  "embedded-time",
@@ -3625,7 +3629,7 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 [[package]]
 name = "webcrypt"
 version = "0.8.0"
-source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?tag=v0.8.0-rc7#d6327fd76f495feb5fe52c1dd3bc2814455472b9"
+source = "git+https://github.com/nitrokey/nitrokey-websmartcard-rust?tag=v0.8.0-rc8#d6705ab95cbc3dd2e4120a5dfa1b8b5a2707b1c7"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,24 +19,22 @@ memory-regions = { path = "components/memory-regions" }
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", rev = "c257432dbe2efb53424d6847d82d90ddb527c53b" }
 cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.3"}
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.15" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.16" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
-serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 trussed = { git = "https://github.com/nitrokey/trussed.git", tag = "v0.1.0-nitrokey.20" }
 
 # unreleased upstream changes
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch.git", tag = "v0.1.2-nitrokey.3" }
-ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "a9f8003a1d9f05f9eea39e615b9159bc0613fcb5" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch.git", tag = "v0.1.1-nitrokey.3" }
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "960e57d9fc0d209308c8e15dc26252bbe1ff6ba8" }
 littlefs2-sys = { git = "https://github.com/trussed-dev/littlefs2-sys.git", rev = "39626c0dbc2f6c38b74889a5bf9d5a200614f121" }
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid.git", rev = "1db2e014f28669bc484c81ab0406c54b16bba33c" }
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid.git", rev = "dcff9009c3cd1ef9e5b09f8f307aca998fc9a8c8" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.13.0" }
-webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc7" }
+webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc8" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.4.1" }
 piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator.git", tag = "v0.3.7" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }


### PR DESCRIPTION
This patch updates ctap-types so that it uses the COSE implementation in the cosey crate instead of shipping its own identical cose module.  This reduces code duplication and has a small effect on the binary size.  We also need to update fido-authenticator to use cosey instead of ctap_types::cosey, and we need to update cose so that it includes a fix that we previously applied to the cose module in ctap-types.

We use this occasion to also pull in other optimizations of ctap-types and fido-authenticator.

See also:
- https://github.com/trussed-dev/ctap-types/pull/37
- https://github.com/Nitrokey/fido-authenticator/pull/83