### PR TITLE
provisioner: Remove ReformatFilesystem command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fido-authenticator: Implement the largeBlobKey extension and the largeBlobs command ([fido-authenticator#38][])
+- provisioner-app: Remove ReformatFilesystem command
 
 ## v1.8.0 (2024-12-06)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,7 +2383,7 @@ dependencies = [
  "heapless",
  "heapless-bytes",
  "iso7816",
- "littlefs2",
+ "littlefs2-core",
  "p256-cortex-m4",
  "salty",
  "trussed",

--- a/components/boards/src/init.rs
+++ b/components/boards/src/init.rs
@@ -198,15 +198,9 @@ pub fn init_apps<B: Board>(
     let provisioner = {
         use apps::Reboot as _;
         let store = store.clone();
-        let int_flash_ref = unsafe { crate::store::steal_internal_storage::<B>() };
         let rebooter: fn() -> ! = B::Soc::reboot_to_firmware_update;
 
-        apps::ProvisionerData {
-            store,
-            stolen_filesystem: int_flash_ref,
-            nfc_powered,
-            rebooter,
-        }
+        apps::ProvisionerData { store, rebooter }
     };
 
     let runner = Runner {

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -25,6 +25,7 @@ use apps::Dispatch;
 #[cfg(feature = "se050")]
 use embedded_hal::blocking::delay::DelayUs;
 use littlefs2::{
+    driver::Storage,
     fs::{Allocation, Filesystem},
     io::Result as LfsResult,
 };
@@ -34,7 +35,7 @@ use trussed::{client::Syscall, Platform};
 
 use crate::{
     soc::{Soc, Uuid},
-    store::{RunnerStore, StoragePointers},
+    store::RunnerStore,
     ui::{buttons::UserPresence, rgb_led::RgbLed, UserInterface},
 };
 
@@ -42,7 +43,7 @@ pub type Trussed<B> =
     trussed::Service<RunnerPlatform<B>, Dispatch<<B as Board>::Twi, <B as Board>::Se050Timer>>;
 pub type Apps<B> = apps::Apps<Runner<B>>;
 
-pub trait Board: StoragePointers {
+pub trait Board {
     type Soc: Soc;
 
     type Resources;
@@ -50,6 +51,9 @@ pub trait Board: StoragePointers {
     type NfcDevice: NfcDevice;
     type Buttons: UserPresence;
     type Led: RgbLed;
+
+    type InternalStorage: Storage + 'static;
+    type ExternalStorage: Storage + 'static;
 
     #[cfg(feature = "se050")]
     type Se050Timer: DelayUs<u32> + 'static;
@@ -87,8 +91,6 @@ impl<B: Board> apps::Runner for Runner<B> {
     type Syscall = RunnerSyscall<B::Soc>;
     type Reboot = B::Soc;
     type Store = RunnerStore<B>;
-    #[cfg(feature = "provisioner")]
-    type Filesystem = B::InternalStorage;
     type Twi = B::Twi;
     type Se050Timer = B::Se050Timer;
 

--- a/components/boards/src/nk3am.rs
+++ b/components/boards/src/nk3am.rs
@@ -17,7 +17,6 @@ use nrf52840_pac::{FICR, GPIOTE, P0, P1, POWER, PWM0, PWM1, PWM2, SPIM3, TIMER1,
 use crate::{
     flash::ExtFlashStorage,
     soc::nrf52::{flash::FlashStorage, rtic_monotonic::RtcMonotonic, Nrf52, UsbClockType},
-    store::impl_storage_pointers,
     ui::UserInterface,
     Board,
 };
@@ -43,6 +42,9 @@ impl Board for NK3AM {
     type NfcDevice = DummyNfc;
     type Buttons = HardwareButtons;
     type Led = RgbLed;
+
+    type InternalStorage = InternalFlashStorage;
+    type ExternalStorage = ExternalFlashStorage;
 
     #[cfg(feature = "se050")]
     type Twi = Twim<TWIM1>;
@@ -103,12 +105,6 @@ impl Board for NK3AM {
 pub type InternalFlashStorage =
     FlashStorage<{ MEMORY_REGIONS.filesystem.start }, { MEMORY_REGIONS.filesystem.end }>;
 pub type ExternalFlashStorage = ExtFlashStorage<Spim<SPIM3>, OutPin>;
-
-impl_storage_pointers!(
-    NK3AM,
-    Internal = InternalFlashStorage,
-    External = ExternalFlashStorage,
-);
 
 pub struct DummyNfc;
 

--- a/components/boards/src/nk3xn.rs
+++ b/components/boards/src/nk3xn.rs
@@ -20,7 +20,7 @@ use lpc55_hal::{
 use memory_regions::MemoryRegions;
 use utils::OptionalStorage;
 
-use crate::{flash::ExtFlashStorage, soc::lpc55::Lpc55, store::impl_storage_pointers, Board};
+use crate::{flash::ExtFlashStorage, soc::lpc55::Lpc55, Board};
 
 pub mod button;
 pub mod led;
@@ -65,6 +65,9 @@ impl Board for NK3xN {
     type Buttons = button::ThreeButtons;
     type Led = led::RgbLed;
 
+    type InternalStorage = InternalFlashStorage;
+    type ExternalStorage = ExternalFlashStorage;
+
     #[cfg(feature = "se050")]
     type Se050Timer = TimerDelay<Timer<ctimer::Ctimer2<lpc55_hal::Enabled>>>;
     #[cfg(feature = "se050")]
@@ -80,12 +83,6 @@ impl Board for NK3xN {
 
 pub type InternalFlashStorage = InternalFilesystem;
 pub type ExternalFlashStorage = OptionalStorage<ExtFlashStorage<Spi, FlashCs>>;
-
-impl_storage_pointers!(
-    NK3xN,
-    Internal = InternalFlashStorage,
-    External = ExternalFlashStorage,
-);
 
 #[cfg(feature = "se050")]
 pub struct TimerDelay<T>(pub T);

--- a/components/boards/src/nkpk.rs
+++ b/components/boards/src/nkpk.rs
@@ -9,7 +9,6 @@ use super::nk3am::{
 };
 use crate::{
     soc::nrf52::{flash::FlashStorage, Nrf52, UsbClockType},
-    store::impl_storage_pointers,
     Board,
 };
 
@@ -27,6 +26,9 @@ impl Board for NKPK {
     type NfcDevice = DummyNfc;
     type Buttons = HardwareButtons;
     type Led = RgbLed;
+
+    type InternalStorage = InternalFlashStorage;
+    type ExternalStorage = ExternalFlashStorage;
 
     type Twi = ();
     type Se050Timer = ();
@@ -54,9 +56,3 @@ pub type InternalFlashStorage =
     FlashStorage<{ MEMORY_REGIONS.filesystem.start }, { MEMORY_REGIONS.filesystem.end }>;
 // TODO: Do we want to mirror the NK3AM EFS?
 pub type ExternalFlashStorage = RamStorage<nk3am::ExternalFlashStorage, 256>;
-
-impl_storage_pointers!(
-    NKPK,
-    Internal = InternalFlashStorage,
-    External = ExternalFlashStorage,
-);

--- a/components/provisioner-app/Cargo.toml
+++ b/components/provisioner-app/Cargo.toml
@@ -13,7 +13,7 @@ delog = "0.1"
 heapless = "0.7"
 heapless-bytes = "0.3"
 iso7816 = "0.1"
-littlefs2.workspace = true
+littlefs2-core = "0.1"
 salty = { version = "0.3", features = ["cose"] }
 trussed = { version = "0.1", default-features = false, features = ["crypto-client"] }
 p256-cortex-m4 = "0.1.0-alpha.6"

--- a/components/provisioner-app/src/apdu.rs
+++ b/components/provisioner-app/src/apdu.rs
@@ -2,7 +2,7 @@ use crate::{Error, Provisioner};
 use apdu_app::{App, CommandView, Data, Interface, Result, Status};
 use core::convert::{TryFrom, TryInto};
 use iso7816::{Aid, Instruction};
-use trussed::{client, store::Store, types::LfsStorage};
+use trussed::{client, store::Store};
 
 const SOLO_PROVISIONER_AID: &[u8] = &[0xA0, 0x00, 0x00, 0x08, 0x47, 0x01, 0x00, 0x00, 0x01];
 
@@ -30,10 +30,9 @@ impl From<Error> for Status {
     }
 }
 
-impl<S, FS, T> iso7816::App for Provisioner<S, FS, T>
+impl<S, T> iso7816::App for Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: client::CryptoClient,
 {
     fn aid(&self) -> Aid {
@@ -41,10 +40,9 @@ where
     }
 }
 
-impl<S, FS, T, const R: usize> App<R> for Provisioner<S, FS, T>
+impl<S, T, const R: usize> App<R> for Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: client::CryptoClient,
 {
     fn select(

--- a/components/provisioner-app/src/ctaphid.rs
+++ b/components/provisioner-app/src/ctaphid.rs
@@ -2,14 +2,13 @@ use crate::{Instruction, Provisioner};
 use core::convert::TryFrom;
 use ctaphid_app::{App, Command, Error, VendorCommand};
 use heapless_bytes::Bytes;
-use trussed::{client, store::Store, types::LfsStorage};
+use trussed::{client, store::Store};
 
 const COMMAND_PROVISIONER: VendorCommand = VendorCommand::H71;
 
-impl<S, FS, T, const N: usize> App<'_, N> for Provisioner<S, FS, T>
+impl<S, T, const N: usize> App<'_, N> for Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: client::CryptoClient,
 {
     fn commands(&self) -> &'static [Command] {

--- a/components/provisioner-app/src/lib.rs
+++ b/components/provisioner-app/src/lib.rs
@@ -19,16 +19,12 @@ generate_macros!();
 
 use core::convert::TryFrom;
 use heapless::Vec;
-use littlefs2::{
-    path,
-    path::{Path, PathBuf},
-};
+use littlefs2_core::{path, Path, PathBuf};
 use trussed::{
     client,
     key::{Flags, Key, Kind as KeyKind},
     store::{self, Store},
     syscall,
-    types::LfsStorage,
 };
 
 const TESTER_FILENAME_ID: [u8; 2] = [0xe1, 0x01];
@@ -42,7 +38,6 @@ pub enum Instruction {
     WriteFile,
 
     BootToBootrom,
-    ReformatFilesystem,
     GetUuid,
 
     GenerateP256Key,
@@ -67,7 +62,6 @@ impl TryFrom<u8> for Instruction {
             0xbf => Self::WriteFile,
 
             0x51 => Self::BootToBootrom,
-            0xbd => Self::ReformatFilesystem,
             0x62 => Self::GetUuid,
 
             0xbc => Self::GenerateP256Key,
@@ -109,10 +103,9 @@ enum SelectedBuffer {
     File,
 }
 
-pub struct Provisioner<S, FS, T>
+pub struct Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: client::CryptoClient,
 {
     trussed: T,
@@ -122,35 +115,22 @@ where
     buffer_file_contents: Vec<u8, 8192>,
 
     store: S,
-    stolen_filesystem: &'static mut FS,
-    #[allow(dead_code)]
-    is_passive: bool,
     uuid: Uuid,
     rebooter: fn() -> !,
 }
 
-impl<S, FS, T> Provisioner<S, FS, T>
+impl<S, T> Provisioner<S, T>
 where
     S: Store,
-    FS: 'static + LfsStorage,
     T: client::CryptoClient,
 {
-    pub fn new(
-        trussed: T,
-        store: S,
-        stolen_filesystem: &'static mut FS,
-        is_passive: bool,
-        uuid: Uuid,
-        rebooter: fn() -> !,
-    ) -> Provisioner<S, FS, T> {
+    pub fn new(trussed: T, store: S, uuid: Uuid, rebooter: fn() -> !) -> Provisioner<S, T> {
         Self {
             trussed,
             selected_buffer: SelectedBuffer::Filename,
             buffer_filename: Vec::new(),
             buffer_file_contents: Vec::new(),
             store,
-            stolen_filesystem,
-            is_passive,
             uuid,
             rebooter,
         }
@@ -170,13 +150,6 @@ where
                     SelectedBuffer::File => self.buffer_file_contents.extend_from_slice(data),
                 }
                 .unwrap();
-                Ok(())
-            }
-            Instruction::ReformatFilesystem => {
-                // Provide a method to reset the FS.
-                info!("Reformatting the FS..");
-                littlefs2::fs::Filesystem::format(self.stolen_filesystem)
-                    .map_err(|_| Error::NotEnoughMemory)?;
                 Ok(())
             }
             Instruction::WriteFile => {
@@ -221,7 +194,7 @@ where
                 // This should use the proper `random` method but is not possible without a `CryptoRng` implementation, which trussed is not
                 let keypair = loop {
                     seed.copy_from_slice(syscall!(self.trussed.random_bytes(32)).bytes.as_slice());
-                    match SecretKey::from_bytes(&seed) {
+                    match SecretKey::from_bytes(seed) {
                         Ok(secret) => {
                             break Keypair {
                                 public: secret.public_key(),

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -114,9 +114,6 @@ impl apps::Runner for Runner {
 
     type Store = store::Store;
 
-    #[cfg(feature = "provisioner")]
-    type Filesystem = store::InternalStorage;
-
     type Twi = ();
     type Se050Timer = ();
 
@@ -201,8 +198,6 @@ fn exec(
                 #[cfg(feature = "provisioner")]
                 provisioner: apps::ProvisionerData {
                     store,
-                    stolen_filesystem: unsafe { FilesystemOrRam::ifs() },
-                    nfc_powered: false,
                     rebooter: || unimplemented!(),
                 },
                 _marker: Default::default(),


### PR DESCRIPTION
The ReformatFilesystem command in the provisioner app required direct access to the IFS storage.  This is potentially unsound and adds complexity to the store implementation.  To avoid this requirement, this patch removes the command.  Instead a factory reset can be performed via admin-app to clear the filesystems.  If they need to be formatted, a custom firmware should be used that can format the filesystems during the store setup.