### PR TITLE
Update fido-authenticator to ensure credential ID stability and release v1.8.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - fido-authenticator: Implement the largeBlobKey extension and the largeBlobs command ([fido-authenticator#38][])
 
-## v1.8.0-rc.1 (2024-11-07)
+## v1.8.0-rc.2 (2024-12-03)
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "fido-authenticator"
 version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.23#5b6ae97b5f92962b545a1af1bf5b69fee66bca0a"
+source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.24#63a14793877f49e0bd6a99d28834a0013fdb9d64"
 dependencies = [
  "apdu-app",
  "cbor-smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "apps"
-version = "1.8.0-rc.1"
+version = "1.8.0-rc.2"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "boards"
-version = "1.8.0-rc.1"
+version = "1.8.0-rc.2"
 dependencies = [
  "apdu-dispatch",
  "apps",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-runner-lib"
-version = "1.8.0-rc.1"
+version = "1.8.0-rc.2"
 dependencies = [
  "alloc-cortex-m",
  "apdu-dispatch",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "usbip-runner"
-version = "1.8.0-rc.1"
+version = "1.8.0-rc.2"
 dependencies = [
  "apps",
  "cfg-if",
@@ -3578,7 +3578,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "1.8.0-rc.1"
+version = "1.8.0-rc.2"
 dependencies = [
  "chrono",
  "delog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ memory-regions = { path = "components/memory-regions" }
 
 # forked
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.18" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.23" }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git", tag = "v0.1.1-nitrokey.24" }
 trussed = { git = "https://github.com/nitrokey/trussed.git", tag = "v0.1.0-nitrokey.23" }
 
 # unreleased upstream changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.0-rc.1"
+version = "1.8.0-rc.2"
 
 [patch.crates-io]
 # components


### PR DESCRIPTION
This patch updates fido-authenticator to make sure that the credential ID for credentials generated with older firmware versions does not change, see https://github.com/Nitrokey/fido-authenticator/issues/111.