### PR TITLE
Require Nitrokey SDK v0.3.0 in manifest

### DIFF
--- a/utils/manifest.template.json
+++ b/utils/manifest.template.json
@@ -1,7 +1,8 @@
 {
     "device": "Nitrokey 3",
     "version": "@VERSION@",
-    "pynitrokey": "v0.4.35",
+    "pynitrokey": "v0.8.0",
+    "sdk": "v0.3.0",
     "images": {
         "lpc55": "firmware-nk3xn-lpc55-@VERSION@.sb2",
         "nrf52": "firmware-nk3am-nrf52-@VERSION@.zip"


### PR DESCRIPTION
This patch replaces the pynitrokey version requirement with a Nitrokey SDK version requirement.  See this PR for more information on the mechanism:
- https://github.com/Nitrokey/nitrokey-sdk-py/pull/65

We also bump the pynitrokey version requirement to make sure that old versions that are not aware of the SDK version requirement reject new updates.

The reason for this new requirement is the support for the migration to the filesystem layout v2, see:
- https://github.com/Nitrokey/nitrokey-sdk-py/pull/67
- https://github.com/Nitrokey/nitrokey-3-firmware/pull/602