### PR TITLE
Lpc55: add support for mcu-link debugger

### DIFF
--- a/utils/lpc55-builder/Makefile
+++ b/utils/lpc55-builder/Makefile
@@ -25,6 +25,10 @@ build-all:
 jlink:
 	JLinkGDBServerCLExe -strict -device LPC55S69 -if SWD -vd
 
+.PHONY: linkserver
+linkserver:
+	LinkServer gdbserver LPC55S69 --gdb-port 2331
+
 .PHONY: run
 run: build
 	arm-none-eabi-gdb -q -x ./jlink.gdb "$(OUTPUT_ELF)"


### PR DESCRIPTION
Normally this should work just as does the JLink software version:

```
make linkserver
make run FEATURES=…
```

I do get some errors, and semihosting logs will probably need a different version.

> INFO: [stub (2331)] Ns: LinkServer RedlinkMulti Driver v24.12 (Dec 18 2024 18:40:01 - crt_emu_cm_redlink build 869)
> INFO: Connected to core cm33_core0
> INFO: [stub (2331)] Pc: (  0) Reading remote configuration
> INFO: [stub (2331)] Wc(03). No cache support.
> INFO: [stub (2331)] Nc: Found generic directory XML file in /tmp/tmpsz6hfkn9/crt_directory.xml
> Pc: (  5) Remote configuration complete
> INFO: [stub (2331)] Nc: Reconnected to existing LinkServer process.
> INFO: [stub (2331)] Nc: Connecting to probe 1 core 0 (using server started externally) reports:
>     'Ee(42). Could not connect to core.'
> Nc: Retrying...
> INFO: [stub (2331)] Nc: Reconnected to existing LinkServer process.
> INFO: [stub (2331)] Nc: Server OK but no connection to probe 1 core 0 (after 3 attempts) - Ee(42). Could not connect to core.
> Ed:02: Failed on connect: Ee(42). Could not connect to core.
> Et:31: No connection to chip's debug port
> Pc: (100) Target Operation Failed
> INFO: Disconnected from core cm33_core0
> Gdbserver on port 2331 has closed
