### PR TITLE
ci: Only generate metrics comment for other branches than main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,10 +197,8 @@ metrics:
   stage: metrics
   script:
     - repometrics generate --cache > metrics.toml
-  after_script:
-    - !reference [notify_github, script] # use notify_github from include
-    - repometrics run --base origin/main --output-format markdown | tee --append metrics-comment.md
     - if [ -n "$CI_COMMIT_BRANCH" ] && [ "$CI_COMMIT_BRANCH" != "main" ] ; then
+          repometrics run --base origin/main --output-format markdown | tee --append metrics-comment.md ;
           nitrokey-ci write-comment --owner Nitrokey --repo nitrokey-3-firmware --id repometrics --commit $(git rev-parse HEAD) metrics-comment.md ;
       fi
   artifacts:


### PR DESCRIPTION
The old logic can lead to problems when the job runs for the first time for a commit on main, e. g. after a merge with a merge commit (instead of a fast-forward merge), as the "root" of the branch is equal to the head and there are no cached metrics for the head.

This also reverts the temporary change to ignore errors during comment creation in https://github.com/Nitrokey/nitrokey-3-firmware/pull/600 as the cause should be fixed with this PR.