### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,8 +494,9 @@ dependencies = [
 
 [[package]]
 name = "cbor-smol"
-version = "0.4.0"
-source = "git+https://github.com/Nitrokey/cbor-smol.git?tag=v0.4.0-nitrokey.4#d6211450a8e29fcf8cd41b01104c32ac15370508"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2529cc8240fcc91e8642754ce85e5360c2ee7f4435a76aa150e4ed746a5da4"
 dependencies = [
  "delog",
  "heapless",
@@ -1175,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.19#0fdecc93df800543aed0f1de0ea0f7178cf93b80"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.20#b34fa475c0c97bc7610ee65d11ecb2191f8d4770"
 dependencies = [
  "apdu-dispatch",
  "cbor-smol",
@@ -1726,7 +1727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,8 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "lpc55-hal"
-version = "0.3.0"
-source = "git+https://github.com/Nitrokey/lpc55-hal?tag=v0.3.0-nitrokey.2#781c97372d07e98d48828ae345412cc311bd4113"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e9bba980b3a2de5813c8db696806c59bdb5f57956c8137ebe1e10b2e988a53"
 dependencies = [
  "block-buffer 0.9.0",
  "cipher 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ memory-regions = { path = "components/memory-regions" }
 
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.13" }
-cbor-smol = { git = "https://github.com/Nitrokey/cbor-smol.git", tag = "v0.4.0-nitrokey.4"}
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.19" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.20" }
 lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/nitrokey/trussed.git", tag = "v0.1.0-nitrokey.21" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ memory-regions = { path = "components/memory-regions" }
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.13" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.20" }
-lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }
 trussed = { git = "https://github.com/nitrokey/trussed.git", tag = "v0.1.0-nitrokey.21" }
 
 # unreleased upstream changes

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -36,7 +36,7 @@ nrf52840-hal = { version = "0.15.1", optional = true }
 nrf52840-pac = { version = "0.11", optional = true }
 
 ### LPC55 specific dependencies
-lpc55-hal = { version = "0.3", features = ["littlefs"], optional = true }
+lpc55-hal = { version = "0.3.1", features = ["littlefs"], optional = true }
 lpc55-pac = { version = "0.4", optional = true }
 nb = { version = "1", optional = true }
 systick-monotonic = { version = "1.0.0", optional = true }


### PR DESCRIPTION
This patch updates fido-authenticator to fix compatibility with Firefox and also updates cbor-smol to 0.4.1 and lpc55-hal to 0.3.1.

See also:
- https://github.com/Nitrokey/fido-authenticator/pull/99