### PR TITLE
Update ctaphid-dispatch to v0.3.0 and usbd-ctaphid to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,10 +161,10 @@ name = "apps"
 version = "1.8.2"
 dependencies = [
  "admin-app",
- "apdu-dispatch",
+ "apdu-app",
  "bitflags 2.6.0",
  "cbor-smol",
- "ctaphid-dispatch",
+ "ctaphid-app",
  "delog",
  "embedded-hal",
  "fido-authenticator",
@@ -376,7 +376,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "cortex-m-semihosting",
- "ctaphid-dispatch",
+ "ctaphid-dispatch 0.3.0",
  "delog",
  "embedded-hal",
  "embedded-storage",
@@ -924,6 +924,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctaphid-dispatch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fd4316573df369820c5a9f8285fe522d8871c0b20bcf7d390f73b8e6caee28"
+dependencies = [
+ "ctaphid-app",
+ "delog",
+ "heapless-bytes",
+ "interchange",
+ "ref-swap",
+ "trussed-core",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,7 +1125,6 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
- "ctaphid-dispatch",
  "delog",
  "embedded-alloc",
  "embedded-hal",
@@ -1955,7 +1968,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
- "ctaphid-dispatch",
+ "ctaphid-dispatch 0.3.0",
  "delog",
  "interchange",
  "memory-regions",
@@ -3441,10 +3454,10 @@ dependencies = [
 [[package]]
 name = "trussed-usbip"
 version = "0.0.1"
-source = "git+https://github.com/trussed-dev/pc-usbip-runner.git?rev=2a002fdbcb4d1d989c896e0a249170b7da7f5ca5#2a002fdbcb4d1d989c896e0a249170b7da7f5ca5"
+source = "git+https://github.com/trussed-dev/pc-usbip-runner.git?rev=504674453c9573a30aa2f155101df49eb2af1ba7#504674453c9573a30aa2f155101df49eb2af1ba7"
 dependencies = [
  "apdu-dispatch",
- "ctaphid-dispatch",
+ "ctaphid-dispatch 0.3.0",
  "interchange",
  "littlefs2-core",
  "log",
@@ -3590,11 +3603,11 @@ dependencies = [
 
 [[package]]
 name = "usbd-ctaphid"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092fad7bf817001ecade9272fe6ccbea4e5d0c02f99ca24c4c5ce97fbbff5371"
+checksum = "82f5a2aa6898726b4eeb3fa3796fb8dc49e76e2a16bd683db103f63bc8ceca97"
 dependencies = [
- "ctaphid-dispatch",
+ "ctaphid-dispatch 0.3.0",
  "delog",
  "embedded-time",
  "heapless-bytes",
@@ -3624,6 +3637,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "clap-num",
+ "ctaphid-dispatch 0.3.0",
  "delog",
  "dialoguer",
  "littlefs2",
@@ -3757,7 +3771,7 @@ dependencies = [
  "cbor-smol",
  "ctap-types",
  "ctaphid-app",
- "ctaphid-dispatch",
+ "ctaphid-dispatch 0.2.0",
  "delog",
  "generic-array",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ memory-regions = { path = "components/memory-regions" }
 # unreleased libraries
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "024e0eca5fb7dbd2457831f7c7bffe4341e08775" }
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "2a002fdbcb4d1d989c896e0a249170b7da7f5ca5" }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", rev = "504674453c9573a30aa2f155101df49eb2af1ba7" }
 
 # applications
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.20" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 delog = "0.1"
-apdu-dispatch = "0.3.1"
+apdu-app = "0.1"
 bitflags = "2"
-ctaphid-dispatch = "0.2"
+ctaphid-app = "0.1"
 embedded-hal = "0.2.7"
 heapless = "0.7"
 heapless-bytes = "0.3"
@@ -17,7 +17,7 @@ serde = { version = "1.0.180", default-features = false }
 trussed = { version = "0.1", default-features = false, features = ["crypto-client", "filesystem-client", "management-client", "serde-extensions", "ui-client"] }
 trussed-core = "0.1.0-rc.1"
 trussed-usbip = { version = "0.0.1", default-features = false, features = ["ctaphid"], optional = true }
-usbd-ctaphid = { version = "0.2", optional = true }
+usbd-ctaphid = { version = "0.3", optional = true }
 utils = { path = "../utils" }
 if_chain = "1.0.2"
 littlefs2-core = "0.1"

--- a/components/boards/Cargo.toml
+++ b/components/boards/Cargo.toml
@@ -9,7 +9,7 @@ apps = { path = "../apps", features = ["fido-authenticator"] }
 cortex-m = "0.7"
 cortex-m-rtic = "1.0"
 cortex-m-rt = "0.6.15"
-ctaphid-dispatch = "0.2"
+ctaphid-dispatch = "0.3"
 delog = "0.1"
 embedded-hal = "0.2.3"
 embedded-time = "0.12"
@@ -26,7 +26,7 @@ spi-memory = "0.2.0"
 trussed = { version = "0.1", default-features = false }
 usb-device = "0.2"
 usbd-ccid = "0.3"
-usbd-ctaphid = "0.2"
+usbd-ctaphid = "0.3"
 utils = { path = "../utils" }
 
 # soc-lpc55

--- a/components/boards/src/runtime.rs
+++ b/components/boards/src/runtime.rs
@@ -1,10 +1,13 @@
 use apdu_dispatch::dispatch::{ApduDispatch, Interface};
 use apps::Endpoints;
-use ctaphid_dispatch::Dispatch as CtaphidDispatch;
 use embedded_time::duration::Milliseconds;
 use nfc_device::{traits::nfc::Device as NfcDevice, Iso14443};
 
-use crate::{init::UsbClasses, soc::Soc, ui, Apps, Board, Trussed};
+use crate::{
+    init::{CtaphidDispatch, UsbClasses},
+    soc::Soc,
+    ui, Apps, Board, Trussed,
+};
 
 pub fn poll_dispatchers<B: Board>(
     apdu_dispatch: &mut ApduDispatch<'_>,

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -23,7 +23,6 @@ utils = { path = "../../components/utils", features = ["storage"] }
 
 ### protocols and dispatchers
 apdu-dispatch = "0.3"
-ctaphid-dispatch = "0.2"
 
 ### trussed core
 trussed = { version = "0.1", default-features = false }

--- a/runners/embedded/src/bin/app-lpc.rs
+++ b/runners/embedded/src/bin/app-lpc.rs
@@ -19,13 +19,12 @@ mod app {
     use apdu_dispatch::dispatch::ApduDispatch;
     use apps::Endpoints;
     use boards::{
-        init::{Resources, UsbClasses},
+        init::{CtaphidDispatch, Resources, UsbClasses},
         nk3xn::{nfc::NfcChip, NK3xN},
         runtime,
         soc::lpc55::{self, monotonic::SystickMonotonic},
         Apps, Trussed,
     };
-    use ctaphid_dispatch::Dispatch as CtaphidDispatch;
     use embedded_runner_lib::nk3xn;
     use lpc55_hal::{
         drivers::timer::Elapsed,

--- a/runners/embedded/src/bin/app-nrf.rs
+++ b/runners/embedded/src/bin/app-nrf.rs
@@ -10,13 +10,12 @@ mod app {
     use apdu_dispatch::{dispatch::ApduDispatch, interchanges::Channel as CcidChannel};
     use apps::{Endpoints, Reboot};
     use boards::{
-        init::{Resources, UsbClasses},
+        init::{CtaphidDispatch, Resources, UsbClasses},
         nk3am::{self, InternalFlashStorage, NK3AM},
         runtime,
         soc::nrf52::{self, rtic_monotonic::RtcDuration, Nrf52},
         store, Apps, Trussed,
     };
-    use ctaphid_dispatch::Dispatch as CtaphidDispatch;
     use interchange::Channel;
     use nrf52840_hal::{
         gpiote::Gpiote,

--- a/runners/nkpk/Cargo.toml
+++ b/runners/nkpk/Cargo.toml
@@ -11,7 +11,7 @@ apps = { path = "../../components/apps", features = ["nkpk"] }
 boards = { path = "../../components/boards", features = ["board-nkpk"] }
 cortex-m = { version = "0.7", features = ["critical-section-single-core"]}
 cortex-m-rtic = "1.0"
-ctaphid-dispatch = "0.2"
+ctaphid-dispatch = "0.3"
 delog = "0.1"
 interchange = "0.3"
 nrf52840-hal = "0.15.1"

--- a/runners/nkpk/src/main.rs
+++ b/runners/nkpk/src/main.rs
@@ -10,13 +10,12 @@ mod app {
     use apdu_dispatch::{dispatch::ApduDispatch, interchanges::Channel as CcidChannel};
     use apps::{Endpoints, Reboot};
     use boards::{
-        init::{Resources, UsbClasses},
+        init::{CtaphidDispatch, Resources, UsbClasses},
         nkpk::{self, ExternalFlashStorage, InternalFlashStorage, NKPK},
         runtime,
         soc::nrf52::{self, rtic_monotonic::RtcDuration, Nrf52},
         store, Apps, Trussed,
     };
-    use ctaphid_dispatch::Dispatch as CtaphidDispatch;
     use interchange::Channel;
     use nrf52840_hal::{
         gpiote::Gpiote,

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -8,6 +8,7 @@ apps = { path = "../../components/apps", features = ["log-all", "nk3", "trussed-
 cfg-if = { version = "1.0.0" }
 clap = { version = "4.0.0", features = ["cargo", "derive"] }
 clap-num = "1.0.0"
+ctaphid-dispatch = "0.3"
 delog = { version = "0.1.6", features = ["std-log"] }
 dialoguer = { version = "0.10.4", default-features = false }
 littlefs2.workspace = true

--- a/runners/usbip/src/main.rs
+++ b/runners/usbip/src/main.rs
@@ -6,6 +6,7 @@ use std::{path::PathBuf, sync::Arc, thread};
 use apps::{AdminData, Apps, Dispatch, FidoData, Variant};
 use clap::{ArgAction, Parser, ValueEnum};
 use clap_num::maybe_hex;
+use ctaphid_dispatch::DEFAULT_MESSAGE_SIZE;
 use rand_core::{OsRng, RngCore};
 use trussed::{platform::Platform as _, types::Location, Bytes};
 use trussed_usbip::{Platform, Store, Syscall};
@@ -185,7 +186,10 @@ fn exec(
 
     let data = apps::Data {
         admin: AdminData::new(store, Variant::Usbip, VERSION, VERSION_STRING),
-        fido: FidoData { has_nfc: false },
+        fido: FidoData {
+            has_nfc: false,
+            max_message_size: DEFAULT_MESSAGE_SIZE,
+        },
         #[cfg(feature = "provisioner")]
         provisioner: apps::ProvisionerData {
             store,


### PR DESCRIPTION
This makes ctaphid generic over the buffer size and synchronizes the buffer sizes between ctaphid-dispatch and usbd-ctaphid.  As the usbd-ctaphid buffer size was only about half the size of the ctaphid-dispatch buffer size, this should lead to a significantly decreased stack usage in ctaphid-dispatch calls.

Depends on:
- https://github.com/trussed-dev/ctaphid-dispatch/pull/16
- https://github.com/trussed-dev/usbd-ctaphid/pull/20
- https://github.com/trussed-dev/pc-usbip-runner/pull/43

ctaphid-dispatch v0.2.0 is still in Cargo.lock because of webcrypt.