### PR TITLE
Update trussed-auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "serde",
  "trussed",
  "trussed-auth",
+ "trussed-auth-backend",
  "trussed-chunked",
  "trussed-core",
  "trussed-fs-info",
@@ -1143,7 +1144,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 [[package]]
 name = "encrypted_container"
 version = "0.1.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=01728a5a5cdd825835a1bea00807b8a8e080e2b8#01728a5a5cdd825835a1bea00807b8a8e080e2b8"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=700863bdfa90a3616cbb695d6638c7aea7730c03#700863bdfa90a3616cbb695d6638c7aea7730c03"
 dependencies = [
  "cbor-smol",
  "delog",
@@ -2128,7 +2129,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "opcard"
 version = "1.5.0"
-source = "git+https://github.com/Nitrokey/opcard-rs?rev=84fd887ac32b59f3451d1fbee21b04a56b07780b#84fd887ac32b59f3451d1fbee21b04a56b07780b"
+source = "git+https://github.com/Nitrokey/opcard-rs?rev=39ec4c37f808c0cfeb84e0a8493bbee06f02c8e2#39ec4c37f808c0cfeb84e0a8493bbee06f02c8e2"
 dependencies = [
  "admin-app",
  "apdu-app",
@@ -2239,7 +2240,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "piv-authenticator"
 version = "0.3.8"
-source = "git+https://github.com/Nitrokey/piv-authenticator.git?rev=95408fceeb8035fa055516d9848519a6e54305c5#95408fceeb8035fa055516d9848519a6e54305c5"
+source = "git+https://github.com/Nitrokey/piv-authenticator.git?rev=65552820b4f931c21e1c7675b1bd6072cb872531#65552820b4f931c21e1c7675b1bd6072cb872531"
 dependencies = [
  "apdu-app",
  "cbor-smol",
@@ -2676,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "secrets-app"
 version = "0.13.0"
-source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=01728a5a5cdd825835a1bea00807b8a8e080e2b8#01728a5a5cdd825835a1bea00807b8a8e080e2b8"
+source = "git+https://github.com/Nitrokey/trussed-secrets-app?rev=700863bdfa90a3616cbb695d6638c7aea7730c03#700863bdfa90a3616cbb695d6638c7aea7730c03"
 dependencies = [
  "apdu-app",
  "bitflags 2.6.0",
@@ -3233,8 +3234,18 @@ dependencies = [
 
 [[package]]
 name = "trussed-auth"
-version = "0.3.0"
-source = "git+https://github.com/trussed-dev/trussed-auth?rev=fc53539536d7658c45a492585041742d8cdc45d0#fc53539536d7658c45a492585041742d8cdc45d0"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3110004319491b9210f50c3653a574d354e27a3de73ae5a3dfc2e686027702e7"
+dependencies = [
+ "serde",
+ "trussed-core",
+]
+
+[[package]]
+name = "trussed-auth-backend"
+version = "0.1.0"
+source = "git+https://github.com/trussed-dev/trussed-auth?tag=v0.4.0#ab6ad8422531fb4801fee795cb44baa375320f15"
 dependencies = [
  "chacha20poly1305",
  "hkdf",
@@ -3246,6 +3257,7 @@ dependencies = [
  "sha2",
  "subtle",
  "trussed",
+ "trussed-auth",
  "trussed-core",
 ]
 
@@ -3335,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "trussed-se050-backend"
 version = "0.3.6"
-source = "git+https://github.com/Nitrokey/trussed-se050-backend.git?rev=58b442331e997b0c50525276258d66d069478f15#58b442331e997b0c50525276258d66d069478f15"
+source = "git+https://github.com/Nitrokey/trussed-se050-backend.git?rev=131c973fbe74d677fb8c8df97c210f78608994f0#131c973fbe74d677fb8c8df97c210f78608994f0"
 dependencies = [
  "bitflags 2.6.0",
  "cbor-smol",
@@ -3361,6 +3373,7 @@ dependencies = [
  "sha2",
  "trussed",
  "trussed-auth",
+ "trussed-auth-backend",
  "trussed-core",
  "trussed-hpke",
  "trussed-manage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", re
 # applications
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.19" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git",tag = "v0.1.1-nitrokey.25" }
-opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "84fd887ac32b59f3451d1fbee21b04a56b07780b" }
-piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator.git", rev = "95408fceeb8035fa055516d9848519a6e54305c5" }
-secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "01728a5a5cdd825835a1bea00807b8a8e080e2b8" }
+opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "39ec4c37f808c0cfeb84e0a8493bbee06f02c8e2" }
+piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator.git", rev = "65552820b4f931c21e1c7675b1bd6072cb872531" }
+secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "700863bdfa90a3616cbb695d6638c7aea7730c03" }
 webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc11" }
 
 # backends
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "fc53539536d7658c45a492585041742d8cdc45d0" }
+trussed-auth-backend = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.4.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "743d9aaa3d8a17d7dbf492bd54dc18ab8fca3dc0" }
-trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", rev = "58b442331e997b0c50525276258d66d069478f15" }
+trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", rev = "131c973fbe74d677fb8c8df97c210f78608994f0" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "1e1ca03a3a62ea9b802f4070ea4bce002eeb4bec" }
 
 [profile.release]

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -22,12 +22,13 @@ if_chain = "1.0.2"
 littlefs2-core = "0.1"
 
 # Backends
-trussed-auth = { version = "0.3.0", optional = true }
+trussed-auth-backend = { version = "0.1.0", optional = true }
 trussed-rsa-alloc = { version = "0.2.0", optional = true }
 trussed-se050-backend = { version = "0.3.6", optional = true }
 trussed-staging = { version = "0.3.2", features = ["wrap-key-to-file", "chunked", "hkdf", "manage", "fs-info"] }
 
 # Extensions
+trussed-auth = { version = "0.4", optional = true }
 trussed-chunked = "0.2.0"
 trussed-hkdf = "0.3.0"
 trussed-manage = "0.2.0"
@@ -75,7 +76,7 @@ piv-authenticator = ["dep:piv-authenticator", "backend-rsa", "backend-auth", "tr
 se050 = ["dep:se05x", "trussed-se050-backend", "trussed-se050-manage", "admin-app/se050"]
 
 # backends
-backend-auth = ["trussed-auth"]
+backend-auth = ["trussed-auth", "trussed-auth-backend"]
 backend-rsa = ["trussed-rsa-alloc"]
 backend-software-hpke = ["trussed-staging/hpke"]
 

--- a/components/apps/src/dispatch.rs
+++ b/components/apps/src/dispatch.rs
@@ -31,7 +31,9 @@ use trussed_se050_backend::{Context as Se050Context, Se050Backend};
 use trussed_se050_manage::Se050ManageExtension;
 
 #[cfg(feature = "backend-auth")]
-use trussed_auth::{AuthBackend, AuthContext, AuthExtension, MAX_HW_KEY_LEN};
+use trussed_auth::AuthExtension;
+#[cfg(feature = "backend-auth")]
+use trussed_auth_backend::{AuthBackend, AuthContext, MAX_HW_KEY_LEN};
 
 #[cfg(feature = "backend-rsa")]
 use trussed_rsa_alloc::SoftwareRsa;

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -582,8 +582,8 @@ impl<R: Runner> Apps<R> {
             && !app.config().opcard.use_se050_backend
         {
             use core::mem;
-            let opcard_trussed_auth_used = trussed_auth::AuthBackend::is_client_active(
-                trussed_auth::FilesystemLayout::V0,
+            let opcard_trussed_auth_used = trussed_auth_backend::AuthBackend::is_client_active(
+                trussed_auth_backend::FilesystemLayout::V0,
                 dispatch::AUTH_LOCATION,
                 path!("opcard"),
                 data.store,

--- a/components/apps/src/migrations.rs
+++ b/components/apps/src/migrations.rs
@@ -6,8 +6,8 @@ use littlefs2_core::path;
 pub(crate) const MIGRATION_VERSION_SPACE_EFFICIENCY: u32 = 1;
 
 #[cfg(feature = "backend-auth")]
-pub(crate) const TRUSSED_AUTH_FS_LAYOUT: trussed_auth::FilesystemLayout =
-    trussed_auth::FilesystemLayout::V1;
+pub(crate) const TRUSSED_AUTH_FS_LAYOUT: trussed_auth_backend::FilesystemLayout =
+    trussed_auth_backend::FilesystemLayout::V1;
 #[cfg(feature = "se050")]
 pub(crate) const SE050_BACKEND_FS_LAYOUT: trussed_se050_backend::FilesystemLayout =
     trussed_se050_backend::FilesystemLayout::V1;
@@ -25,7 +25,7 @@ pub(crate) const MIGRATORS: &[Migrator] = &[
     #[cfg(feature = "backend-auth")]
     Migrator {
         migrate: |ifs, _efs| {
-            trussed_auth::migrate::migrate_remove_dat(
+            trussed_auth_backend::migrate::migrate_remove_dat(
                 ifs,
                 &[
                     path!("opcard"),


### PR DESCRIPTION
This patch updates to the released trussed-auth v0.4.0.  The crate now only provides the extension.  The backend has been moved to the trussed-auth-backend crate.

Depends on:
- https://github.com/Nitrokey/opcard-rs/pull/218
- https://github.com/Nitrokey/piv-authenticator/pull/71
- https://github.com/Nitrokey/trussed-secrets-app/pull/128
- https://github.com/Nitrokey/trussed-se050-backend/pull/47