### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,11 +2207,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -2599,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2695,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",

--- a/utils/fido2-mds/requirements.in
+++ b/utils/fido2-mds/requirements.in
@@ -1,2 +1,2 @@
-cairosvg
-fido2
+cairosvg >=2.8,<3
+fido2 >=2,<3

--- a/utils/fido2-mds/requirements.txt
+++ b/utils/fido2-mds/requirements.txt
@@ -2,25 +2,25 @@
 #    uv pip compile requirements.in -o requirements.txt
 cairocffi==1.7.1
     # via cairosvg
-cairosvg==2.8.2
+cairosvg==2.9.0
     # via -r requirements.in
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   cairocffi
     #   cryptography
-cryptography==45.0.6
+cryptography==48.0.0
     # via fido2
-cssselect2==0.8.0
+cssselect2==0.9.0
     # via cairosvg
 defusedxml==0.7.1
     # via cairosvg
-fido2==2.0.0
+fido2==2.2.0
     # via -r requirements.in
-pillow==11.3.0
+pillow==12.2.0
     # via cairosvg
-pycparser==2.22
+pycparser==3.0
     # via cffi
-tinycss2==1.4.0
+tinycss2==1.5.1
     # via
     #   cairosvg
     #   cssselect2


### PR DESCRIPTION
This PR updates the `rand` and `rsa` dependencies in the firmware and all dependencies for the FIDO2 MDS generation to fix dependabot warnings.