### PR TITLE
Update piv to 0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "apps"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "boards"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "apdu-dispatch",
  "apps",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-runner-lib"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "alloc-cortex-m",
  "apdu-dispatch",
@@ -2238,8 +2238,8 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piv-authenticator"
-version = "0.3.8"
-source = "git+https://github.com/Nitrokey/piv-authenticator.git?rev=65552820b4f931c21e1c7675b1bd6072cb872531#65552820b4f931c21e1c7675b1bd6072cb872531"
+version = "0.3.9"
+source = "git+https://github.com/Nitrokey/piv-authenticator.git?rev=2fec80ff825408a3d479668ff5557fdd32ead342#2fec80ff825408a3d479668ff5557fdd32ead342"
 dependencies = [
  "apdu-app",
  "cbor-smol",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "usbip-runner"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "apps",
  "cfg-if",
@@ -3620,7 +3620,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "chrono",
  "delog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.0"
+version = "1.8.1"
 
 [patch.crates-io]
 # components
@@ -26,7 +26,7 @@ lpc55-hal = { git = "https://github.com/lpc55/lpc55-hal.git", rev ="1a25fc366013
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.19" }
 fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git",tag = "v0.1.1-nitrokey.25" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", rev = "39ec4c37f808c0cfeb84e0a8493bbee06f02c8e2" }
-piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator.git", rev = "65552820b4f931c21e1c7675b1bd6072cb872531" }
+piv-authenticator = { git = "https://github.com/Nitrokey/piv-authenticator.git", rev = "2fec80ff825408a3d479668ff5557fdd32ead342" }
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", rev = "700863bdfa90a3616cbb695d6638c7aea7730c03" }
 webcrypt = { git = "https://github.com/nitrokey/nitrokey-websmartcard-rust", tag = "v0.8.0-rc11" }
 


### PR DESCRIPTION
This actually updates piv to https://github.com/Nitrokey/piv-authenticator/pull/74 to avoid having an intermediary commit that does not compile.