### PR TITLE
Remove unused ctap-types patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,8 +3855,3 @@ dependencies = [
  "quote",
  "syn 2.0.69",
 ]
-
-[[patch.unused]]
-name = "ctap-types"
-version = "0.2.0"
-source = "git+https://github.com/trussed-dev/ctap-types.git?rev=72eb68b61e3f14957c5ab89bd22f776ac860eb62#72eb68b61e3f14957c5ab89bd22f776ac860eb62"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ littlefs2-sys = { git = "https://github.com/trussed-dev/littlefs2-sys.git", rev 
 usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid.git", rev = "dcff9009c3cd1ef9e5b09f8f307aca998fc9a8c8" }
 usbd-ccid = { git = "https://github.com/Nitrokey/usbd-ccid", tag = "v0.2.0-nitrokey.1" }
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
-ctap-types = { git = "https://github.com/trussed-dev/ctap-types.git", rev = "72eb68b61e3f14957c5ab89bd22f776ac860eb62" }
 
 # unreleased crates
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.13.0" }


### PR DESCRIPTION
We are now using the released ctap-types 0.3.0