### PR TITLE
update github-comment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,7 +180,7 @@ metrics:
   after_script:
     - !reference [notify_github, script] # use notify_github from include
     - repometrics run --base origin/main --output-format markdown | tee --append metrics-comment.md
-    - github-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.md
+    - nitrokey-ci write-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.md
   artifacts:
     paths:
       - metrics.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
 RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
-RUN cargo install --git https://github.com/Nitrokey/github-comment --rev ac9713f9d6d04ed03fb67d0199ebffc78ba5dcab --locked
+RUN cargo install --git https://github.com/Nitrokey/nitrokey-ci --rev 934fe3d441cfd15901a88aa5aff712edd29a78aa --locked
 RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 98ffa20ddded8f09c0ef252b4e93ec6a9792f9dc --locked
 RUN rustup install nightly-2024-04-01
 RUN rustup component add rust-src --toolchain nightly-2024-04-01


### PR DESCRIPTION
Update the `github-comment` tool. This includes the rename to `nitrokey-ci`.