### PR TITLE
Configure the watchdog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,8 +1831,7 @@ dependencies = [
 [[package]]
 name = "lpc55-hal"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0434f9766e2521d8f550550f6c894e9bcf1503d0994d64feafa32981946203d"
+source = "git+https://github.com/lpc55/lpc55-hal.git?rev=841c6b27008a1c75ca0d03ecc1e4b2e015bdfad8#841c6b27008a1c75ca0d03ecc1e4b2e015bdfad8"
 dependencies = [
  "block-buffer 0.9.0",
  "cipher 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "lpc55-hal"
 version = "0.4.0"
-source = "git+https://github.com/lpc55/lpc55-hal.git?rev=841c6b27008a1c75ca0d03ecc1e4b2e015bdfad8#841c6b27008a1c75ca0d03ecc1e4b2e015bdfad8"
+source = "git+https://github.com/lpc55/lpc55-hal.git?rev=1a25fc366013503b46af938646c88aed4e36d74c#1a25fc366013503b46af938646c88aed4e36d74c"
 dependencies = [
  "block-buffer 0.9.0",
  "cipher 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ memory-regions = { path = "components/memory-regions" }
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "6bba8fde36d05c0227769eb63345744e87d84b2b" }
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "4fe4e4e287dac1d92fcd4f97e8926497bfa9d7a9" }
-lpc55-hal = { git = "https://github.com/lpc55/lpc55-hal.git", rev ="841c6b27008a1c75ca0d03ecc1e4b2e015bdfad8" }
+lpc55-hal = { git = "https://github.com/lpc55/lpc55-hal.git", rev ="1a25fc366013503b46af938646c88aed4e36d74c" }
 
 # applications
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.19" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ memory-regions = { path = "components/memory-regions" }
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "6bba8fde36d05c0227769eb63345744e87d84b2b" }
 trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "4fe4e4e287dac1d92fcd4f97e8926497bfa9d7a9" }
+lpc55-hal = { git = "https://github.com/lpc55/lpc55-hal.git", rev ="841c6b27008a1c75ca0d03ecc1e4b2e015bdfad8" }
 
 # applications
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.19" }

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -162,3 +162,5 @@ pub fn handle_hard_fault<B: Board>(_ef: &ExceptionFrame) -> ! {
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
     }
 }
+
+pub const WATCHDOG_DURATION_SECONDS: u64 = 15 * 60;

--- a/components/boards/src/nk3am.rs
+++ b/components/boards/src/nk3am.rs
@@ -266,7 +266,7 @@ pub fn power_handler(power: &mut POWER) {
     }
 }
 
-pub fn init_watchdog(wdt: WDT) -> wdt::Parts<(WatchdogHandle<Hdl0>,)> {
+pub fn init_watchdog(wdt: WDT) -> Result<wdt::Parts<(WatchdogHandle<Hdl0>,)>, WDT> {
     const WDT_FREQUENCY: u32 = 32_768;
     // Watchdog triggers after 3 minutes
     const DURATION_SECONS: u32 = 3 * 60;
@@ -276,15 +276,14 @@ pub fn init_watchdog(wdt: WDT) -> wdt::Parts<(WatchdogHandle<Hdl0>,)> {
         Ok(mut watchdog) => {
             watchdog.set_lfosc_ticks(TICKS);
             watchdog.enable_interrupt();
-            let parts = watchdog.activate::<One>();
+            let mut parts = watchdog.activate::<One>();
             parts.handles.0.pet();
-            parts
+            Ok(parts)
         }
         Err(wdt) => {
-            let parts = Watchdog::try_recover::<One>(wdt)
-                .expect("Recover should always work for one handle");
+            let mut parts = Watchdog::try_recover::<One>(wdt)?;
             parts.handles.0.pet();
-            parts
+            Ok(parts)
         }
     }
 }

--- a/components/boards/src/nk3am.rs
+++ b/components/boards/src/nk3am.rs
@@ -7,10 +7,14 @@ use nfc_device::traits::nfc::{Device as NfcDevice, Error as NfcError, State as N
 use nrf52840_hal::{
     gpio::{p0, p1, Level, Output, Pin, PushPull},
     gpiote::Gpiote,
+    pac::power::RESETREAS,
+    pac::WDT,
     prelude::OutputPin as _,
     spim,
     timer::Timer,
-    twim, Spim, Twim,
+    twim,
+    wdt::{self, count::One, handles::Hdl0, Watchdog, WatchdogHandle},
+    Spim, Twim,
 };
 use nrf52840_pac::{FICR, GPIOTE, P0, P1, POWER, PWM0, PWM1, PWM2, SPIM3, TIMER1, TWIM1};
 
@@ -260,4 +264,71 @@ pub fn power_handler(power: &mut POWER) {
         power.events_usbremoved.write(|w| unsafe { w.bits(0) });
         trace!("usb-");
     }
+}
+
+pub fn init_watchdog(wdt: WDT) -> wdt::Parts<(WatchdogHandle<Hdl0>,)> {
+    const WDT_FREQUENCY: u32 = 32_768;
+    // Watchdog triggers after 3 minutes
+    const DURATION_SECONS: u32 = 3 * 60;
+    const TICKS: u32 = DURATION_SECONS * WDT_FREQUENCY;
+
+    match Watchdog::try_new(wdt) {
+        Ok(mut watchdog) => {
+            watchdog.set_lfosc_ticks(TICKS);
+            watchdog.enable_interrupt();
+            let parts = watchdog.activate::<One>();
+            parts.handles.0.pet();
+            parts
+        }
+        Err(wdt) => {
+            let parts = Watchdog::try_recover::<One>(wdt)
+                .expect("Recover should always work for one handle");
+            parts.handles.0.pet();
+            parts
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ResetReason {
+    pub resetpin: bool,
+    /// Reset from watchdog
+    pub dog: bool,
+    /// Soft Reset
+    pub sreq: bool,
+    pub lockup: bool,
+    pub off: bool,
+    pub lpcomp: bool,
+    pub dif: bool,
+    pub nfc: bool,
+    pub vbus: bool,
+}
+
+pub fn reset_reason(reset_reason: &RESETREAS) -> ResetReason {
+    debug_now!("Reset Reason: {:b}", reset_reason.read().bits());
+    let read = reset_reason.read();
+    let res = ResetReason {
+        resetpin: read.resetpin().bits(),
+        dog: read.dog().bits(),
+        sreq: read.sreq().bits(),
+        lockup: read.lockup().bits(),
+        off: read.off().bits(),
+        lpcomp: read.lpcomp().bits(),
+        dif: read.dif().bits(),
+        nfc: read.nfc().bits(),
+        vbus: read.vbus().bits(),
+    };
+    reset_reason.write(|w| {
+        w.resetpin().bit(false);
+        w.dog().bit(false);
+        w.sreq().bit(false);
+        w.lockup().bit(false);
+        w.off().bit(false);
+        w.lpcomp().bit(false);
+        w.dif().bit(false);
+        w.nfc().bit(false);
+        w.vbus().bit(false);
+        w
+    });
+    res
 }

--- a/components/boards/src/soc/nrf52.rs
+++ b/components/boards/src/soc/nrf52.rs
@@ -65,9 +65,6 @@ pub fn init_bootup(
     uuid[0..4].copy_from_slice(&deviceid0.to_be_bytes());
     uuid[4..8].copy_from_slice(&deviceid1.to_be_bytes());
 
-    info!("RESET Reason: {:x}", power.resetreas.read().bits());
-    power.resetreas.write(|w| w);
-
     info!("FICR DeviceID {}", delog::hex_str!(&uuid),);
     info!(
         "FICR IdtRoot  {:08x} {:08x} {:08x} {:08x}",

--- a/components/boards/src/soc/nrf52.rs
+++ b/components/boards/src/soc/nrf52.rs
@@ -2,8 +2,9 @@ use apps::Variant;
 use nrf52840_hal::{
     clocks::Clocks,
     usbd::{UsbPeripheral, Usbd},
+    wdt::{self, count::One, handles::Hdl0, Watchdog, WatchdogHandle},
 };
-use nrf52840_pac::{Interrupt, SCB};
+use nrf52840_pac::{power::RESETREAS, Interrupt, SCB, WDT};
 
 use super::{Soc, Uuid};
 use rtic_monotonic::{RtcDuration, RtcMonotonic};
@@ -53,11 +54,7 @@ impl apps::Reboot for Nrf52 {
     }
 }
 
-pub fn init_bootup(
-    ficr: &nrf52840_pac::FICR,
-    uicr: &nrf52840_pac::UICR,
-    power: &mut nrf52840_pac::POWER,
-) -> Nrf52 {
+pub fn init_bootup(ficr: &nrf52840_pac::FICR, uicr: &nrf52840_pac::UICR) -> Nrf52 {
     let deviceid0 = ficr.deviceid[0].read().bits();
     let deviceid1 = ficr.deviceid[1].read().bits();
 
@@ -132,4 +129,59 @@ pub fn setup_usb_bus(
     });
 
     Usbd::new(UsbPeripheral::new(usb_pac, usb_clock))
+}
+
+#[derive(Debug)]
+pub struct ResetReason {
+    pub resetpin: bool,
+    /// Reset from watchdog
+    pub dog: bool,
+    /// Soft Reset
+    pub sreq: bool,
+    pub lockup: bool,
+    pub off: bool,
+    pub lpcomp: bool,
+    pub dif: bool,
+    pub nfc: bool,
+    pub vbus: bool,
+}
+
+pub fn reset_reason(reset_reason: &RESETREAS) -> ResetReason {
+    debug_now!("Reset Reason: {:b}", reset_reason.read().bits());
+    let read = reset_reason.read();
+    let res = ResetReason {
+        resetpin: read.resetpin().bits(),
+        dog: read.dog().bits(),
+        sreq: read.sreq().bits(),
+        lockup: read.lockup().bits(),
+        off: read.off().bits(),
+        lpcomp: read.lpcomp().bits(),
+        dif: read.dif().bits(),
+        nfc: read.nfc().bits(),
+        vbus: read.vbus().bits(),
+    };
+    reset_reason.write(|w| w);
+    res
+}
+
+pub fn init_watchdog(wdt: WDT) -> Result<wdt::Parts<(WatchdogHandle<Hdl0>,)>, WDT> {
+    const WDT_FREQUENCY: u32 = 32_768;
+    // Watchdog triggers after 3 minutes
+    const DURATION_SECONS: u32 = 15 * 60;
+    const TICKS: u32 = DURATION_SECONS * WDT_FREQUENCY;
+
+    match Watchdog::try_new(wdt) {
+        Ok(mut watchdog) => {
+            watchdog.set_lfosc_ticks(TICKS);
+            watchdog.enable_interrupt();
+            let mut parts = watchdog.activate::<One>();
+            parts.handles.0.pet();
+            Ok(parts)
+        }
+        Err(wdt) => {
+            let mut parts = Watchdog::try_recover::<One>(wdt)?;
+            parts.handles.0.pet();
+            Ok(parts)
+        }
+    }
 }

--- a/components/boards/src/soc/nrf52.rs
+++ b/components/boards/src/soc/nrf52.rs
@@ -7,6 +7,7 @@ use nrf52840_hal::{
 use nrf52840_pac::{power::RESETREAS, Interrupt, SCB, WDT};
 
 use super::{Soc, Uuid};
+use crate::WATCHDOG_DURATION_SECONDS;
 use rtic_monotonic::{RtcDuration, RtcMonotonic};
 
 pub mod flash;
@@ -166,9 +167,7 @@ pub fn reset_reason(reset_reason: &RESETREAS) -> ResetReason {
 
 pub fn init_watchdog(wdt: WDT) -> Result<wdt::Parts<(WatchdogHandle<Hdl0>,)>, WDT> {
     const WDT_FREQUENCY: u32 = 32_768;
-    // Watchdog triggers after 15 minutes
-    const DURATION_SECONDS: u32 = 15 * 60;
-    const TICKS: u32 = DURATION_SECONDS * WDT_FREQUENCY;
+    const TICKS: u32 = (WATCHDOG_DURATION_SECONDS as u32) * WDT_FREQUENCY;
 
     match Watchdog::try_new(wdt) {
         Ok(mut watchdog) => {

--- a/components/boards/src/soc/nrf52.rs
+++ b/components/boards/src/soc/nrf52.rs
@@ -166,9 +166,9 @@ pub fn reset_reason(reset_reason: &RESETREAS) -> ResetReason {
 
 pub fn init_watchdog(wdt: WDT) -> Result<wdt::Parts<(WatchdogHandle<Hdl0>,)>, WDT> {
     const WDT_FREQUENCY: u32 = 32_768;
-    // Watchdog triggers after 3 minutes
-    const DURATION_SECONS: u32 = 15 * 60;
-    const TICKS: u32 = DURATION_SECONS * WDT_FREQUENCY;
+    // Watchdog triggers after 15 minutes
+    const DURATION_SECONDS: u32 = 15 * 60;
+    const TICKS: u32 = DURATION_SECONDS * WDT_FREQUENCY;
 
     match Watchdog::try_new(wdt) {
         Ok(mut watchdog) => {

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -114,7 +114,7 @@ mod app {
             trussed,
             apps,
             clock_controller,
-            wwdt, 
+            wwdt,
         } = nk3xn::init(c.device, c.core, c.local.resources);
         let perf_timer = basic.perf_timer;
         let wait_extender = basic.delay_timer;

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -93,7 +93,9 @@ mod app {
     }
 
     #[local]
-    struct LocalResources {}
+    struct LocalResources {
+        wwdt: nk3xn::init::EnabledWwdt,
+    }
 
     // TODO: replace
     #[monotonic(binds = SysTick, default = true)]
@@ -101,6 +103,8 @@ mod app {
 
     #[init(local = [resources: Resources<NK3xN> = Resources::new()])]
     fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
+        let was_reset_from_wwdt = c.device.PMC.aoreg1.read().wdtreset().bit();
+
         #[cfg(feature = "alloc")]
         embedded_runner_lib::init_alloc();
 
@@ -110,6 +114,7 @@ mod app {
             trussed,
             apps,
             clock_controller,
+            wwdt, 
         } = nk3xn::init(c.device, c.core, c.local.resources);
         let perf_timer = basic.perf_timer;
         let wait_extender = basic.delay_timer;
@@ -123,6 +128,11 @@ mod app {
         let systick = unsafe { lpc55_hal::raw::CorePeripherals::steal() }.SYST;
         let systick = Systick::new(systick, 96_000_000); // TODO: read out sysclk
 
+        debug_now!("Reset from watchdog: {}", was_reset_from_wwdt);
+        if was_reset_from_wwdt {
+            lpc55_hal::boot_to_bootrom();
+        }
+
         let shared = SharedResources {
             apdu_dispatch: usb_nfc.apdu_dispatch,
             ctaphid_dispatch: usb_nfc.ctaphid_dispatch,
@@ -134,10 +144,14 @@ mod app {
             clock_ctrl: clock_controller,
             wait_extender,
         };
-        (shared, LocalResources {}, init::Monotonics(systick.into()))
+        (
+            shared,
+            LocalResources { wwdt },
+            init::Monotonics(systick.into()),
+        )
     }
 
-    #[idle(shared = [apdu_dispatch, ctaphid_dispatch, apps, perf_timer, usb_classes])]
+    #[idle(shared = [apdu_dispatch, ctaphid_dispatch, apps, perf_timer, usb_classes], local = [wwdt])]
     fn idle(c: idle::Context) -> ! {
         let idle::SharedResources {
             mut apdu_dispatch,
@@ -146,6 +160,7 @@ mod app {
             mut perf_timer,
             mut usb_classes,
         } = c.shared;
+        let idle::LocalResources { mut wwdt } = c.local;
 
         info_now!("inside IDLE, initial SP = {:08X}", super::msp());
         loop {
@@ -156,9 +171,12 @@ mod app {
                     perf_timer.start(60_000_000.microseconds());
                 }
             });
+            wwdt.feed();
 
             #[cfg(not(feature = "no-delog"))]
             if time > 1_200_000 {
+                let counter = wwdt.timer();
+                info_now!("Current wwdt counter: {}", wwdt.timer());
                 boards::init::Delogger::flush();
             }
 

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -160,7 +160,7 @@ mod app {
             mut perf_timer,
             mut usb_classes,
         } = c.shared;
-        let idle::LocalResources { mut wwdt } = c.local;
+        let idle::LocalResources { wwdt } = c.local;
 
         info_now!("inside IDLE, initial SP = {:08X}", super::msp());
         loop {
@@ -175,8 +175,6 @@ mod app {
 
             #[cfg(not(feature = "no-delog"))]
             if time > 1_200_000 {
-                let counter = wwdt.timer();
-                info_now!("Current wwdt counter: {}", wwdt.timer());
                 boards::init::Delogger::flush();
             }
 

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -61,7 +61,7 @@ mod app {
 
         boards::init::init_logger::<Board>(VERSION_STRING);
 
-        let reset_reason = nk3am::reset_reason(&ctx.device.POWER.resetreas);
+        let reset_reason = nrf52::reset_reason(&ctx.device.POWER.resetreas);
         debug_now!("Reset Reason: {reset_reason:?}");
 
         // Go to bootloader after watchdog failure
@@ -72,9 +72,9 @@ mod app {
             Nrf52::reboot_to_firmware_update();
         }
 
-        let soc = nrf52::init_bootup(&ctx.device.FICR, &ctx.device.UICR, &mut ctx.device.POWER);
+        let soc = nrf52::init_bootup(&ctx.device.FICR, &ctx.device.UICR);
 
-        let wdt_parts = nk3am::init_watchdog(ctx.device.WDT);
+        let wdt_parts = nrf52::init_watchdog(ctx.device.WDT);
 
         let mut board_gpio = nk3am::init_pins(ctx.device.GPIOTE, ctx.device.P0, ctx.device.P1);
 
@@ -184,10 +184,9 @@ mod app {
         // cortex_m::asm::wfi();
 
         loop {
-            ctx.local
-                .watchdog_parts
-                .as_mut()
-                .map(|mut parts| parts.handles.pet());
+            if let Some(ref mut parts) = ctx.local.watchdog_parts {
+                parts.handles.pet();
+            }
 
             #[cfg(not(feature = "no-delog"))]
             boards::init::Delogger::flush();

--- a/runners/embedded/src/nk3xn.rs
+++ b/runners/embedded/src/nk3xn.rs
@@ -21,7 +21,7 @@ pub fn init(
     let boot_to_bootrom = true;
 
     init::start(hal.syscon, hal.pmc, hal.anactrl)
-        .next(hal.iocon, hal.gpio)
+        .next(hal.iocon, hal.gpio, hal.wwdt)
         .next(
             hal.adc,
             hal.ctimer.0,

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -155,10 +155,11 @@ impl Stage0 {
         wwdt: WWDT,
     ) -> Stage1 {
         let mut wwdt = Wwdt::try_new(wwdt, &self.peripherals.syscon, 63).unwrap();
-        // Frequency is 1/(4*64) MHz, there is a built-in 4x multiplier, 15min timer
-        wwdt.set_timer(3_515_625).unwrap();
+        // Frequency is 1/(4*64) MHz, there is a built-in 4x multiplier
+        const TIMER_COUNT: u32 = (1_000_000 / (4 * 64) * boards::WATCHDOG_DURATION_SECONDS) as u32;
+        wwdt.set_timer(TIMER_COUNT).unwrap();
         wwdt.set_warning(0b1_1111_1111).unwrap();
-        let mut wwdt = wwdt.set_resetting().set_enabled();
+        let wwdt = wwdt.set_resetting().set_enabled();
         debug_now!("Wwdt tv: {:?}", wwdt.timer());
         let mut iocon = iocon.enabled(&mut self.peripherals.syscon);
         let mut gpio = gpio.enabled(&mut self.peripherals.syscon);

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -47,7 +47,9 @@ use hal::{
         prince::Prince,
         rng::Rng,
         usbhs::Usbhs,
+        wwdt::{self, Wwdt},
     },
+    raw::WWDT,
     time::{DurationExtensions as _, RateExtensions as _},
     traits::wg::digital::v2::InputPin,
     typestates::{
@@ -68,6 +70,11 @@ use utils::OptionalStorage;
 use crate::{VERSION, VERSION_STRING};
 
 type UsbBusType = usb_device::bus::UsbBusAllocator<<Lpc55 as Soc>::UsbBus>;
+
+pub type WwdtEnabled = wwdt::Active;
+pub type WwdtResetting = wwdt::Active;
+pub type WwdtProtecting = wwdt::Inactive;
+pub type EnabledWwdt = Wwdt<WwdtEnabled, WwdtResetting, WwdtProtecting>;
 
 struct Peripherals {
     syscon: hal::Syscon,
@@ -141,7 +148,18 @@ impl Stage0 {
     }
 
     #[inline(never)]
-    pub fn next(mut self, iocon: hal::Iocon<Unknown>, gpio: hal::Gpio<Unknown>) -> Stage1 {
+    pub fn next(
+        mut self,
+        iocon: hal::Iocon<Unknown>,
+        gpio: hal::Gpio<Unknown>,
+        wwdt: WWDT,
+    ) -> Stage1 {
+        let mut wwdt = Wwdt::try_new(wwdt, &self.peripherals.syscon, 63).unwrap();
+        // Frequency is 1/(4*64) MHz, there is a built-in 4x multiplier, 15min timer
+        wwdt.set_timer(3_515_625).unwrap();
+        wwdt.set_warning(0b1_1111_1111).unwrap();
+        let mut wwdt = wwdt.set_resetting().set_enabled();
+        debug_now!("Wwdt tv: {:?}", wwdt.timer());
         let mut iocon = iocon.enabled(&mut self.peripherals.syscon);
         let mut gpio = gpio.enabled(&mut self.peripherals.syscon);
 
@@ -158,10 +176,12 @@ impl Stage0 {
             iocon,
             gpio,
         };
+        debug_now!("Wwdt tv again: {:?}", wwdt.timer());
         Stage1 {
             status: self.status,
             peripherals: self.peripherals,
             clocks,
+            wwdt,
         }
     }
 }
@@ -170,6 +190,7 @@ pub struct Stage1 {
     status: InitStatus,
     peripherals: Peripherals,
     clocks: Clocks,
+    wwdt: EnabledWwdt,
 }
 
 impl Stage1 {
@@ -335,6 +356,7 @@ impl Stage1 {
             clocks: self.clocks,
             se050_timer,
             basic,
+            wwdt: self.wwdt,
         }
     }
 }
@@ -345,6 +367,7 @@ pub struct Stage2 {
     clocks: Clocks,
     basic: Basic,
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
+    wwdt: EnabledWwdt,
 }
 
 impl Stage2 {
@@ -471,6 +494,7 @@ impl Stage2 {
             spi,
             se050_timer: self.se050_timer,
             se050_i2c,
+            wwdt: self.wwdt,
         }
     }
 }
@@ -485,6 +509,7 @@ pub struct Stage3 {
     spi: Option<Spi>,
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
     se050_i2c: Option<I2C>,
+    wwdt: EnabledWwdt,
 }
 
 impl Stage3 {
@@ -522,6 +547,7 @@ impl Stage3 {
             se050_timer: self.se050_timer,
             se050_i2c: self.se050_i2c,
             flash,
+            wwdt: self.wwdt,
         }
     }
 }
@@ -537,6 +563,7 @@ pub struct Stage4 {
     flash: Flash,
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
     se050_i2c: Option<I2C>,
+    wwdt: EnabledWwdt,
 }
 
 impl Stage4 {
@@ -641,6 +668,7 @@ impl Stage4 {
             se050_timer: self.se050_timer,
             se050_i2c: self.se050_i2c,
             store,
+            wwdt: self.wwdt,
         }
     }
 }
@@ -690,6 +718,7 @@ pub struct Stage5 {
     store: RunnerStore<NK3xN>,
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
     se050_i2c: Option<I2C>,
+    wwdt: EnabledWwdt,
 }
 
 impl Stage5 {
@@ -738,6 +767,7 @@ impl Stage5 {
             nfc_rp: self.nfc_rp,
             store: self.store,
             trussed,
+            wwdt: self.wwdt,
         }
     }
 }
@@ -751,6 +781,7 @@ pub struct Stage6 {
     nfc_rp: CcidResponder<'static>,
     store: RunnerStore<NK3xN>,
     trussed: Trussed<NK3xN>,
+    wwdt: EnabledWwdt,
 }
 
 impl Stage6 {
@@ -837,6 +868,7 @@ impl Stage6 {
         };
 
         info!("init took {} ms", self.basic.perf_timer.elapsed().0 / 1000);
+        debug_now!("Wwdt tv again: {:?}", self.wwdt.timer());
 
         All {
             basic: self.basic,
@@ -844,6 +876,7 @@ impl Stage6 {
             apps,
             clock_controller,
             usb_nfc,
+            wwdt: self.wwdt,
         }
     }
 }
@@ -854,6 +887,7 @@ pub struct All {
     pub trussed: Trussed<NK3xN>,
     pub apps: Apps<NK3xN>,
     pub clock_controller: Option<DynamicClockController>,
+    pub wwdt: EnabledWwdt,
 }
 
 #[inline(never)]


### PR DESCRIPTION
Behaviour is:

After a watchdog reset: restart to bootloader
For the NRF52: Any soft reset after that (for example after an update): restart normally (this is because it is not possible to clear the `RESETREAS` (reset reason), so the watchdog bit is always set after the first time the watchdog is triggered. This means that clearing requires a power cycle.

Watchdog is configured for 15 minutes, to make sure it does not break any operation.

Depends on:

- https://github.com/lpc55/lpc55-hal/pull/76