### PR TITLE
Update version to v1.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "apps"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "admin-app",
  "apdu-dispatch",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "boards"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "apdu-dispatch",
  "apps",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-runner-lib"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "apdu-dispatch",
  "apps",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "usbip-runner"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "apps",
  "cfg-if",
@@ -3645,7 +3645,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "chrono",
  "delog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.1"
+version = "1.8.2"
 
 [workspace.dependencies]
 littlefs2 = "0.6"


### PR DESCRIPTION
This PR merges the v1.8.1 tag to ensure a continuous history and updates the version to v1.8.2 as a preparation for the next test release.