### PR TITLE
Update trussed to remove clients-? features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "heapless-bytes",
  "hex",
  "if_chain",
+ "interchange",
  "littlefs2-core",
  "ndef-app",
  "opcard",
@@ -1780,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "littlefs2-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250ec1e3017a4540932dc8b33daca325cb6195cded097e1addd9111d9ea2c48f"
+checksum = "9a81a4745d38b288b7583fe8ea3736897628df81f4d0f1d0314fa5a3af570de4"
 dependencies = [
  "bitflags 2.6.0",
  "heapless-bytes",
@@ -3196,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "trussed"
 version = "0.1.0"
-source = "git+https://github.com/trussed-dev/trussed.git?rev=6bba8fde36d05c0227769eb63345744e87d84b2b#6bba8fde36d05c0227769eb63345744e87d84b2b"
+source = "git+https://github.com/trussed-dev/trussed.git?rev=805fe7657e79e06b3220324481cd6325b94877d7#805fe7657e79e06b3220324481cd6325b94877d7"
 dependencies = [
  "aes",
  "bitflags 2.6.0",
@@ -3420,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner.git?rev=4fe4e4e287dac1d92fcd4f97e8926497bfa9d7a9#4fe4e4e287dac1d92fcd4f97e8926497bfa9d7a9"
+source = "git+https://github.com/trussed-dev/pc-usbip-runner.git?rev=a0e9b855809577f0067a93e08c716aa285b03700#a0e9b855809577f0067a93e08c716aa285b03700"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ memory-regions = { path = "components/memory-regions" }
 
 # unreleased libraries
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "6bba8fde36d05c0227769eb63345744e87d84b2b" }
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "4fe4e4e287dac1d92fcd4f97e8926497bfa9d7a9" }
 lpc55-hal = { git = "https://github.com/lpc55/lpc55-hal.git", rev ="1a25fc366013503b46af938646c88aed4e36d74c" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "805fe7657e79e06b3220324481cd6325b94877d7" }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "a0e9b855809577f0067a93e08c716aa285b03700" }
 
 # applications
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.19" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -11,6 +11,7 @@ ctaphid-dispatch = "0.2"
 embedded-hal = "0.2.7"
 heapless = "0.7"
 heapless-bytes = "0.3"
+interchange = "0.3"
 se05x = { version = "0.1.1", optional = true}
 serde = { version = "1.0.180", default-features = false }
 trussed = { version = "0.1", default-features = false, features = ["crypto-client", "filesystem-client", "management-client", "serde-extensions", "ui-client"] }
@@ -52,20 +53,14 @@ cbor-smol = "0.5"
 hex = "0.4"
 
 [features]
-# client count = n + 1, where n is the number of activated optional
-# applications except ndef-app:
-# - admin-app is always enabled (+1)
-# - ndef-app does not require a Trussed client (0)
-# - all other optional apps require a Trussed client (+n)
-
 # nk3
-nk3 = ["fido-authenticator", "ndef-app", "secrets-app", "opcard", "piv-authenticator", "factory-reset", "trussed/clients-5"]
-nk3-test = ["nk3", "trussed/clients-5"]
-nk3-provisioner = ["nk3", "provisioner-app", "trussed/clients-6"]
+nk3 = ["fido-authenticator", "ndef-app", "secrets-app", "opcard", "piv-authenticator", "factory-reset"]
+nk3-test = ["nk3"]
+nk3-provisioner = ["nk3", "provisioner-app"]
 
 # nkpk
-nkpk = ["fido-authenticator", "factory-reset", "trussed/clients-2"]
-nkpk-provisioner = ["nkpk", "provisioner-app", "trussed/clients-3"]
+nkpk = ["fido-authenticator", "factory-reset"]
+nkpk-provisioner = ["nkpk", "provisioner-app"]
 
 # apps
 secrets-app = ["dep:secrets-app", "backend-auth", "trussed/chacha8-poly1305", "trussed/hmac-sha1", "trussed/hmac-sha256", "trussed/sha256"]

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+#[cfg(feature = "trussed-usbip")]
+extern crate alloc;
+
 #[cfg(feature = "secrets-app")]
 const SECRETS_APP_CREDENTIALS_COUNT_LIMIT: u16 = 50;
 #[cfg(feature = "webcrypt")]
@@ -28,11 +31,11 @@ use serde::{Deserialize, Serialize};
 use trussed::{api::NotBefore, service::Filestore};
 use trussed::{
     backend::BackendId,
-    client::ClientBuilder,
     interrupt::InterruptFlag,
+    pipe::{ServiceEndpoint, TrussedChannel},
     platform::Syscall,
     store::filestore::ClientFilestore,
-    types::{Location, Mechanism, Path},
+    types::{CoreContext, Location, Mechanism, Path},
     ClientImplementation, Platform, Service,
 };
 
@@ -45,8 +48,7 @@ use admin_app::{ConfigValueMut, ResetSignalAllocation};
 use webcrypt::{PeekingBypass, Webcrypt};
 
 mod dispatch;
-use dispatch::Backend;
-pub use dispatch::Dispatch;
+pub use dispatch::{Backend, Dispatch, DispatchContext};
 
 #[cfg(any(feature = "backend-auth", feature = "se050"))]
 pub use dispatch::AUTH_LOCATION;
@@ -314,7 +316,7 @@ pub struct PivConfig {
 }
 
 pub trait Runner {
-    type Syscall: Syscall + 'static;
+    type Syscall: Syscall + Clone + 'static;
 
     type Reboot: Reboot;
     type Store: trussed::store::Store;
@@ -343,6 +345,7 @@ pub struct Data<R: Runner> {
 }
 
 type Client<R> = ClientImplementation<
+    'static,
     <R as Runner>::Syscall,
     Dispatch<<R as Runner>::Twi, <R as Runner>::Se050Timer>,
 >;
@@ -407,6 +410,62 @@ pub struct Apps<R: Runner> {
     provisioner: ProvisionerApp<R>,
     #[cfg(feature = "webcrypt")]
     webcrypt: Option<PeekingBypass<'static, FidoApp<R>, WebcryptApp<R>>>,
+}
+
+const CLIENT_COUNT: usize = const {
+    // ndef is not listed here because it does not need a client
+    let clients = [
+        cfg!(feature = "fido-authenticator"),
+        cfg!(feature = "opcard"),
+        cfg!(feature = "piv-authenticator"),
+        cfg!(feature = "provisioner-app"),
+        cfg!(feature = "secrets-app"),
+        cfg!(feature = "webcrypt"),
+    ];
+
+    let mut n = 0;
+    let mut i = 0;
+    while i < clients.len() {
+        if clients[i] {
+            n += 1;
+        }
+        i += 1;
+    }
+    // admin-app is always enabled
+    n + 1
+};
+
+pub type Endpoint = ServiceEndpoint<'static, Backend, DispatchContext>;
+pub type Endpoints = Vec<Endpoint, CLIENT_COUNT>;
+
+pub struct ClientBuilder<R: Runner> {
+    syscall: R::Syscall,
+    endpoints: Endpoints,
+}
+
+impl<R: Runner> ClientBuilder<R> {
+    pub fn new(syscall: R::Syscall) -> Self {
+        Self {
+            syscall,
+            endpoints: Default::default(),
+        }
+    }
+
+    fn client<A: App<R>>(&mut self, runner: &R, config: &A::Config) -> Client<R> {
+        let interrupt = A::interrupt();
+        let backends = A::backends(runner, config);
+        let (requester, responder) = A::channel().split().unwrap();
+        let context = CoreContext::with_interrupt(A::CLIENT_ID.into(), interrupt);
+        self.endpoints
+            .push(Endpoint::new(responder, context, backends))
+            .ok()
+            .unwrap();
+        Client::<R>::new(requester, self.syscall.clone(), interrupt)
+    }
+
+    pub fn into_endpoints(self) -> Endpoints {
+        self.endpoints
+    }
 }
 
 const fn contains(data: &[Mechanism], item: Mechanism) -> bool {
@@ -474,19 +533,13 @@ impl<R: Runner> Apps<R> {
     pub fn new<P: Platform>(
         runner: &R,
         trussed_service: &mut Service<P, Dispatch<R::Twi, R::Se050Timer>>,
-        mut make_client: impl FnMut(
-            &mut Service<P, Dispatch<R::Twi, R::Se050Timer>>,
-            &'static Path,
-            &'static [BackendId<Backend>],
-            Option<&'static InterruptFlag>,
-        ) -> Client<R>,
+        client_builder: &mut ClientBuilder<R>,
         data: Data<R>,
     ) -> Self {
         const {
             validate_mechanisms();
         }
 
-        let _ = (runner, &mut make_client);
         let Data {
             admin,
             #[cfg(feature = "fido-authenticator")]
@@ -496,11 +549,8 @@ impl<R: Runner> Apps<R> {
             ..
         } = data;
 
-        let (admin, init_status) =
-            Self::admin_app(runner, trussed_service, &mut make_client, admin);
+        let (admin, init_status) = Self::admin_app(runner, trussed_service, client_builder, admin);
 
-        let mut make_client =
-            |ids, backends, interrupt| make_client(trussed_service, ids, backends, interrupt);
         let migrated_successfully = !init_status.contains(InitStatus::MIGRATION_ERROR);
         #[cfg(feature = "opcard")]
         let config_has_error = init_status.contains(InitStatus::CONFIG_ERROR);
@@ -510,27 +560,27 @@ impl<R: Runner> Apps<R> {
         // error occured.
         #[cfg(feature = "opcard")]
         let opcard = (!config_has_error && migrated_successfully)
-            .then(|| App::new(runner, &mut make_client, (), &admin.config().opcard));
+            .then(|| App::new(runner, client_builder, (), &admin.config().opcard));
         #[cfg(all(feature = "fido-authenticator", not(feature = "webcrypt")))]
         let fido = migrated_successfully
-            .then(|| App::new(runner, &mut make_client, fido, &admin.config().fido));
+            .then(|| App::new(runner, client_builder, fido, &admin.config().fido));
 
         #[cfg(feature = "webcrypt")]
         let webcrypt_fido_bypass = migrated_successfully.then(|| {
             PeekingBypass::new(
-                App::new(runner, &mut make_client, fido, &admin.config().fido),
-                App::new(runner, &mut make_client, (), &()),
+                App::new(runner, client_builder, fido, &admin.config().fido),
+                App::new(runner, client_builder, (), &()),
             )
         });
 
         #[cfg(feature = "secrets-app")]
-        let oath = migrated_successfully.then(|| App::new(runner, &mut make_client, (), &()));
+        let oath = migrated_successfully.then(|| App::new(runner, client_builder, (), &()));
 
         #[cfg(feature = "piv-authenticator")]
-        let piv = migrated_successfully.then(|| App::new(runner, &mut make_client, (), &()));
+        let piv = migrated_successfully.then(|| App::new(runner, client_builder, (), &()));
 
         #[cfg(feature = "provisioner-app")]
-        let provisioner = App::new(runner, &mut make_client, provisioner, &());
+        let provisioner = App::new(runner, client_builder, provisioner, &());
 
         Self {
             #[cfg(all(feature = "fido-authenticator", not(feature = "webcrypt")))]
@@ -554,19 +604,13 @@ impl<R: Runner> Apps<R> {
     fn admin_app<P: Platform>(
         runner: &R,
         trussed_service: &mut Service<P, Dispatch<R::Twi, R::Se050Timer>>,
-        make_client: impl FnOnce(
-            &mut Service<P, Dispatch<R::Twi, R::Se050Timer>>,
-            &'static Path,
-            &'static [BackendId<Backend>],
-            Option<&'static InterruptFlag>,
-        ) -> Client<R>,
+        client_builder: &mut ClientBuilder<R>,
         mut data: AdminData<R>,
     ) -> (AdminApp<R>, InitStatus) {
-        let trussed = AdminApp::<R>::client(
-            runner,
-            |id, backends, interrupt| make_client(trussed_service, id, backends, interrupt),
-            &(),
-        );
+        #[cfg(not(feature = "se050"))]
+        let _ = trussed_service;
+
+        let trussed = client_builder.client::<AdminApp<R>>(runner, &());
         // TODO: use CLIENT_ID directly
         let mut filestore = ClientFilestore::new(ADMIN_APP_CLIENT_ID.into(), data.store);
         let version = data.version.encode();
@@ -676,29 +720,6 @@ impl<R: Runner> Apps<R> {
         (app, data.init_status)
     }
 
-    pub fn with_service<P: Platform>(
-        runner: &R,
-        trussed_service: &mut Service<P, Dispatch<R::Twi, R::Se050Timer>>,
-        data: Data<R>,
-    ) -> Self
-    where
-        R::Syscall: Default,
-    {
-        Self::new(
-            runner,
-            trussed_service,
-            |trussed_service, id, backends, interrupt| {
-                ClientBuilder::new(id)
-                    .backends(backends)
-                    .interrupt(interrupt)
-                    .prepare(trussed_service)
-                    .unwrap()
-                    .build(R::Syscall::default())
-            },
-            data,
-        )
-    }
-
     pub fn apdu_dispatch<F, T>(&mut self, f: F) -> T
     where
         F: FnOnce(&mut [&mut dyn ApduApp<ApduResponseSize>]) -> T,
@@ -788,21 +809,14 @@ where
 
     fn new(
         trussed_service: &mut Service<trussed::virt::Platform<S>, Dispatch<R::Twi, R::Se050Timer>>,
+        endpoints: &mut alloc::vec::Vec<Endpoint>,
         syscall: trussed_usbip::Syscall,
         (runner, data): (R, Data<R>),
     ) -> Self {
-        Self::new(
-            &runner,
-            trussed_service,
-            move |trussed_service, id, backends, _| {
-                ClientBuilder::new(id)
-                    .backends(backends)
-                    .prepare(trussed_service)
-                    .unwrap()
-                    .build(syscall.clone())
-            },
-            data,
-        )
+        let mut client_builder = ClientBuilder::new(syscall);
+        let apps = Self::new(&runner, trussed_service, &mut client_builder, data);
+        endpoints.extend(client_builder.into_endpoints());
+        apps
     }
 
     fn with_ctaphid_apps<T>(
@@ -831,36 +845,18 @@ trait App<R: Runner>: Sized {
 
     fn new(
         runner: &R,
-        make_client: impl FnOnce(
-            &'static Path,
-            &'static [BackendId<Backend>],
-            Option<&'static InterruptFlag>,
-        ) -> Client<R>,
+        client_builder: &mut ClientBuilder<R>,
         data: Self::Data,
         config: &Self::Config,
     ) -> Self {
-        let client = Self::client(runner, make_client, config);
+        let client = client_builder.client::<Self>(runner, config);
         Self::with_client(runner, client, data, config)
-    }
-
-    fn client(
-        runner: &R,
-        make_client: impl FnOnce(
-            &'static Path,
-            &'static [BackendId<Backend>],
-            Option<&'static InterruptFlag>,
-        ) -> Client<R>,
-        config: &Self::Config,
-    ) -> Client<R> {
-        make_client(
-            Self::CLIENT_ID,
-            Self::backends(runner, config),
-            Self::interrupt(),
-        )
     }
 
     fn with_client(runner: &R, trussed: Client<R>, data: Self::Data, config: &Self::Config)
         -> Self;
+
+    fn channel() -> &'static TrussedChannel;
 
     fn backends(runner: &R, config: &Self::Config) -> &'static [BackendId<Backend>] {
         let _ = (runner, config);
@@ -985,6 +981,11 @@ impl<R: Runner> App<R> for AdminApp<R> {
         unimplemented!();
     }
 
+    fn channel() -> &'static TrussedChannel {
+        static CHANNEL: TrussedChannel = TrussedChannel::new();
+        &CHANNEL
+    }
+
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();
         Some(&INTERRUPT)
@@ -1040,6 +1041,12 @@ impl<R: Runner> App<R> for FidoApp<R> {
             },
         )
     }
+
+    fn channel() -> &'static TrussedChannel {
+        static CHANNEL: TrussedChannel = TrussedChannel::new();
+        &CHANNEL
+    }
+
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();
         Some(&INTERRUPT)
@@ -1068,6 +1075,12 @@ impl<R: Runner> App<R> for WebcryptApp<R> {
             ),
         )
     }
+
+    fn channel() -> &'static TrussedChannel {
+        static CHANNEL: TrussedChannel = TrussedChannel::new();
+        &CHANNEL
+    }
+
     fn backends(runner: &R, _: &()) -> &'static [BackendId<Backend>] {
         const BACKENDS_WEBCRYPT: &[BackendId<Backend>] = &[
             BackendId::Custom(Backend::SoftwareRsa),
@@ -1098,12 +1111,19 @@ impl<R: Runner> App<R> for SecretsApp<R> {
         );
         Self::new(trussed, options)
     }
+
+    fn channel() -> &'static TrussedChannel {
+        static CHANNEL: TrussedChannel = TrussedChannel::new();
+        &CHANNEL
+    }
+
     fn backends(runner: &R, _: &()) -> &'static [BackendId<Backend>] {
         const BACKENDS_OATH: &[BackendId<Backend>] =
             &[BackendId::Custom(Backend::Auth), BackendId::Core];
         let _ = runner;
         BACKENDS_OATH
     }
+
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();
         Some(&INTERRUPT)
@@ -1171,9 +1191,16 @@ impl<R: Runner> App<R> for OpcardApp<R> {
         }
         Self::new(trussed, options)
     }
+
+    fn channel() -> &'static TrussedChannel {
+        static CHANNEL: TrussedChannel = TrussedChannel::new();
+        &CHANNEL
+    }
+
     fn backends(_runner: &R, config: &OpcardConfig) -> &'static [BackendId<Backend>] {
         config.backends()
     }
+
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();
         Some(&INTERRUPT)
@@ -1193,6 +1220,12 @@ impl<R: Runner> App<R> for PivApp<R> {
             piv_authenticator::Options::default().uuid(Some(runner.uuid())),
         )
     }
+
+    fn channel() -> &'static TrussedChannel {
+        static CHANNEL: TrussedChannel = TrussedChannel::new();
+        &CHANNEL
+    }
+
     fn backends(runner: &R, _: &()) -> &'static [BackendId<Backend>] {
         const BACKENDS_PIV: &[BackendId<Backend>] = &[
             #[cfg(feature = "se050")]
@@ -1203,6 +1236,7 @@ impl<R: Runner> App<R> for PivApp<R> {
         let _ = runner;
         BACKENDS_PIV
     }
+
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();
         Some(&INTERRUPT)
@@ -1235,6 +1269,12 @@ impl<R: Runner> App<R> for ProvisionerApp<R> {
             data.rebooter,
         )
     }
+
+    fn channel() -> &'static TrussedChannel {
+        static CHANNEL: TrussedChannel = TrussedChannel::new();
+        &CHANNEL
+    }
+
     fn interrupt() -> Option<&'static InterruptFlag> {
         static INTERRUPT: InterruptFlag = InterruptFlag::new();
         Some(&INTERRUPT)

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -129,6 +129,12 @@ pub struct RunnerSyscall<S: Soc> {
     _marker: PhantomData<S>,
 }
 
+impl<S: Soc> Clone for RunnerSyscall<S> {
+    fn clone(&self) -> Self {
+        Default::default()
+    }
+}
+
 impl<S: Soc> Default for RunnerSyscall<S> {
     fn default() -> Self {
         Self {

--- a/components/boards/src/runtime.rs
+++ b/components/boards/src/runtime.rs
@@ -1,4 +1,5 @@
 use apdu_dispatch::dispatch::{ApduDispatch, Interface};
+use apps::Endpoints;
 use ctaphid_dispatch::Dispatch as CtaphidDispatch;
 use embedded_time::duration::Milliseconds;
 use nfc_device::{traits::nfc::Device as NfcDevice, Iso14443};
@@ -119,6 +120,6 @@ where
     };
 }
 
-pub fn run_trussed<B: Board>(trussed: &mut Trussed<B>) {
-    trussed.process();
+pub fn run_trussed<B: Board>(trussed: &mut Trussed<B>, endpoints: &mut Endpoints) {
+    trussed.process(endpoints);
 }

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -1,7 +1,7 @@
 use apdu_dispatch::interchanges::{
     Channel as CcidChannel, Requester as CcidRequester, Responder as CcidResponder,
 };
-use apps::InitStatus;
+use apps::{Endpoints, InitStatus};
 #[cfg(feature = "se050")]
 use boards::nk3xn::TimerDelay;
 use boards::{
@@ -828,7 +828,7 @@ impl Stage6 {
         usbhs: Usbhs<Unknown>,
     ) -> All {
         self.perform_data_migrations();
-        let apps = init::init_apps(
+        let (apps, endpoints) = init::init_apps(
             &Lpc55::new(),
             &mut self.trussed,
             self.status,
@@ -875,6 +875,7 @@ impl Stage6 {
             basic: self.basic,
             trussed: self.trussed,
             apps,
+            endpoints,
             clock_controller,
             usb_nfc,
             wwdt: self.wwdt,
@@ -887,6 +888,7 @@ pub struct All {
     pub usb_nfc: UsbNfc<NK3xN>,
     pub trussed: Trussed<NK3xN>,
     pub apps: Apps<NK3xN>,
+    pub endpoints: Endpoints,
     pub clock_controller: Option<DynamicClockController>,
     pub wwdt: EnabledWwdt,
 }

--- a/runners/nkpk/src/main.rs
+++ b/runners/nkpk/src/main.rs
@@ -8,7 +8,7 @@ use cortex_m_rt::{exception, ExceptionFrame};
 #[rtic::app(device = nrf52840_pac, peripherals = true, dispatchers = [SWI3_EGU3, SWI4_EGU4, SWI5_EGU5])]
 mod app {
     use apdu_dispatch::{dispatch::ApduDispatch, interchanges::Channel as CcidChannel};
-    use apps::Reboot;
+    use apps::{Endpoints, Reboot};
     use boards::{
         init::{Resources, UsbClasses},
         nkpk::{self, ExternalFlashStorage, InternalFlashStorage, NKPK},
@@ -46,6 +46,7 @@ mod app {
         gpiote: Gpiote,
         power: nrf52840_pac::POWER,
         watchdog_parts: Option<wdt::Parts<WatchdogHandle<Hdl0>>>,
+        endpoints: Endpoints,
     }
 
     #[monotonic(binds = RTC0, default = true)]
@@ -120,7 +121,7 @@ mod app {
         let mut trussed =
             boards::init::init_trussed(&mut dev_rng, store, user_interface, &mut init_status);
 
-        let apps = boards::init::init_apps(
+        let (apps, endpoints) = boards::init::init_apps(
             &soc,
             &mut trussed,
             init_status,
@@ -149,6 +150,7 @@ mod app {
                     watchdog: parts.watchdog,
                     handles: parts.handles.0,
                 }),
+                endpoints,
             },
             init::Monotonics(rtc_mono),
         )
@@ -198,13 +200,13 @@ mod app {
         }
     }
 
-    #[task(priority = 2, binds = SWI0_EGU0, shared = [trussed])]
+    #[task(priority = 2, binds = SWI0_EGU0, shared = [trussed], local = [endpoints])]
     fn task_trussed(ctx: task_trussed::Context) {
         let mut trussed = ctx.shared.trussed;
 
         //trace!("irq SWI0_EGU0");
         trussed.lock(|trussed| {
-            runtime::run_trussed(trussed);
+            runtime::run_trussed(trussed, ctx.local.endpoints);
         });
     }
 

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -15,7 +15,7 @@ log = { version = "0.4.14", default-features = false }
 pretty_env_logger = "0.5.0"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 signal-hook = { version = "0.3.17", default-features = false }
-trussed = { version = "0.1", default-features = false, features = ["clients-3"] }
+trussed = { version = "0.1", default-features = false }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 utils = { path = "../../components/utils", features = ["log-all"] }
 


### PR DESCRIPTION
This patch updates trussed to remove the need for the clients-? feature and manage the endpoints in the runner instead.