### PR TITLE
Dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,8 +437,7 @@ dependencies = [
 [[package]]
 name = "cargo-license"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f061c0dbae23c1fe7ace394590d59b7e9bd24c7c678cd1b5f179081592d5894b"
+source = "git+https://github.com/Nitrokey/cargo-license.git?rev=d38912dc4b7a10d3cf48f8cf86f49640ff3173ab#d38912dc4b7a10d3cf48f8cf86f49640ff3173ab"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -451,7 +450,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "spdx 0.10.6",
+ "spdx",
  "toml 0.8.14",
 ]
 
@@ -679,7 +678,7 @@ dependencies = [
  "cargo-license",
  "cargo_metadata",
  "gumdrop",
- "spdx 0.9.0",
+ "spdx",
 ]
 
 [[package]]
@@ -2933,18 +2932,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "spdx"
-version = "0.9.0"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a346909b3fd07776f9b96b98d4a58e3666f831c9a672c279b10f795a34c36425"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "spdx"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
+checksum = "58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,16 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-cortex-m"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483c3bd0f9a7bb982b72988f5f173d29687c432d8013c1d3232635e6c0f0a60c"
-dependencies = [
- "cortex-m",
- "linked_list_allocator",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +290,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
@@ -706,6 +702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1071,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2de9133f68db0d4627ad69db767726c99ff8585272716708227008d3f1bddd"
+dependencies = [
+ "const-default",
+ "critical-section 1.1.2",
+ "linked_list_allocator",
+ "rlsf",
+]
+
+[[package]]
 name = "embedded-dma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,7 +1105,6 @@ dependencies = [
 name = "embedded-runner-lib"
 version = "1.8.0"
 dependencies = [
- "alloc-cortex-m",
  "apdu-dispatch",
  "apps",
  "boards",
@@ -1101,6 +1114,7 @@ dependencies = [
  "cortex-m-rtic",
  "ctaphid-dispatch",
  "delog",
+ "embedded-alloc",
  "embedded-hal",
  "interchange",
  "littlefs2-core",
@@ -2516,6 +2530,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlsf"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "svgbobdoc",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3008,19 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgbobdoc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
+dependencies = [
+ "base64",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-width",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ trussed-auth-backend = { git = "https://github.com/trussed-dev/trussed-auth", ta
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "743d9aaa3d8a17d7dbf492bd54dc18ab8fca3dc0" }
 trussed-se050-backend = { git = "https://github.com/Nitrokey/trussed-se050-backend.git", rev = "131c973fbe74d677fb8c8df97c210f78608994f0" }
 trussed-staging = { git = "https://github.com/trussed-dev/trussed-staging.git", rev = "7922d67e9637a87e5625aaff9e5111f0d4ec0346" }
+cargo-license = { git = "https://github.com/Nitrokey/cargo-license.git", rev = "d38912dc4b7a10d3cf48f8cf86f49640ff3173ab" }
 
 [profile.release]
 codegen-units = 1

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -43,7 +43,7 @@ nb = { version = "1", optional = true }
 systick-monotonic = { version = "1.0.0", optional = true }
 
 ### Allocator
-alloc-cortex-m = { version = "0.4.3", optional = true }
+embedded-alloc = { version = "0.6.0", optional = true }
 
 # littlefs2-sys for intrinsics feature
 littlefs2-sys = { version = "0.3", optional = true }
@@ -79,7 +79,7 @@ no-buttons = ["boards/no-buttons"]
 # Format filesystem anyway
 format-filesystem = []
 
-alloc = ["alloc-cortex-m"]
+alloc = ["embedded-alloc"]
 
 board-nk3am = ["boards/board-nk3am", "soc-nrf52", "se050"]
 board-nk3xn = ["boards/board-nk3xn", "soc-lpc55", "se050"]

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -24,7 +24,7 @@ pub const VERSION_STRING: &str = env!("NK3_FIRMWARE_VERSION");
 
 #[cfg(feature = "alloc")]
 #[global_allocator]
-static ALLOCATOR: alloc_cortex_m::CortexMHeap = alloc_cortex_m::CortexMHeap::empty();
+static ALLOCATOR: embedded_alloc::LlffHeap = embedded_alloc::LlffHeap::empty();
 
 #[cfg(feature = "alloc")]
 pub fn init_alloc() {

--- a/utils/collect-license-info/Cargo.toml
+++ b/utils/collect-license-info/Cargo.toml
@@ -10,4 +10,4 @@ askama = "0.11.1"
 cargo-license = "0.6.0"
 cargo_metadata = "0.18.1"
 gumdrop = "0.8.1"
-spdx = { version = "0.9.0", features = ["text"] }
+spdx = { version = "0.10.8", features = ["text"] }

--- a/utils/collect-license-info/src/main.rs
+++ b/utils/collect-license-info/src/main.rs
@@ -41,6 +41,7 @@ impl Args {
                 avoid_dev_deps: false,
                 avoid_build_deps: false,
                 direct_deps_only: false,
+                avoid_proc_macros: false,
                 root_only: false,
             },
         )


### PR DESCRIPTION
cortex-m-alloc has been deprecated.
    
The new embedded-allocator supports two allocator algorithms.     This PR uses the same as previously. I will make a PR that switches the allocator to see if there is any benefit.

Also bump minimum apdu-dispatch version to ensure https://github.com/trussed-dev/apdu-dispatch/pull/28 is used.

Uses a fork to fix collect-license-info: https://github.com/onur/cargo-license/pull/79