### PR TITLE
Add secp256k1 support in opcard to changelog for v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
+## Unreleased
+
 - fido-authenticator: Implement the largeBlobKey extension and the largeBlobs command ([fido-authenticator#38][])
 
-## 1.8.3 (2025-10-13)
+## v1.8.3 (2025-10-13)
 
 - OpenPGP: fix factory reset and retry counter display
 
-## 1.8.2 (2025-08-12)
+## v1.8.2 (2025-08-12)
 
 - provisioner-app: Remove ReformatFilesystem command
 - fido-authenticator: Increase the maximum number of discoverable credentials (resident keys) to 100.
@@ -17,6 +19,8 @@
   - Forbid up = false when using the hmac-secret extension ([fido-authenticator#19](https://github.com/Nitrokey/fido-authenticator/issues/19))
   - Allow creating credentials without PIN (`makeCredUvNotRqd`, [fido-authenticator#34](https://github.com/Nitrokey/fido-authenticator/issues/34))
   - Support clientPin getRetries without PIN protocol ([fido-authenticator#118](https://github.com/Nitrokey/fido-authenticator/issues/118))
+- OpenPGP: Update to [opcard v1.6.1](https://github.com/Nitrokey/opcard-rs/releases/tag/v1.6.1)
+  - Add support for secp256k1
 
 ## v1.8.1 (2025-02-11)
 


### PR DESCRIPTION
secpk256k1 is mentioned in the release notes for v1.8.2-rc.1 but neither in the changelog nor in the release notes for v1.8.2.  This patch updates the changelog and fixes some inconsistent formatting.