### PR TITLE
nk3xn: Remove reference to reconfigure-nfc feature

### DIFF
--- a/components/boards/src/nk3xn/nfc.rs
+++ b/components/boards/src/nk3xn/nfc.rs
@@ -27,7 +27,6 @@ pub fn try_setup(
     nfc_irq: Pin<NfcIrqPin, pin::state::Gpio<pin::gpio::direction::Input>>,
     // fm: &mut NfcChip,
     timer: &mut Timer<impl lpc55_hal::peripherals::ctimer::Ctimer<Enabled>>,
-    always_reconfig: bool,
     status: &mut InitStatus,
 ) -> Option<NfcChip> {
     // Start unselected.
@@ -56,8 +55,7 @@ pub fn try_setup(
         return None;
     }
 
-    let reconfig =
-        always_reconfig || (current_regu_config != REGU_CONFIG) || (is_select_int_masked);
+    let reconfig = (current_regu_config != REGU_CONFIG) || (is_select_int_masked);
 
     if reconfig {
         // info_now!("{:?}", fm.dump_eeprom() );

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -372,15 +372,12 @@ impl Stage2 {
         );
         mux.disabled(&mut self.peripherals.syscon);
 
-        let force_nfc_reconfig = cfg!(feature = "reconfigure-nfc");
-
         let nfc = nfc::try_setup(
             spi,
             &mut self.clocks.gpio,
             &mut self.clocks.iocon,
             nfc_irq,
             &mut self.basic.delay_timer,
-            force_nfc_reconfig,
             &mut self.status,
         )?;
 


### PR DESCRIPTION
The reconfigure-nfc feature has been removed when refactoring the runner because we’ve never used it.  This patch removes old code referencing the feature (fixing a new compiler warning).