### PR TITLE
ci: Validate lockfile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,6 +153,8 @@ build-firmware:
     - docker
   stage: build
   script:
+    # Ensure that the lockfile is up-to-date
+    - cargo fetch --locked
     # Generate normal binaries
     - make binaries
     # Generate no-buttons firmware binaries for HIL


### PR DESCRIPTION
This patch adds a step to the build-firmware CI job that ensures that the lockfile is up-to-date.  See also:  https://github.com/Nitrokey/nethsm-pkcs11/issues/221