### PR TITLE
Update fido-authenticator v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,8 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "fido-authenticator"
-version = "0.1.1"
-source = "git+https://github.com/Nitrokey/fido-authenticator.git?tag=v0.1.1-nitrokey.27#5ebb4a48302e4c80a2abe1c2d86201a3df2a1d2d"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f7367d82579f74638875b1a277d55a4c23a3b4865b53d26cd315e99aa528b42"
 dependencies = [
  "apdu-app",
  "cbor-smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner.git", re
 
 # applications
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.20" }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git",tag = "v0.1.1-nitrokey.27" }
 opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.6.1" }
 piv-authenticator = { git = "https://github.com/trussed-dev/piv-authenticator.git", tag = "v0.5.3" }
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.14.0" }

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -40,7 +40,7 @@ trussed-hpke = "0.2.0"
 
 # apps
 admin-app = "0.1.0"
-fido-authenticator = { version = "0.1.1", features = ["chunked", "dispatch"], optional = true }
+fido-authenticator = { version = "0.2", features = ["chunked", "dispatch"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
 secrets-app = { version = "0.14.0", features = ["apdu-dispatch", "ctaphid"], optional = true }
 opcard = { version = "1.6.1", features = ["apdu-dispatch", "delog", "rsa2048-gen", "rsa4096", "admin-app"], optional = true }


### PR DESCRIPTION
As we have merged all of our patches, we can now use the upstream v0.2.0 release for fido-authenticator.