### PR TITLE
utils/lpc: adapt provisioning for a better prince init

### DIFF
--- a/docs/lpc55-quickstart.md
+++ b/docs/lpc55-quickstart.md
@@ -87,7 +87,7 @@ $ make -C utils/lpc55-builder reset
 
 Build the firmware, configure the device and flash the firmware by running:
 ```
-$ make -C utils/lpc55-builder provision-develop
+$ make -C utils/lpc55-builder provision-release
 ```
 
 Now check that everything worked by running `nitropy nk3 test --exclude provisioner`.  The `uuid` and `version` checks should be successful.  The `fido2` test will fail with a message about an unexpected certificate hash.  This is expected because you don’t have access to the real FIDO2 batch keys and certificates.  If it fails with a different error message, something went wrong.

--- a/utils/lpc55-builder/Makefile
+++ b/utils/lpc55-builder/Makefile
@@ -29,35 +29,6 @@ jlink:
 run: build
 	arm-none-eabi-gdb -q -x ./jlink.gdb "$(OUTPUT_ELF)"
 
-.PHONY: provision-develop
-provision-develop:
-	# Step 1: reset CMPA, erase firmware, build & flash provisioner
-	./scripts/boot-to-bootrom.sh
-	./scripts/usbwait.sh 1fc9:0021 20a0:42dd
-	$(MAKE) build FEATURES=develop,provisioner,$(FEATURES)
-	$(MAKE) bl-config-cmpa-empty
-	$(MAKE) bl-erase-firmware
-	$(MAKE) bl-flash
-	lpc55 reboot
-	./scripts/usbwait.sh 20a0:42b2
-	# wait 5 more seconds for the device to show up properly again
-	sleep 5
-	# Step 2: provision certs
-	$(MAKE) fw-provision-certs
-	./scripts/boot-to-bootrom.sh
-	./scripts/usbwait.sh 1fc9:0021
-	# Step 3: erase firmware, configure CMPA
-	$(MAKE) bl-erase-firmware
-	$(MAKE) bl-config-cmpa-develop
-	lpc55 reboot
-	./scripts/usbwait.sh 20a0:42dd
-	# Step 3: build & flash final firmware
-	$(MAKE) build FEATURES=develop,$(FEATURES)
-	$(MAKE) bl-erase-firmware
-	$(MAKE) bl-flash
-	lpc55 reboot
-	./scripts/usbwait.sh 20a0:42b2
-
 .PHONY: provision-release
 provision-release:
 	# TODO: add secure boot
@@ -68,24 +39,24 @@ provision-release:
 	$(MAKE) bl-erase-firmware
 	lpc55 reboot
 	./scripts/usbwait.sh 1fc9:0021
-	# Step 1: build & flash provisioner, provision keystore
-	$(MAKE) build FEATURES=provisioner,$(FEATURES)
+	# Step 1: build & flash provisioner, provision keystore, cmpa
 	$(MAKE) bl-provision-keystore
+	lpc55 reboot
+	./scripts/usbwait.sh 1fc9:0021
+	$(MAKE) bl-config-cmpa-develop
+	lpc55 reboot
+	./scripts/usbwait.sh 20a0:42dd
+	$(MAKE) build FEATURES=provisioner,$(FEATURES)
 	$(MAKE) bl-flash
 	lpc55 reboot
 	./scripts/usbwait.sh 20a0:42b2
 	# Step 2: provision certs
 	$(MAKE) fw-provision-certs
 	./scripts/boot-to-bootrom.sh
-	./scripts/usbwait.sh 1fc9:0021
-	# Step 3: erase firmware, configure CMPA
-	$(MAKE) bl-erase-firmware
-	$(MAKE) bl-config-cmpa-develop
-	lpc55 reboot
 	./scripts/usbwait.sh 20a0:42dd
-	# Step 3: build & flash final firmware
-	$(MAKE) build FEATURES=$(FEATURES)
+	# Step 3: erase firmware, build & flash final firmware
 	$(MAKE) bl-erase-firmware
+	$(MAKE) build FEATURES=$(FEATURES)
 	$(MAKE) bl-flash
 	lpc55 reboot
 	./scripts/usbwait.sh 20a0:42b2


### PR DESCRIPTION
* remove: `provision-develop` as it's unused
* change order for `provision-release` to have a proper prince behavior during provisioning

The observation (breaking at main) is that the prince registers look like that after applying `keystore.toml` and flashing the provisioner:
```
0x4003501c:	0x00000001
0x4003502c:	0x00000001
0x4003503c:	0x00003fff
```
This is leading to a panic once the provisioner is flashed (since piv was included, so potentially(!) once a given firmware binary size is reached). Once `factory-settings` with some pid:vid are applied, these show the expected values:
```
0x4003501c:	0x00000000
0x4003502c:	0x00000000
0x4003503c:	0x00000000
```
so this PR essentially only pulls the `factory-setting` before flashing the provisioner and the observed panic doesn't occur anymore.