### PR TITLE
lpc55-builder: Use GDB server CLI

### DIFF
--- a/utils/lpc55-builder/Makefile
+++ b/utils/lpc55-builder/Makefile
@@ -23,7 +23,7 @@ build-all:
 
 .PHONY: jlink
 jlink:
-	JLinkGDBServer -strict -device LPC55S69 -if SWD -vd
+	JLinkGDBServerCLExe -strict -device LPC55S69 -if SWD -vd
 
 .PHONY: run
 run: build


### PR DESCRIPTION
Previously, we used the JLinkGDBServer binary that links against the outdated Qt4.  This patch replaces it with JLinkGDBServerCLExe that is included in the same bundle to get rid of the EOL Qt4 dependency and to make sure that we always use CLI mode. (JLinkGDBServer sometimes runs in GUI mode and sometimes in CLI mode depending on the exact version and setup.)