### PR TITLE
Put opcard config behind feature flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,5 @@ manifest.json:
 
 .PHONY: software-tests
 software-tests:
-	cd components/apps && cargo test
+	cd components/apps && cargo test --all-features
 	cd components/boards && cargo test


### PR DESCRIPTION
The opcard config fields should not be available on the Nitrokey Passkey that does not include the opcard app.