### PR TITLE
nix: Remove hash for rust-toolchain.toml

### DIFF
--- a/utils/nix/shell.nix
+++ b/utils/nix/shell.nix
@@ -13,7 +13,6 @@ let
     { };
   toolchain = fenix.fromToolchainFile {
     dir = ../..;
-    sha256 = "sha256-Q9UgzzvxLi4x9aWUJTn+/5EXekC98ODRU1TwhUs9RnY=";
   };
 in
 pkgs.mkShell {


### PR DESCRIPTION
Including the hash of the rust-toolchain.toml file in the Nix shell configuration leads to additional maintenance effort and does not provide significant benefits as the toolchain file is tracked by version control.