### PR TITLE
make binaries: add elf binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,21 @@ binaries:
 	mkdir -p binaries
 	$(MAKE) -C runners/embedded build-all FEATURES=
 	cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin binaries/firmware-nk3xn.bin
+	cp runners/embedded/artifacts/runner-lpc55-nk3xn.elf binaries/firmware-nk3xn.elf
 	cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex binaries/firmware-nk3am.ihex
 	$(MAKE) -C runners/embedded build-all FEATURES=provisioner
 	cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin binaries/provisioner-nk3xn.bin
+	cp runners/embedded/artifacts/runner-lpc55-nk3xn.elf binaries/provisioner-nk3xn.elf
 	cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex binaries/provisioner-nk3am.ihex
 	$(MAKE) -C runners/embedded build-all FEATURES=test
 	cp runners/embedded/artifacts/runner-lpc55-nk3xn.bin binaries/firmware-nk3xn-test.bin
+	cp runners/embedded/artifacts/runner-lpc55-nk3xn.elf binaries/firmware-nk3xn-test.elf
 	cp runners/embedded/artifacts/runner-nrf52-bootloader-nk3am.bin.ihex binaries/firmware-nk3am-test.ihex
 	$(MAKE) -C runners/nkpk build
+	cp runners/nkpk/artifacts/runner-nkpk.elf binaries/firmware-nkpk.elf
 	cp runners/nkpk/artifacts/runner-nkpk.bin.ihex binaries/firmware-nkpk.ihex
 	$(MAKE) -C runners/nkpk build FEATURES=provisioner
+	cp runners/nkpk/artifacts/runner-nkpk.elf binaries/provisioner-nkpk.elf
 	cp runners/nkpk/artifacts/runner-nkpk.bin.ihex binaries/provisioner-nkpk.ihex
 
 .PHONY: metrics


### PR DESCRIPTION
These include the debug info, so we can extract them from the CI artifacts.