### PR TITLE
lpc55-builder: Replace solo2 with nitropy

### DIFF
--- a/docs/lpc55-quickstart.md
+++ b/docs/lpc55-quickstart.md
@@ -16,10 +16,7 @@ This guide explains how to compile and flash the firmware on a LPC55 Nitrokey 3 
   * Git
   * LLVM, Clang, GCC
     * On Debian-based distributions, you need to install these packages: `llvm clang libclang-dev gcc-arm-none-eabi libc6-dev-i386`
-  * PC/SC Smart Card Daemon [`pcsclite`](https://pcsclite.apdu.fr/) (needed for `solo2`)
-    * On Debian-based distributions, you neeed to install this package: `pcscd`
   * [`nitropy`](https://github.com/nitrokey/pynitrokey)
-  * [`solo2`](https://github.com/solokeys/solo2-cli) with the `dev-pki` feature
   * [`lpc55`](https://github.com/lpc55/lpc55-host)
   * [`flip-link`](https://github.com/knurling-rs/flip-link)
 

--- a/utils/lpc55-builder/Makefile
+++ b/utils/lpc55-builder/Makefile
@@ -118,13 +118,6 @@ bl-provision-keystore:
 # The following targets prefixed with fw- require that the device is in firmware mode.
 
 .PHONY: fw-provision-certs
-fw-provision-certs: data/fido.key data/fido.cert
+fw-provision-certs:
 	# TODO: add Trussed key & cert
-	solo2 app provision store-fido-batch-cert data/fido.cert
-	solo2 app provision store-fido-batch-key data/fido.key
-
-data/fido.key: data/fido.cert
-
-data/fido.cert:
-	mkdir -p data
-	solo2 pki dev fido data/fido.key data/fido.cert
+	nitropy nk3 provision fido2 --key ../test-certificates/fido/nk-fido-ee-key.trussed --cert ../test-certificates/fido/nk-fido-ee-cert.der


### PR DESCRIPTION
This patch replaces solo2 with nitropy for provisioning the FIDO2 attestation key and certificate.  It also replaces the custom key and certificate with the standard test data from utils/test-certificates.

Fixes: https://github.com/Nitrokey/nitrokey-3-firmware/issues/593