### PR TITLE
Fix usbip runner build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,12 +128,12 @@ build-usbip:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:
     - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "push"'
   tags:
     - docker
   stage: build
   script:
-    - git describe --exact-match
-    - export VERSION=`git describe --exact-match`
+    - export VERSION=`git describe`
     - if echo $VERSION | grep test ; then export FEATURES=test ; fi
     - mkdir -p artifacts
     - cargo build --release --manifest-path runners/usbip/Cargo.toml --features $FEATURES,

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -441,6 +441,29 @@ const fn validate_mechanisms() {
         if contains(trussed_se050_backend::MECHANISMS, mechanism) {
             continue;
         }
+        // The usbip runner does not have the mechanisms normally provided by the se050 backend.
+        // Until there is a backend implementing them in software, we ignore them and return an
+        // error at runtime.
+        #[cfg(feature = "trussed-usbip")]
+        if contains(
+            &[
+                Mechanism::BrainpoolP256R1,
+                Mechanism::BrainpoolP256R1Prehashed,
+                Mechanism::BrainpoolP384R1,
+                Mechanism::BrainpoolP384R1Prehashed,
+                Mechanism::BrainpoolP512R1,
+                Mechanism::BrainpoolP512R1Prehashed,
+                Mechanism::P384,
+                Mechanism::P384Prehashed,
+                Mechanism::P521,
+                Mechanism::P521Prehashed,
+                Mechanism::Secp256k1,
+                Mechanism::Secp256k1Prehashed,
+            ],
+            mechanism,
+        ) {
+            continue;
+        }
 
         // This mechanism is not implemented by Trussed or any of the backends.
         mechanism.panic();

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -15,7 +15,7 @@ log = { version = "0.4.14", default-features = false }
 pretty_env_logger = "0.5.0"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 signal-hook = { version = "0.3.17", default-features = false }
-trussed = { version = "0.1", features = ["clients-3"] }
+trussed = { version = "0.1", default-features = false, features = ["clients-3"] }
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"] }
 utils = { path = "../../components/utils", features = ["log-all"] }
 


### PR DESCRIPTION
This PR makes sure that the usbip runner is always built in the CI so that linker errors and failed const assertions are properly detected.  Currently, the build fails as some mechanisms are only implemented by the SE050 backend and are not available in the usbip runner.  Instead of failing the compilation, this PR ignores those mechanisms when compiling the usbip runner so that a runtime error is raised when such a mechanism is used.  In the medium term, we should use a backend providing a software implementation of these mechanisms.