### PR TITLE
ci: Move metrics comment from after_script to script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,8 +197,6 @@ metrics:
   stage: metrics
   script:
     - repometrics generate --cache > metrics.toml
-  after_script:
-    - !reference [notify_github, script] # use notify_github from include
     - repometrics run --base origin/main --output-format markdown | tee --append metrics-comment.md
     - nitrokey-ci write-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.md
   artifacts:


### PR DESCRIPTION
Previously, we had the metrics comparison and comment creation in the after_script part of the metrics job so that a failure in these commands would not cause a CI failure.  As we increasingly rely on the metrics comments and the relevant commands are pretty stable, this patch moves them to the script part so that we will notice failures more easily.