### PR TITLE
ci: Only comment metrics on other branches than main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -198,7 +198,9 @@ metrics:
   script:
     - repometrics generate --cache > metrics.toml
     - repometrics run --base origin/main --output-format markdown | tee --append metrics-comment.md
-    - nitrokey-ci write-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.md
+    - if [ -n "$CI_COMMIT_BRANCH" ] && [ "$CI_COMMIT_BRANCH" != "main" ] ; then
+          nitrokey-ci write-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.md ;
+      fi
   artifacts:
     paths:
       - metrics.toml


### PR DESCRIPTION
In https://github.com/Nitrokey/nitrokey-3-firmware/pull/594, we changed the metrics job to fail if the comment cannot be posted.  This causes a CI failure on main as there is no matching PR for the CI run.  This patch adds a condition to only post the comment if the CI runs against a branch other than main.