### PR TITLE
update nitrokey-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
 RUN cargo install flip-link cargo-binutils
 RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
-RUN cargo install --git https://github.com/Nitrokey/nitrokey-ci --rev 934fe3d441cfd15901a88aa5aff712edd29a78aa --locked
+RUN cargo install --git https://github.com/Nitrokey/nitrokey-ci --rev ef155b0c34317fab71405fe5e914d4732f8c9396 --locked
 RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 98ffa20ddded8f09c0ef252b4e93ec6a9792f9dc --locked
 RUN rustup install nightly-2024-04-01
 RUN rustup component add rust-src --toolchain nightly-2024-04-01


### PR DESCRIPTION
Update `nitrokey-ci` for improved permission management in the command interface.

New version is already running on the runner and tests are passing.