### PR TITLE
Move some statics into init task

### DIFF
--- a/components/boards/src/init.rs
+++ b/components/boards/src/init.rs
@@ -23,10 +23,39 @@ use usbd_ccid::Ccid;
 use usbd_ctaphid::CtapHid;
 use utils::Version;
 
-use crate::{soc::Soc, Apps, Board, Runner, RunnerPlatform, RunnerStore, Trussed, UserInterface};
+use crate::{
+    soc::Soc, store::StoreResources, Apps, Board, Runner, RunnerPlatform, RunnerStore, Trussed,
+    UserInterface,
+};
 
 #[cfg(not(feature = "no-delog"))]
 delog!(Delogger, 3 * 1024, 512, DelogFlusher);
+
+pub struct Resources<B: Board> {
+    pub board: Option<B::Resources>,
+    pub store: StoreResources<B>,
+    pub usb: UsbResources<B>,
+}
+
+impl<B: Board> Resources<B> {
+    pub const fn new() -> Self {
+        Self {
+            board: None,
+            store: StoreResources::new(),
+            usb: UsbResources::new(),
+        }
+    }
+}
+
+pub struct UsbResources<B: Board> {
+    usb_bus: Option<UsbBusAllocator<<B::Soc as Soc>::UsbBus>>,
+}
+
+impl<B: Board> UsbResources<B> {
+    pub const fn new() -> Self {
+        Self { usb_bus: None }
+    }
+}
 
 #[derive(Debug)]
 pub struct DelogFlusher {}
@@ -84,7 +113,8 @@ const USB_MANUFACTURER: &str = "Nitrokey";
 const USB_VENDOR_ID: u16 = 0x20A0;
 
 pub fn init_usb_nfc<B: Board>(
-    usb_bus: Option<&'static UsbBusAllocator<<B::Soc as Soc>::UsbBus>>,
+    resources: &'static mut UsbResources<B>,
+    usb_bus: Option<UsbBusAllocator<<B::Soc as Soc>::UsbBus>>,
     nfc: Option<Iso14443<B::NfcDevice>>,
     nfc_rp: CcidResponder<'static>,
     usb_product: &'static str,
@@ -105,6 +135,8 @@ pub fn init_usb_nfc<B: Board>(
 
     /* populate requesters (if bus options are provided) */
     let usb_classes = usb_bus.map(|usb_bus| {
+        let usb_bus = resources.usb_bus.insert(usb_bus);
+
         /* Class #1: CCID */
         let ccid = Ccid::new(usb_bus, ccid_rq, Some(CARD_ISSUER));
 

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -45,6 +45,8 @@ pub type Apps<B> = apps::Apps<Runner<B>>;
 pub trait Board: StoragePointers {
     type Soc: Soc;
 
+    type Resources;
+
     type NfcDevice: NfcDevice;
     type Buttons: UserPresence;
     type Led: RgbLed;

--- a/components/boards/src/nk3am.rs
+++ b/components/boards/src/nk3am.rs
@@ -16,7 +16,7 @@ use nrf52840_pac::{FICR, GPIOTE, P0, P1, POWER, PWM0, PWM1, PWM2, SPIM3, TIMER1,
 
 use crate::{
     flash::ExtFlashStorage,
-    soc::nrf52::{flash::FlashStorage, rtic_monotonic::RtcMonotonic, Nrf52},
+    soc::nrf52::{flash::FlashStorage, rtic_monotonic::RtcMonotonic, Nrf52, UsbClockType},
     store::impl_storage_pointers,
     ui::UserInterface,
     Board,
@@ -37,6 +37,8 @@ pub struct NK3AM;
 
 impl Board for NK3AM {
     type Soc = Nrf52;
+
+    type Resources = UsbClockType;
 
     type NfcDevice = DummyNfc;
     type Buttons = HardwareButtons;

--- a/components/boards/src/nk3xn.rs
+++ b/components/boards/src/nk3xn.rs
@@ -59,6 +59,8 @@ pub struct NK3xN;
 impl Board for NK3xN {
     type Soc = Lpc55;
 
+    type Resources = ();
+
     type NfcDevice = NfcChip;
     type Buttons = button::ThreeButtons;
     type Led = led::RgbLed;

--- a/components/boards/src/nkpk.rs
+++ b/components/boards/src/nkpk.rs
@@ -8,7 +8,7 @@ use super::nk3am::{
     DummyNfc,
 };
 use crate::{
-    soc::nrf52::{flash::FlashStorage, Nrf52},
+    soc::nrf52::{flash::FlashStorage, Nrf52, UsbClockType},
     store::impl_storage_pointers,
     Board,
 };
@@ -21,6 +21,8 @@ pub struct NKPK;
 
 impl Board for NKPK {
     type Soc = Nrf52;
+
+    type Resources = UsbClockType;
 
     type NfcDevice = DummyNfc;
     type Buttons = HardwareButtons;

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -18,7 +18,7 @@ pub fn msp() -> u32 {
 mod app {
     use apdu_dispatch::dispatch::ApduDispatch;
     use boards::{
-        init::UsbClasses,
+        init::{Resources, UsbClasses},
         nk3xn::{nfc::NfcChip, NK3xN},
         runtime,
         soc::lpc55::{self, monotonic::SystickMonotonic},
@@ -99,7 +99,7 @@ mod app {
     #[monotonic(binds = SysTick, default = true)]
     type Monotonic = SystickMonotonic;
 
-    #[init()]
+    #[init(local = [resources: Resources<NK3xN> = Resources::new()])]
     fn init(c: init::Context) -> (SharedResources, LocalResources, init::Monotonics) {
         #[cfg(feature = "alloc")]
         embedded_runner_lib::init_alloc();
@@ -110,7 +110,7 @@ mod app {
             trussed,
             apps,
             clock_controller,
-        } = nk3xn::init(c.device, c.core);
+        } = nk3xn::init(c.device, c.core, c.local.resources);
         let perf_timer = basic.perf_timer;
         let wait_extender = basic.delay_timer;
 

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -2,7 +2,11 @@
 #![warn(trivial_casts, unused, unused_qualifications)]
 
 use apdu_dispatch::interchanges::Responder as CcidResponder;
-use boards::{init::UsbNfc, soc::Soc, Board};
+use boards::{
+    init::{UsbNfc, UsbResources},
+    soc::Soc,
+    Board,
+};
 use nfc_device::Iso14443;
 use usb_device::bus::UsbBusAllocator;
 use utils::Version;
@@ -31,11 +35,20 @@ pub fn init_alloc() {
 }
 
 pub fn init_usb_nfc<B: Board>(
-    usb_bus: Option<&'static UsbBusAllocator<<B::Soc as Soc>::UsbBus>>,
+    resources: &'static mut UsbResources<B>,
+    usb_bus: Option<UsbBusAllocator<<B::Soc as Soc>::UsbBus>>,
     nfc: Option<Iso14443<B::NfcDevice>>,
     nfc_rp: CcidResponder<'static>,
 ) -> UsbNfc<B> {
     const USB_PRODUCT: &str = "Nitrokey 3";
     const USB_PRODUCT_ID: u16 = 0x42B2;
-    boards::init::init_usb_nfc(usb_bus, nfc, nfc_rp, USB_PRODUCT, USB_PRODUCT_ID, VERSION)
+    boards::init::init_usb_nfc(
+        resources,
+        usb_bus,
+        nfc,
+        nfc_rp,
+        USB_PRODUCT,
+        USB_PRODUCT_ID,
+        VERSION,
+    )
 }

--- a/runners/embedded/src/nk3xn.rs
+++ b/runners/embedded/src/nk3xn.rs
@@ -1,12 +1,13 @@
 pub mod init;
 
-use boards::nk3xn::NK3xN;
+use boards::{init::Resources, nk3xn::NK3xN};
 
 use crate::{VERSION, VERSION_STRING};
 
 pub fn init(
     device_peripherals: lpc55_hal::raw::Peripherals,
     core_peripherals: rtic::export::Peripherals,
+    resources: &'static mut Resources<NK3xN>,
 ) -> init::All {
     const SECURE_FIRMWARE_VERSION: u32 = VERSION.encode();
 
@@ -41,7 +42,7 @@ pub fn init(
             nfc_enabled,
         )
         .next(hal.rng, hal.prince, hal.flash)
-        .next()
+        .next(&mut resources.store)
         .next(hal.rtc)
-        .next(hal.usbhs)
+        .next(&mut resources.usb, hal.usbhs)
 }


### PR DESCRIPTION
To avoid unsafe code and fix some clippy lints, we can move static muts into the locals for the init task which also have static lifetime.  This is currently not possible for all statics because some need to be accessed globally.  This patch moves the easy cases into a new Resources struct and adds it to the locals of the init task.