### PR TITLE
Use correct feature flag in config field list

### DIFF
--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -99,6 +99,7 @@ impl admin_app::Config for Config {
                 destructive: true,
                 ty: FieldType::Bool,
             },
+            #[cfg(feature = "opcard")]
             ConfigField {
                 name: "opcard.disabled",
                 requires_touch_confirmation: false,


### PR DESCRIPTION
In https://github.com/Nitrokey/nitrokey-3-firmware/pull/651, I only updated the config struct but not the list of config fields.