### PR TITLE
PIV: use se050 backend and trussed-auth for key wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@
   - brainpoolp512r1
 - admin-app: Add command to list all supported config fields ([admin-app#28][])
 - admin-app: Add `opcard.disabled` configuration option to disable OpenPGP ([#539][])
+- piv: Use SE050 and encrypt data on external flash ([#534][])
 
 [admin-app#28]: https://github.com/Nitrokey/admin-app/issues/28
 [fido-authenticator#38]: https://github.com/Nitrokey/fido-authenticator/issues/38
 [piv-authenticator#38]: https://github.com/Nitrokey/piv-authenticator/issues/38
 [#524]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/524
+[#534]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/534
 [#539]: https://github.com/Nitrokey/nitrokey-3-firmware/pull/539
 
 ## v1.7.2 (2024-06-11)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "trussed-chunked",
  "trussed-fs-info",
  "trussed-hkdf",
+ "trussed-hpke",
  "trussed-manage",
  "trussed-rsa-alloc",
  "trussed-se050-backend",
@@ -2205,23 +2206,27 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piv-authenticator"
-version = "0.3.7"
-source = "git+https://github.com/Nitrokey/piv-authenticator.git?tag=v0.3.7#9c88e0bb586ef1c750cc043dff867e3306105d15"
+version = "0.3.8"
+source = "git+https://github.com/Nitrokey/piv-authenticator.git?tag=v0.3.8#e67a954cf93a4cbf3c364ca9ba6c612d3cc3d5ff"
 dependencies = [
  "apdu-dispatch",
+ "cfg-if",
  "delog",
  "flexiber",
  "heapless",
  "heapless-bytes",
  "hex-literal 0.3.4",
  "iso7816",
+ "littlefs2",
  "log",
  "serde",
  "subtle",
  "trussed",
  "trussed-auth",
  "trussed-chunked",
+ "trussed-hpke",
  "trussed-rsa-alloc",
+ "trussed-wrap-key-to-file",
  "untrusted",
 ]
 
@@ -3237,6 +3242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "trussed-hpke"
+version = "0.1.0"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=hpke-v0.1.0#7c99973187eb9ae2c1e410b5996169ccf2690efa"
+dependencies = [
+ "serde",
+ "serde-byte-array",
+ "trussed",
+]
+
+[[package]]
 name = "trussed-manage"
 version = "0.1.0"
 source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=manage-v0.1.0#5fc00717e6aa3f43d4f72fd3bd589f2de3a89b98"
@@ -3261,12 +3276,13 @@ dependencies = [
 
 [[package]]
 name = "trussed-se050-backend"
-version = "0.3.0"
-source = "git+https://github.com/Nitrokey/trussed-se050-backend.git?tag=v0.3.5#f04beb6e1d5cc0ec84af4fcdc05338450c24cb0e"
+version = "0.3.6"
+source = "git+https://github.com/Nitrokey/trussed-se050-backend.git?tag=v0.3.6#f12e134d001895c5e46d8892a4f88209f9a1a676"
 dependencies = [
  "admin-app",
  "bitflags 2.6.0",
  "cbor-smol",
+ "chacha20poly1305",
  "crypto-bigint",
  "delog",
  "der",
@@ -3288,6 +3304,7 @@ dependencies = [
  "sha2",
  "trussed",
  "trussed-auth",
+ "trussed-hpke",
  "trussed-manage",
  "trussed-rsa-alloc",
  "trussed-se050-manage",
@@ -3305,14 +3322,18 @@ dependencies = [
 
 [[package]]
 name = "trussed-staging"
-version = "0.3.0"
-source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=v0.3.1#72b082002e0869facfc11bf8d76a1272c7ddf4ee"
+version = "0.3.2"
+source = "git+https://github.com/trussed-dev/trussed-staging.git?tag=v0.3.2#7c99973187eb9ae2c1e410b5996169ccf2690efa"
 dependencies = [
+ "aead",
  "chacha20poly1305",
  "delog",
+ "digest 0.10.7",
+ "hex-literal 0.4.1",
  "hkdf",
  "littlefs2",
  "rand_core",
+ "salty",
  "serde",
  "serde-byte-array",
  "sha2",
@@ -3320,6 +3341,7 @@ dependencies = [
  "trussed-chunked",
  "trussed-fs-info",
  "trussed-hkdf",
+ "trussed-hpke",
  "trussed-manage",
  "trussed-wrap-key-to-file",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,19 @@ p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev =
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.13.0" }
 webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc9" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.5.0" }
-piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator.git", tag = "v0.3.7" }
+piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator.git", tag = "v0.3.8" }
 trussed-fs-info = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "fs-info-v0.1.0" }
 trussed-chunked = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "chunked-v0.1.0" }
 trussed-manage = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "manage-v0.1.0" }
 trussed-wrap-key-to-file = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "wrap-key-to-file-v0.1.0" }
-trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.1" }
+trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "v0.3.2" }
+trussed-hpke = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hpke-v0.1.0" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "947ffe6cff426ccbbbb2d0f689437f427665919e" }
 trussed-hkdf = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "hkdf-v0.2.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", tag = "v0.2.1" }
 trussed-usbip = { git = "https://github.com/Nitrokey/pc-usbip-runner.git", tag = "v0.0.1-nitrokey.4" }
 trussed-se050-manage = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "se050-manage-v0.1.0" }
-trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag ="v0.3.5" }
+trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", tag = "v0.3.6" }
 
 [profile.release]
 codegen-units = 1

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -76,10 +76,11 @@ se050 = ["dep:se05x", "trussed-se050-backend", "trussed-se050-manage", "admin-ap
 # backends
 backend-auth = ["trussed-auth"]
 backend-rsa = ["trussed-rsa-alloc"]
+backend-software-hpke = ["trussed-staging/hpke"]
 
 log-all = ["admin-app/log-all", "fido-authenticator?/log-all", "secrets-app?/log-all", "webcrypt?/log-all", "opcard?/log-all", "provisioner-app?/log-all"]
 
-trussed-usbip-ccid = ["trussed-usbip/ccid", "trussed-staging/hpke"]
+trussed-usbip-ccid = ["trussed-usbip/ccid", "backend-software-hpke"]
 
 factory-reset = ["admin-app/factory-reset"]
 

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -24,7 +24,7 @@ littlefs2 = "0.4"
 trussed-auth = { version = "0.3.0", optional = true }
 trussed-rsa-alloc = { version = "0.2.0", optional = true }
 trussed-se050-backend = { version = "0.3.6", optional = true }
-trussed-staging = { version = "0.3.2", features = ["wrap-key-to-file", "chunked", "hkdf", "manage", "fs-info", "hpke"] }
+trussed-staging = { version = "0.3.2", features = ["wrap-key-to-file", "chunked", "hkdf", "manage", "fs-info"] }
 
 # Extensions
 trussed-chunked = "0.1.0"
@@ -58,7 +58,7 @@ hex = "0.4"
 
 # nk3
 nk3 = ["fido-authenticator", "ndef-app", "secrets-app", "opcard", "factory-reset", "trussed/clients-4"]
-nk3-test = ["nk3", "piv-authenticator", "trussed/clients-6"]
+nk3-test = ["nk3", "piv-authenticator", "trussed/clients-5"]
 nk3-provisioner = ["nk3", "provisioner-app", "trussed/clients-5"]
 
 # nkpk

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -58,7 +58,7 @@ hex = "0.4"
 
 # nk3
 nk3 = ["fido-authenticator", "ndef-app", "secrets-app", "opcard", "factory-reset", "trussed/clients-4"]
-nk3-test = ["nk3", "piv-authenticator", "webcrypt", "trussed/clients-6"]
+nk3-test = ["nk3", "piv-authenticator", "trussed/clients-6"]
 nk3-provisioner = ["nk3", "provisioner-app", "trussed/clients-5"]
 
 # nkpk

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -23,8 +23,8 @@ littlefs2 = "0.4"
 # Backends
 trussed-auth = { version = "0.3.0", optional = true }
 trussed-rsa-alloc = { version = "0.2.0", optional = true }
-trussed-se050-backend = { version = "0.3.0", optional = true }
-trussed-staging = { version = "0.3.0", features = ["wrap-key-to-file", "chunked", "hkdf", "manage", "fs-info"] }
+trussed-se050-backend = { version = "0.3.6", optional = true }
+trussed-staging = { version = "0.3.2", features = ["wrap-key-to-file", "chunked", "hkdf", "manage", "fs-info", "hpke"] }
 
 # Extensions
 trussed-chunked = "0.1.0"
@@ -33,6 +33,7 @@ trussed-manage = "0.1.0"
 trussed-se050-manage = { version = "0.1.0", optional = true }
 trussed-wrap-key-to-file = "0.1.0"
 trussed-fs-info = "0.1.0"
+trussed-hpke = "0.1.0"
 
 # apps
 admin-app = "0.1.0"
@@ -41,7 +42,7 @@ ndef-app = { path = "../ndef-app", optional = true }
 webcrypt = { version = "0.8.0", optional = true }
 secrets-app = { version = "0.13.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.4.0", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096", "admin-app"], optional = true }
-piv-authenticator = { version = "0.3.4", features = ["apdu-dispatch", "delog", "rsa"], optional = true }
+piv-authenticator = { version = "0.3.8", features = ["apdu-dispatch", "delog", "rsa"], optional = true }
 provisioner-app = { path = "../provisioner-app", optional = true }
 
 [dev-dependencies]
@@ -78,7 +79,7 @@ backend-rsa = ["trussed-rsa-alloc"]
 
 log-all = ["admin-app/log-all", "fido-authenticator?/log-all", "secrets-app?/log-all", "webcrypt?/log-all", "opcard?/log-all", "provisioner-app?/log-all"]
 
-trussed-usbip-ccid = ["trussed-usbip/ccid"]
+trussed-usbip-ccid = ["trussed-usbip/ccid", "trussed-staging/hpke"]
 
 factory-reset = ["admin-app/factory-reset"]
 

--- a/components/apps/src/dispatch.rs
+++ b/components/apps/src/dispatch.rs
@@ -55,6 +55,9 @@ use webcrypt::hmacsha256p256::{
     HmacSha256P256Extension,
 };
 
+#[cfg(feature = "piv-authenticator")]
+use trussed_hpke::HpkeExtension;
+
 pub struct Dispatch<T = (), D = ()> {
     #[cfg(feature = "backend-auth")]
     auth: AuthBackend,
@@ -118,6 +121,10 @@ const NAMESPACE: trussed_se050_backend::namespacing::Namespace = {
         NamespaceItem {
             client: path!("opcard"),
             value: NamespaceValue::Client2,
+        },
+        NamespaceItem {
+            client: path!("piv"),
+            value: NamespaceValue::Client3,
         },
     ])
 };
@@ -316,6 +323,16 @@ impl<T: Twi, D: Delay> ExtensionDispatch for Dispatch<T, D> {
                         resources,
                     )
                 }
+                #[cfg(feature = "piv-authenticator")]
+                // Don't use staging hpke if se050 is available
+                #[cfg(not(feature = "se050"))]
+                Extension::Hpke => ExtensionImpl::<HpkeExtension>::extension_request_serialized(
+                    &mut self.staging,
+                    &mut ctx.core,
+                    &mut ctx.backends.staging,
+                    request,
+                    resources,
+                ),
                 #[allow(unreachable_patterns)]
                 _ => Err(TrussedError::RequestNotAvailable),
             },
@@ -350,6 +367,14 @@ impl<T: Twi, D: Delay> ExtensionDispatch for Dispatch<T, D> {
                         resources,
                     )
                 }
+                #[cfg(feature = "piv-authenticator")]
+                Extension::Hpke => ExtensionImpl::<HpkeExtension>::extension_request_serialized(
+                    self.se050.as_mut().ok_or(TrussedError::GeneralError)?,
+                    &mut ctx.core,
+                    &mut ctx.backends.se050,
+                    request,
+                    resources,
+                ),
                 _ => Err(TrussedError::RequestNotAvailable),
             },
             #[cfg(feature = "se050")]
@@ -410,6 +435,8 @@ pub enum Extension {
     HmacSha256P256,
     #[cfg(feature = "se050")]
     Se050Manage,
+    #[cfg(feature = "piv-authenticator")]
+    Hpke,
 }
 
 impl From<Extension> for u8 {
@@ -426,6 +453,8 @@ impl From<Extension> for u8 {
             Extension::Se050Manage => 5,
             Extension::Hkdf => 6,
             Extension::FsInfo => 7,
+            #[cfg(feature = "piv-authenticator")]
+            Extension::Hpke => 8,
         }
     }
 }
@@ -446,6 +475,8 @@ impl TryFrom<u8> for Extension {
             5 => Ok(Extension::Se050Manage),
             6 => Ok(Extension::Hkdf),
             7 => Ok(Extension::FsInfo),
+            #[cfg(feature = "piv-authenticator")]
+            8 => Ok(Extension::Hpke),
             _ => Err(TrussedError::InternalError),
         }
     }
@@ -500,6 +531,13 @@ impl<T: Twi, D: Delay> ExtensionId<FsInfoExtension> for Dispatch<T, D> {
     type Id = Extension;
 
     const ID: Self::Id = Self::Id::FsInfo;
+}
+
+#[cfg(feature = "piv-authenticator")]
+impl<T: Twi, D: Delay> ExtensionId<HpkeExtension> for Dispatch<T, D> {
+    type Id = Extension;
+
+    const ID: Self::Id = Self::Id::Hpke;
 }
 
 #[cfg(test)]

--- a/components/apps/src/dispatch.rs
+++ b/components/apps/src/dispatch.rs
@@ -323,9 +323,7 @@ impl<T: Twi, D: Delay> ExtensionDispatch for Dispatch<T, D> {
                         resources,
                     )
                 }
-                #[cfg(feature = "piv-authenticator")]
-                // Don't use staging hpke if se050 is available
-                #[cfg(not(feature = "se050"))]
+                #[cfg(feature = "backend-software-hpke")]
                 Extension::Hpke => ExtensionImpl::<HpkeExtension>::extension_request_serialized(
                     &mut self.staging,
                     &mut ctx.core,

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -1136,8 +1136,8 @@ impl<R: Runner> App<R> for PivApp<R> {
     }
     fn backends(runner: &R, _: &()) -> &'static [BackendId<Backend>] {
         const BACKENDS_PIV: &[BackendId<Backend>] = &[
-            BackendId::Custom(Backend::SoftwareRsa),
-            BackendId::Custom(Backend::Auth),
+            #[cfg(feature = "se050")]
+            BackendId::Custom(Backend::Se050),
             BackendId::Custom(Backend::Staging),
             BackendId::Core,
         ];


### PR DESCRIPTION
Depends on 

Waiting for merge before updating the patch section of the cargo.toml.

- https://github.com/trussed-dev/trussed-staging/pull/25
- https://github.com/Nitrokey/trussed-se050-backend/pull/36
- https://github.com/Nitrokey/trussed-se050-backend/pull/37
- https://github.com/Nitrokey/piv-authenticator/pull/57