### PR TITLE
Add basic cargo vet configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,6 +186,18 @@ build-firmware:
       - artifacts
       - binaries
 
+vet-dependencies:
+  image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "pipeline" && $COMMAND_BOT == "nitrokey-ci" && $COMMAND == "full-test"'
+  tags:
+    - docker
+  stage: build
+  script:
+    - cargo vet check --locked
+
 # metrics stage
 
 metrics:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN rustup target add thumbv7em-none-eabihf thumbv8m.main-none-eabi
 RUN rustup component add llvm-tools-preview clippy rustfmt
 RUN cargo install --git https://github.com/Nitrokey/nitrokey-ci --rev 1dcacd7a89621b29403bace6cd0abb254844bf0c --locked
 RUN cargo install --git https://github.com/Nitrokey/repometrics --rev 1f0f43a119e4b0412f8eae416cff96b68d62b8bd --locked
+RUN cargo install cargo-vet@0.10.2 --locked
 RUN rustup install nightly-2025-05-09
 RUN rustup component add rust-src --toolchain nightly-2025-05-09
 WORKDIR /app

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,4 @@
+
+# cargo-vet audits file
+
+[audits]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -221,6 +221,18 @@ who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.3.2"
 
+[[audits.log]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.29 -> 0.4.32"
+notes = "Mostly lint/formatting changes, other changes are sensible"
+
+[[audits.memchr]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "2.7.5 -> 2.8.2"
+notes = "Mostly changes that correspond to applying lints, otherwise addition of one vector operation that is as safe as the existing ones"
+
 [[audits.num]]
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
@@ -230,6 +242,24 @@ delta = "0.4.0 -> 0.3.1"
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.2 -> 0.1.3"
+
+[[audits.regex]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "1.12.3 -> 1.12.4"
+notes = "No changes in this crate, changes are only in dependencies but their version criterias are not changed"
+
+[[audits.regex]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-run"
+delta = "1.12.3 -> 1.12.4"
+notes = "Nothing has been changed in the code of this crate, only in the dependencies that are part of the regex project"
+
+[[audits.regex-syntax]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.8.11"
+notes = "Mostly lint/formatting changes small feature change"
 
 [[audits.serde-indexed]]
 who = "Robin Krahl <robin@nitrokey.com>"
@@ -245,6 +275,18 @@ delta = "1.0.3 -> 1.0.2"
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.0 -> 1.0.0"
+
+[[audits.shlex]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.0 -> 2.0.1"
+notes = "Mostly function removals"
+
+[[audits.stable_deref_trait]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+notes = "Just a stricter CFG and support for `Cow`"
 
 [[audits.toml_writer]]
 who = "Robin Krahl <robin@nitrokey.com>"
@@ -280,6 +322,12 @@ version = "0.5.0-rc.1"
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0-rc.1"
+
+[[audits.version_check]]
+who = "Sosthène Guédon <sosthene@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.9.5"
+notes = "Only documentation changes"
 
 [[audits.winapi-util]]
 who = "Robin Krahl <robin@nitrokey.com>"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,4 +1,242 @@
 
 # cargo-vet audits file
 
-[audits]
+[[wildcard-audits.apdu-app]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/apdu-dispatch"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[wildcard-audits.apdu-dispatch]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/apdu-dispatch"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[wildcard-audits.ctap-types]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/ctap-types"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[wildcard-audits.ctaphid-app]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/ctaphid-dispatch"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.ctaphid-dispatch]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/ctaphid-dispatch"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.fido-authenticator]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/fido-authenticator"
+start = "2025-09-02"
+end = "2027-06-17"
+
+[[wildcard-audits.heapless-bytes]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/heapless-bytes"
+start = "2025-09-18"
+end = "2027-06-17"
+
+[[wildcard-audits.iso7816]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/iso7816"
+start = "2025-09-25"
+end = "2027-06-17"
+
+[[wildcard-audits.littlefs2]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/littlefs2"
+start = "2026-03-09"
+end = "2027-06-17"
+
+[[wildcard-audits.littlefs2-core]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/littlefs2"
+start = "2025-10-16"
+end = "2027-06-17"
+
+[[wildcard-audits.littlefs2-sys]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/littlefs2-sys"
+start = "2026-03-03"
+end = "2027-06-17"
+
+[[wildcard-audits.lpc55-hal]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:lpc55/lpc55-hal"
+start = "2026-03-20"
+end = "2027-06-17"
+
+[[wildcard-audits.se05x]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:Nitrokey/se05x"
+start = "2025-09-25"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-auth]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-auth"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-chunked]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-core]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed"
+start = "2026-03-20"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-fs-info]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-hkdf]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-hpke]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-manage]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-rsa-types]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-rsa-backend"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-se050-manage]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:Nitrokey/trussed-se050-backend"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[wildcard-audits.trussed-wrap-key-to-file]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+start = "2026-03-23"
+end = "2027-06-17"
+
+[[wildcard-audits.usbd-ccid]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/usbd-ccid"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[wildcard-audits.usbd-ctaphid]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/usbd-ctaphid"
+start = "2026-03-25"
+end = "2027-06-17"
+
+[[audits.cbor-smol]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+
+[[audits.cosey]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+
+[[audits.delog]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.1.8"
+
+[[audits.flexiber]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+
+[[audits.flexiber_derive]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+
+[[audits.interchange]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+
+[[audits.serde-indexed]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+
+[[audits.trussed]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0-rc.1"
+
+[[audits.trussed-auth-backend]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0-rc.1"
+
+[[audits.trussed-rsa-alloc]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0-rc.1"
+
+[[audits.trussed-se050-backend]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.8.0-rc.1"
+
+[[audits.trussed-staging]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.5.0-rc.1"
+
+[[audits.trussed-usbip]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0-rc.1"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -181,10 +181,20 @@ who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.5.1"
 
+[[audits.clap_lex]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.4 -> 0.7.5"
+
 [[audits.cosey]]
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.4.0"
+
+[[audits.crunchy]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.3 -> 0.2.4"
 
 [[audits.delog]]
 who = "Robin Krahl <robin@nitrokey.com>"
@@ -201,15 +211,45 @@ who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.1.3"
 
+[[audits.inout]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.1.4"
+
 [[audits.interchange]]
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.3.2"
 
+[[audits.num]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.3.1"
+
+[[audits.potential_utf]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.3"
+
 [[audits.serde-indexed]]
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.1.1"
+
+[[audits.serde_spanned]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.0.2"
+
+[[audits.serial_test]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 1.0.0"
+
+[[audits.toml_writer]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.6+spec-1.1.0 -> 1.0.3"
 
 [[audits.trussed]]
 who = "Robin Krahl <robin@nitrokey.com>"
@@ -240,3 +280,13 @@ version = "0.5.0-rc.1"
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0-rc.1"
+
+[[audits.winapi-util]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.9 -> 0.1.11"
+
+[[audits.windows-link]]
+who = "Robin Krahl <robin@nitrokey.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.3"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,1709 @@
+
+# cargo-vet config file
+
+[cargo-vet]
+version = "0.10"
+
+[policy.admin-app]
+audit-as-crates-io = false
+notes = "pinned to a reviewed revision"
+
+[policy.collect-license-info]
+criteria = "safe-to-run"
+notes = "relaxed to reduce initial efforts"
+
+[policy.embedded-runner-lib]
+criteria = "safe-to-run"
+notes = "relaxed to reduce initial efforts"
+
+[policy.gen-commands-bd]
+criteria = "safe-to-run"
+notes = "relaxed to reduce initial efforts"
+
+[policy.nkpk]
+criteria = "safe-to-run"
+notes = "relaxed to reduce initial efforts"
+
+[policy.opcard]
+audit-as-crates-io = false
+notes = "pinned to a reviewed revision"
+
+[policy.p256-cortex-m4]
+audit-as-crates-io = false
+notes = "pinned to a reviewed revision"
+
+[policy.usbip-runner]
+criteria = "safe-to-run"
+notes = "relaxed to reduce initial efforts"
+
+[[exemptions.aead]]
+version = "0.5.2"
+criteria = "safe-to-run"
+
+[[exemptions.aes]]
+version = "0.8.4"
+criteria = "safe-to-run"
+
+[[exemptions.aes-gcm]]
+version = "0.10.3"
+criteria = "safe-to-run"
+
+[[exemptions.aho-corasick]]
+version = "1.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.android_system_properties]]
+version = "0.1.5"
+criteria = "safe-to-run"
+
+[[exemptions.anstream]]
+version = "0.6.20"
+criteria = "safe-to-run"
+
+[[exemptions.anstyle]]
+version = "1.0.11"
+criteria = "safe-to-run"
+
+[[exemptions.anstyle-parse]]
+version = "0.2.7"
+criteria = "safe-to-run"
+
+[[exemptions.anstyle-query]]
+version = "1.1.4"
+criteria = "safe-to-run"
+
+[[exemptions.anstyle-wincon]]
+version = "3.0.10"
+criteria = "safe-to-run"
+
+[[exemptions.anyhow]]
+version = "1.0.100"
+criteria = "safe-to-run"
+
+[[exemptions.apdu-app]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.apdu-dispatch]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.askama]]
+version = "0.14.0"
+criteria = "safe-to-run"
+
+[[exemptions.askama_derive]]
+version = "0.14.0"
+criteria = "safe-to-run"
+
+[[exemptions.askama_parser]]
+version = "0.14.0"
+criteria = "safe-to-run"
+
+[[exemptions.atomic-polyfill]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.autocfg]]
+version = "1.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.az]]
+version = "1.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.bare-metal]]
+version = "0.2.5"
+criteria = "safe-to-run"
+
+[[exemptions.bare-metal]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.base16ct]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.base64]]
+version = "0.13.1"
+criteria = "safe-to-run"
+
+[[exemptions.base64ct]]
+version = "1.8.0"
+criteria = "safe-to-run"
+
+[[exemptions.basic-toml]]
+version = "0.1.10"
+criteria = "safe-to-run"
+
+[[exemptions.bindgen]]
+version = "0.70.1"
+criteria = "safe-to-run"
+
+[[exemptions.bitfield]]
+version = "0.13.2"
+criteria = "safe-to-run"
+
+[[exemptions.bitflags]]
+version = "1.3.2"
+criteria = "safe-to-run"
+
+[[exemptions.bitflags]]
+version = "2.9.4"
+criteria = "safe-to-run"
+
+[[exemptions.block-buffer]]
+version = "0.10.4"
+criteria = "safe-to-run"
+
+[[exemptions.block-padding]]
+version = "0.3.3"
+criteria = "safe-to-run"
+
+[[exemptions.bumpalo]]
+version = "3.19.0"
+criteria = "safe-to-run"
+
+[[exemptions.bytemuck]]
+version = "1.23.2"
+criteria = "safe-to-run"
+
+[[exemptions.byteorder]]
+version = "1.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.camino]]
+version = "1.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.cargo-license]]
+version = "0.7.0"
+criteria = "safe-to-run"
+
+[[exemptions.cargo-lock]]
+version = "10.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.cargo-platform]]
+version = "0.1.9"
+criteria = "safe-to-run"
+
+[[exemptions.cargo-platform]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.cargo-util-schemas]]
+version = "0.8.2"
+criteria = "safe-to-run"
+
+[[exemptions.cargo_metadata]]
+version = "0.18.1"
+criteria = "safe-to-run"
+
+[[exemptions.cargo_metadata]]
+version = "0.21.0"
+criteria = "safe-to-run"
+
+[[exemptions.cast]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.cbc]]
+version = "0.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.cbor-smol]]
+version = "0.5.1"
+criteria = "safe-to-run"
+
+[[exemptions.cc]]
+version = "1.2.38"
+criteria = "safe-to-run"
+
+[[exemptions.cexpr]]
+version = "0.6.0"
+criteria = "safe-to-run"
+
+[[exemptions.cfg-if]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.chacha20]]
+version = "0.9.1"
+criteria = "safe-to-run"
+
+[[exemptions.chacha20poly1305]]
+version = "0.10.1"
+criteria = "safe-to-run"
+
+[[exemptions.chrono]]
+version = "0.4.42"
+criteria = "safe-to-run"
+
+[[exemptions.cipher]]
+version = "0.4.4"
+criteria = "safe-to-run"
+
+[[exemptions.clang-sys]]
+version = "1.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.clap]]
+version = "4.5.48"
+criteria = "safe-to-run"
+
+[[exemptions.clap-num]]
+version = "1.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.clap_builder]]
+version = "4.5.48"
+criteria = "safe-to-run"
+
+[[exemptions.clap_derive]]
+version = "4.5.47"
+criteria = "safe-to-run"
+
+[[exemptions.clap_lex]]
+version = "0.7.5"
+criteria = "safe-to-run"
+
+[[exemptions.cmac]]
+version = "0.7.2"
+criteria = "safe-to-run"
+
+[[exemptions.cobs]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.colorchoice]]
+version = "1.0.4"
+criteria = "safe-to-run"
+
+[[exemptions.console]]
+version = "0.15.11"
+criteria = "safe-to-run"
+
+[[exemptions.const-default]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.const-oid]]
+version = "0.9.6"
+criteria = "safe-to-run"
+
+[[exemptions.core-foundation-sys]]
+version = "0.8.7"
+criteria = "safe-to-run"
+
+[[exemptions.cortex-m]]
+version = "0.7.7"
+criteria = "safe-to-run"
+
+[[exemptions.cortex-m-rt]]
+version = "0.7.5"
+criteria = "safe-to-run"
+
+[[exemptions.cortex-m-rt-macros]]
+version = "0.7.5"
+criteria = "safe-to-run"
+
+[[exemptions.cortex-m-rtic]]
+version = "1.1.4"
+criteria = "safe-to-run"
+
+[[exemptions.cortex-m-rtic-macros]]
+version = "1.1.6"
+criteria = "safe-to-run"
+
+[[exemptions.cortex-m-semihosting]]
+version = "0.3.7"
+criteria = "safe-to-run"
+
+[[exemptions.cosey]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.cpufeatures]]
+version = "0.2.17"
+criteria = "safe-to-run"
+
+[[exemptions.crc16]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.critical-section]]
+version = "1.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.crunchy]]
+version = "0.2.4"
+criteria = "safe-to-run"
+
+[[exemptions.crypto-bigint]]
+version = "0.5.5"
+criteria = "safe-to-run"
+
+[[exemptions.crypto-common]]
+version = "0.1.6"
+criteria = "safe-to-run"
+
+[[exemptions.csv]]
+version = "1.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.csv-core]]
+version = "0.1.12"
+criteria = "safe-to-run"
+
+[[exemptions.ctap-types]]
+version = "0.6.0-rc.4"
+criteria = "safe-to-run"
+
+[[exemptions.ctaphid-app]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.ctaphid-dispatch]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.ctr]]
+version = "0.9.2"
+criteria = "safe-to-run"
+
+[[exemptions.cty]]
+version = "0.2.2"
+criteria = "safe-to-run"
+
+[[exemptions.dashmap]]
+version = "5.5.3"
+criteria = "safe-to-run"
+
+[[exemptions.dbl]]
+version = "0.3.2"
+criteria = "safe-to-run"
+
+[[exemptions.delog]]
+version = "0.1.8"
+criteria = "safe-to-run"
+
+[[exemptions.der]]
+version = "0.7.10"
+criteria = "safe-to-run"
+
+[[exemptions.der_derive]]
+version = "0.7.3"
+criteria = "safe-to-run"
+
+[[exemptions.des]]
+version = "0.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.dialoguer]]
+version = "0.10.4"
+criteria = "safe-to-run"
+
+[[exemptions.digest]]
+version = "0.10.7"
+criteria = "safe-to-run"
+
+[[exemptions.displaydoc]]
+version = "0.2.5"
+criteria = "safe-to-run"
+
+[[exemptions.ecdsa]]
+version = "0.16.9"
+criteria = "safe-to-run"
+
+[[exemptions.ed25519]]
+version = "2.2.3"
+criteria = "safe-to-run"
+
+[[exemptions.either]]
+version = "1.15.0"
+criteria = "safe-to-run"
+
+[[exemptions.elliptic-curve]]
+version = "0.13.8"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-alloc]]
+version = "0.6.0"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-dma]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-hal]]
+version = "0.2.7"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-storage]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.embedded-time]]
+version = "0.12.1"
+criteria = "safe-to-run"
+
+[[exemptions.encode_unicode]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.env_logger]]
+version = "0.8.4"
+criteria = "safe-to-run"
+
+[[exemptions.env_logger]]
+version = "0.10.2"
+criteria = "safe-to-run"
+
+[[exemptions.equivalent]]
+version = "1.0.2"
+criteria = "safe-to-run"
+
+[[exemptions.erased-serde]]
+version = "0.4.8"
+criteria = "safe-to-run"
+
+[[exemptions.ff]]
+version = "0.13.1"
+criteria = "safe-to-run"
+
+[[exemptions.fido-authenticator]]
+version = "0.4.0-rc.3"
+criteria = "safe-to-run"
+
+[[exemptions.find-msvc-tools]]
+version = "0.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.fixed]]
+version = "1.29.0"
+criteria = "safe-to-run"
+
+[[exemptions.flexiber]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.flexiber_derive]]
+version = "0.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.form_urlencoded]]
+version = "1.2.2"
+criteria = "safe-to-run"
+
+[[exemptions.fugit]]
+version = "0.3.7"
+criteria = "safe-to-run"
+
+[[exemptions.futures]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.futures-channel]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.futures-core]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.futures-executor]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.futures-io]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.futures-sink]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.futures-task]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.futures-util]]
+version = "0.3.31"
+criteria = "safe-to-run"
+
+[[exemptions.gcd]]
+version = "2.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.generator]]
+version = "0.7.5"
+criteria = "safe-to-run"
+
+[[exemptions.generic-array]]
+version = "0.14.7"
+criteria = "safe-to-run"
+
+[[exemptions.generic-array]]
+version = "1.3.3"
+criteria = "safe-to-run"
+
+[[exemptions.getopts]]
+version = "0.2.24"
+criteria = "safe-to-run"
+
+[[exemptions.getrandom]]
+version = "0.2.16"
+criteria = "safe-to-run"
+
+[[exemptions.ghash]]
+version = "0.5.1"
+criteria = "safe-to-run"
+
+[[exemptions.glob]]
+version = "0.3.3"
+criteria = "safe-to-run"
+
+[[exemptions.group]]
+version = "0.13.0"
+criteria = "safe-to-run"
+
+[[exemptions.gumdrop]]
+version = "0.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.gumdrop_derive]]
+version = "0.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.half]]
+version = "2.6.0"
+criteria = "safe-to-run"
+
+[[exemptions.hash32]]
+version = "0.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.hash32]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.hashbrown]]
+version = "0.12.3"
+criteria = "safe-to-run"
+
+[[exemptions.hashbrown]]
+version = "0.14.5"
+criteria = "safe-to-run"
+
+[[exemptions.hashbrown]]
+version = "0.16.0"
+criteria = "safe-to-run"
+
+[[exemptions.heapless]]
+version = "0.7.17"
+criteria = "safe-to-run"
+
+[[exemptions.heapless]]
+version = "0.9.1"
+criteria = "safe-to-run"
+
+[[exemptions.heapless-bytes]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.heck]]
+version = "0.4.1"
+criteria = "safe-to-run"
+
+[[exemptions.heck]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.hermit-abi]]
+version = "0.5.2"
+criteria = "safe-to-run"
+
+[[exemptions.hex]]
+version = "0.4.3"
+criteria = "safe-to-run"
+
+[[exemptions.hex-literal]]
+version = "0.3.4"
+criteria = "safe-to-run"
+
+[[exemptions.hex-literal]]
+version = "0.4.1"
+criteria = "safe-to-run"
+
+[[exemptions.hkdf]]
+version = "0.12.4"
+criteria = "safe-to-run"
+
+[[exemptions.hmac]]
+version = "0.12.1"
+criteria = "safe-to-run"
+
+[[exemptions.humantime]]
+version = "2.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.iana-time-zone]]
+version = "0.1.64"
+criteria = "safe-to-run"
+
+[[exemptions.iana-time-zone-haiku]]
+version = "0.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.icu_collections]]
+version = "2.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.icu_locale_core]]
+version = "2.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.icu_normalizer]]
+version = "2.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.icu_normalizer_data]]
+version = "2.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.icu_properties]]
+version = "2.0.1"
+criteria = "safe-to-run"
+
+[[exemptions.icu_properties_data]]
+version = "2.0.1"
+criteria = "safe-to-run"
+
+[[exemptions.icu_provider]]
+version = "2.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.idna]]
+version = "1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.idna_adapter]]
+version = "1.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.if_chain]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.indexmap]]
+version = "1.9.3"
+criteria = "safe-to-run"
+
+[[exemptions.indexmap]]
+version = "2.11.4"
+criteria = "safe-to-run"
+
+[[exemptions.inout]]
+version = "0.1.4"
+criteria = "safe-to-run"
+
+[[exemptions.interchange]]
+version = "0.3.2"
+criteria = "safe-to-run"
+
+[[exemptions.is-terminal]]
+version = "0.4.16"
+criteria = "safe-to-run"
+
+[[exemptions.is_terminal_polyfill]]
+version = "1.70.1"
+criteria = "safe-to-run"
+
+[[exemptions.iso7816]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.itertools]]
+version = "0.13.0"
+criteria = "safe-to-run"
+
+[[exemptions.itertools]]
+version = "0.14.0"
+criteria = "safe-to-run"
+
+[[exemptions.itoa]]
+version = "1.0.15"
+criteria = "safe-to-run"
+
+[[exemptions.js-sys]]
+version = "0.3.81"
+criteria = "safe-to-run"
+
+[[exemptions.lazy_static]]
+version = "1.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.libc]]
+version = "0.2.176"
+criteria = "safe-to-run"
+
+[[exemptions.libloading]]
+version = "0.8.9"
+criteria = "safe-to-run"
+
+[[exemptions.libm]]
+version = "0.2.15"
+criteria = "safe-to-run"
+
+[[exemptions.linked_list_allocator]]
+version = "0.10.5"
+criteria = "safe-to-run"
+
+[[exemptions.litemap]]
+version = "0.8.0"
+criteria = "safe-to-run"
+
+[[exemptions.littlefs2]]
+version = "0.7.0"
+criteria = "safe-to-run"
+
+[[exemptions.littlefs2-core]]
+version = "0.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.littlefs2-sys]]
+version = "0.3.2"
+criteria = "safe-to-run"
+
+[[exemptions.lock_api]]
+version = "0.4.13"
+criteria = "safe-to-run"
+
+[[exemptions.log]]
+version = "0.4.28"
+criteria = "safe-to-run"
+
+[[exemptions.loom]]
+version = "0.5.6"
+criteria = "safe-to-run"
+
+[[exemptions.lpc55-hal]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.lpc55-pac]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.matchers]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.memchr]]
+version = "2.7.5"
+criteria = "safe-to-run"
+
+[[exemptions.minimal-lexical]]
+version = "0.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.nb]]
+version = "0.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.nb]]
+version = "1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.nom]]
+version = "7.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.nrf-hal-common]]
+version = "0.15.1"
+criteria = "safe-to-run"
+
+[[exemptions.nrf-usbd]]
+version = "0.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.nrf52840-hal]]
+version = "0.15.1"
+criteria = "safe-to-run"
+
+[[exemptions.nrf52840-pac]]
+version = "0.11.0"
+criteria = "safe-to-run"
+
+[[exemptions.nu-ansi-term]]
+version = "0.50.1"
+criteria = "safe-to-run"
+
+[[exemptions.num]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.num-bigint-dig]]
+version = "0.8.6"
+criteria = "safe-to-run"
+
+[[exemptions.num-complex]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.num-integer]]
+version = "0.1.46"
+criteria = "safe-to-run"
+
+[[exemptions.num-iter]]
+version = "0.1.45"
+criteria = "safe-to-run"
+
+[[exemptions.num-rational]]
+version = "0.3.2"
+criteria = "safe-to-run"
+
+[[exemptions.num-traits]]
+version = "0.2.19"
+criteria = "safe-to-run"
+
+[[exemptions.once_cell]]
+version = "1.21.3"
+criteria = "safe-to-run"
+
+[[exemptions.once_cell_polyfill]]
+version = "1.70.1"
+criteria = "safe-to-run"
+
+[[exemptions.opaque-debug]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.ordered-float]]
+version = "2.10.1"
+criteria = "safe-to-run"
+
+[[exemptions.p256]]
+version = "0.13.2"
+criteria = "safe-to-run"
+
+[[exemptions.p256-cortex-m4-sys]]
+version = "0.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.parking_lot]]
+version = "0.12.4"
+criteria = "safe-to-run"
+
+[[exemptions.parking_lot_core]]
+version = "0.9.11"
+criteria = "safe-to-run"
+
+[[exemptions.percent-encoding]]
+version = "2.3.2"
+criteria = "safe-to-run"
+
+[[exemptions.pin-project-lite]]
+version = "0.2.16"
+criteria = "safe-to-run"
+
+[[exemptions.pin-utils]]
+version = "0.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.pkcs1]]
+version = "0.7.5"
+criteria = "safe-to-run"
+
+[[exemptions.pkcs8]]
+version = "0.10.2"
+criteria = "safe-to-run"
+
+[[exemptions.poly1305]]
+version = "0.8.0"
+criteria = "safe-to-run"
+
+[[exemptions.polyval]]
+version = "0.6.2"
+criteria = "safe-to-run"
+
+[[exemptions.postcard]]
+version = "0.7.3"
+criteria = "safe-to-run"
+
+[[exemptions.postcard]]
+version = "1.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.postcard-cobs]]
+version = "0.1.5-pre"
+criteria = "safe-to-run"
+
+[[exemptions.potential_utf]]
+version = "0.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.ppv-lite86]]
+version = "0.2.21"
+criteria = "safe-to-run"
+
+[[exemptions.pretty_env_logger]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.primeorder]]
+version = "0.13.6"
+criteria = "safe-to-run"
+
+[[exemptions.proc-macro-error]]
+version = "1.0.4"
+criteria = "safe-to-run"
+
+[[exemptions.proc-macro-error-attr]]
+version = "1.0.4"
+criteria = "safe-to-run"
+
+[[exemptions.proc-macro2]]
+version = "1.0.101"
+criteria = "safe-to-run"
+
+[[exemptions.quickcheck]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.quote]]
+version = "1.0.40"
+criteria = "safe-to-run"
+
+[[exemptions.rand]]
+version = "0.8.6"
+criteria = "safe-to-run"
+
+[[exemptions.rand_chacha]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.rand_core]]
+version = "0.6.4"
+criteria = "safe-to-run"
+
+[[exemptions.redox_syscall]]
+version = "0.5.17"
+criteria = "safe-to-run"
+
+[[exemptions.ref-swap]]
+version = "0.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.regex]]
+version = "1.11.2"
+criteria = "safe-to-run"
+
+[[exemptions.regex-automata]]
+version = "0.4.10"
+criteria = "safe-to-run"
+
+[[exemptions.regex-syntax]]
+version = "0.8.6"
+criteria = "safe-to-run"
+
+[[exemptions.rfc6979]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.rlsf]]
+version = "0.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.rsa]]
+version = "0.9.10"
+criteria = "safe-to-run"
+
+[[exemptions.rtic-core]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.rtic-monotonic]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.rtic-syntax]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.rtt-target]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.rustc-hash]]
+version = "1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.rustc-hash]]
+version = "2.1.1"
+criteria = "safe-to-run"
+
+[[exemptions.rustc_version]]
+version = "0.2.3"
+criteria = "safe-to-run"
+
+[[exemptions.rustc_version]]
+version = "0.4.1"
+criteria = "safe-to-run"
+
+[[exemptions.rustversion]]
+version = "1.0.22"
+criteria = "safe-to-run"
+
+[[exemptions.ryu]]
+version = "1.0.20"
+criteria = "safe-to-run"
+
+[[exemptions.salty]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.scoped-tls]]
+version = "1.0.1"
+criteria = "safe-to-run"
+
+[[exemptions.scopeguard]]
+version = "1.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.se05x]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.sec1]]
+version = "0.7.3"
+criteria = "safe-to-run"
+
+[[exemptions.semver]]
+version = "0.9.0"
+criteria = "safe-to-run"
+
+[[exemptions.semver]]
+version = "1.0.27"
+criteria = "safe-to-run"
+
+[[exemptions.semver-parser]]
+version = "0.7.0"
+criteria = "safe-to-run"
+
+[[exemptions.serde]]
+version = "1.0.226"
+criteria = "safe-to-run"
+
+[[exemptions.serde-byte-array]]
+version = "0.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.serde-indexed]]
+version = "0.1.1"
+criteria = "safe-to-run"
+
+[[exemptions.serde-untagged]]
+version = "0.1.9"
+criteria = "safe-to-run"
+
+[[exemptions.serde-value]]
+version = "0.7.0"
+criteria = "safe-to-run"
+
+[[exemptions.serde_bytes]]
+version = "0.11.19"
+criteria = "safe-to-run"
+
+[[exemptions.serde_core]]
+version = "1.0.226"
+criteria = "safe-to-run"
+
+[[exemptions.serde_derive]]
+version = "1.0.226"
+criteria = "safe-to-run"
+
+[[exemptions.serde_json]]
+version = "1.0.145"
+criteria = "safe-to-run"
+
+[[exemptions.serde_repr]]
+version = "0.1.20"
+criteria = "safe-to-run"
+
+[[exemptions.serde_spanned]]
+version = "0.6.9"
+criteria = "safe-to-run"
+
+[[exemptions.serde_spanned]]
+version = "1.0.2"
+criteria = "safe-to-run"
+
+[[exemptions.serial_test]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.serial_test_derive]]
+version = "1.0.0"
+criteria = "safe-to-run"
+
+[[exemptions.sha-1]]
+version = "0.10.1"
+criteria = "safe-to-run"
+
+[[exemptions.sha2]]
+version = "0.10.9"
+criteria = "safe-to-run"
+
+[[exemptions.sharded-slab]]
+version = "0.1.7"
+criteria = "safe-to-run"
+
+[[exemptions.shell-words]]
+version = "1.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.shlex]]
+version = "1.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.signal-hook]]
+version = "0.3.18"
+criteria = "safe-to-run"
+
+[[exemptions.signal-hook-registry]]
+version = "1.4.6"
+criteria = "safe-to-run"
+
+[[exemptions.signature]]
+version = "2.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.slab]]
+version = "0.4.11"
+criteria = "safe-to-run"
+
+[[exemptions.smallvec]]
+version = "1.15.1"
+criteria = "safe-to-run"
+
+[[exemptions.spdx]]
+version = "0.10.9"
+criteria = "safe-to-run"
+
+[[exemptions.spi-memory]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.spin]]
+version = "0.9.8"
+criteria = "safe-to-run"
+
+[[exemptions.spki]]
+version = "0.7.3"
+criteria = "safe-to-run"
+
+[[exemptions.stable_deref_trait]]
+version = "1.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.strsim]]
+version = "0.11.1"
+criteria = "safe-to-run"
+
+[[exemptions.strum_macros]]
+version = "0.25.3"
+criteria = "safe-to-run"
+
+[[exemptions.subtle]]
+version = "2.6.1"
+criteria = "safe-to-run"
+
+[[exemptions.svgbobdoc]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.syn]]
+version = "1.0.109"
+criteria = "safe-to-run"
+
+[[exemptions.syn]]
+version = "2.0.106"
+criteria = "safe-to-run"
+
+[[exemptions.synstructure]]
+version = "0.13.2"
+criteria = "safe-to-run"
+
+[[exemptions.systick-monotonic]]
+version = "1.0.1"
+criteria = "safe-to-run"
+
+[[exemptions.termcolor]]
+version = "1.4.1"
+criteria = "safe-to-run"
+
+[[exemptions.thiserror]]
+version = "1.0.69"
+criteria = "safe-to-run"
+
+[[exemptions.thiserror]]
+version = "2.0.16"
+criteria = "safe-to-run"
+
+[[exemptions.thiserror-impl]]
+version = "1.0.69"
+criteria = "safe-to-run"
+
+[[exemptions.thiserror-impl]]
+version = "2.0.16"
+criteria = "safe-to-run"
+
+[[exemptions.thread_local]]
+version = "1.1.9"
+criteria = "safe-to-run"
+
+[[exemptions.tinystr]]
+version = "0.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.toml]]
+version = "0.8.23"
+criteria = "safe-to-run"
+
+[[exemptions.toml]]
+version = "0.9.7"
+criteria = "safe-to-run"
+
+[[exemptions.toml_datetime]]
+version = "0.6.11"
+criteria = "safe-to-run"
+
+[[exemptions.toml_datetime]]
+version = "0.7.2"
+criteria = "safe-to-run"
+
+[[exemptions.toml_edit]]
+version = "0.22.27"
+criteria = "safe-to-run"
+
+[[exemptions.toml_parser]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.toml_write]]
+version = "0.1.2"
+criteria = "safe-to-run"
+
+[[exemptions.toml_writer]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.tracing]]
+version = "0.1.41"
+criteria = "safe-to-run"
+
+[[exemptions.tracing-attributes]]
+version = "0.1.30"
+criteria = "safe-to-run"
+
+[[exemptions.tracing-core]]
+version = "0.1.34"
+criteria = "safe-to-run"
+
+[[exemptions.tracing-log]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.tracing-subscriber]]
+version = "0.3.20"
+criteria = "safe-to-run"
+
+[[exemptions.trussed]]
+version = "0.2.0-rc.1"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-auth]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-auth-backend]]
+version = "0.2.0-rc.1"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-chunked]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-core]]
+version = "0.2.2"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-fs-info]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-hkdf]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-hpke]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-manage]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-rsa-alloc]]
+version = "0.5.0-rc.1"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-rsa-types]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-se050-backend]]
+version = "0.8.0-rc.1"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-se050-manage]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-staging]]
+version = "0.5.0-rc.1"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-usbip]]
+version = "0.1.0-rc.1"
+criteria = "safe-to-run"
+
+[[exemptions.trussed-wrap-key-to-file]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.typed-builder]]
+version = "0.23.2"
+criteria = "safe-to-run"
+
+[[exemptions.typed-builder-macro]]
+version = "0.23.2"
+criteria = "safe-to-run"
+
+[[exemptions.typeid]]
+version = "1.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.typenum]]
+version = "1.18.0"
+criteria = "safe-to-run"
+
+[[exemptions.ufmt-write]]
+version = "0.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.unicode-ident]]
+version = "1.0.19"
+criteria = "safe-to-run"
+
+[[exemptions.unicode-width]]
+version = "0.1.14"
+criteria = "safe-to-run"
+
+[[exemptions.unicode-width]]
+version = "0.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.unicode-xid]]
+version = "0.2.6"
+criteria = "safe-to-run"
+
+[[exemptions.universal-hash]]
+version = "0.5.1"
+criteria = "safe-to-run"
+
+[[exemptions.untrusted]]
+version = "0.9.0"
+criteria = "safe-to-run"
+
+[[exemptions.url]]
+version = "2.5.7"
+criteria = "safe-to-run"
+
+[[exemptions.usb-device]]
+version = "0.2.9"
+criteria = "safe-to-run"
+
+[[exemptions.usbd-ccid]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.usbd-ctaphid]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.usbip-device]]
+version = "0.1.5"
+criteria = "safe-to-run"
+
+[[exemptions.utf8_iter]]
+version = "1.0.4"
+criteria = "safe-to-run"
+
+[[exemptions.utf8parse]]
+version = "0.2.2"
+criteria = "safe-to-run"
+
+[[exemptions.valuable]]
+version = "0.1.1"
+criteria = "safe-to-run"
+
+[[exemptions.vcell]]
+version = "0.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.version_check]]
+version = "0.9.5"
+criteria = "safe-to-run"
+
+[[exemptions.void]]
+version = "1.0.2"
+criteria = "safe-to-run"
+
+[[exemptions.volatile-register]]
+version = "0.2.2"
+criteria = "safe-to-run"
+
+[[exemptions.wasi]]
+version = "0.11.1+wasi-snapshot-preview1"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen]]
+version = "0.2.104"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-backend]]
+version = "0.2.104"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.104"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.104"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.104"
+criteria = "safe-to-run"
+
+[[exemptions.winapi-util]]
+version = "0.1.11"
+criteria = "safe-to-run"
+
+[[exemptions.windows]]
+version = "0.48.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-core]]
+version = "0.62.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-implement]]
+version = "0.60.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-interface]]
+version = "0.59.1"
+criteria = "safe-to-run"
+
+[[exemptions.windows-link]]
+version = "0.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.windows-link]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-result]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-strings]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-sys]]
+version = "0.52.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-sys]]
+version = "0.59.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-sys]]
+version = "0.60.2"
+criteria = "safe-to-run"
+
+[[exemptions.windows-sys]]
+version = "0.61.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows-targets]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows-targets]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows-targets]]
+version = "0.53.3"
+criteria = "safe-to-run"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_gnullvm]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.48.5"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.52.6"
+criteria = "safe-to-run"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.53.0"
+criteria = "safe-to-run"
+
+[[exemptions.winnow]]
+version = "0.7.13"
+criteria = "safe-to-run"
+
+[[exemptions.writeable]]
+version = "0.6.1"
+criteria = "safe-to-run"
+
+[[exemptions.yoke]]
+version = "0.8.0"
+criteria = "safe-to-run"
+
+[[exemptions.yoke-derive]]
+version = "0.8.0"
+criteria = "safe-to-run"
+
+[[exemptions.zerocopy]]
+version = "0.8.27"
+criteria = "safe-to-run"
+
+[[exemptions.zerocopy-derive]]
+version = "0.8.27"
+criteria = "safe-to-run"
+
+[[exemptions.zerofrom]]
+version = "0.1.6"
+criteria = "safe-to-run"
+
+[[exemptions.zerofrom-derive]]
+version = "0.1.6"
+criteria = "safe-to-run"
+
+[[exemptions.zeroize]]
+version = "1.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.zeroize_derive]]
+version = "1.4.2"
+criteria = "safe-to-run"
+
+[[exemptions.zerotrie]]
+version = "0.2.2"
+criteria = "safe-to-run"
+
+[[exemptions.zerovec]]
+version = "0.11.4"
+criteria = "safe-to-run"
+
+[[exemptions.zerovec-derive]]
+version = "0.11.1"
+criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -80,14 +80,6 @@ criteria = "safe-to-run"
 version = "1.0.100"
 criteria = "safe-to-run"
 
-[[exemptions.apdu-app]]
-version = "0.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.apdu-dispatch]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
 [[exemptions.askama]]
 version = "0.14.0"
 criteria = "safe-to-run"
@@ -212,10 +204,6 @@ criteria = "safe-to-run"
 version = "0.1.2"
 criteria = "safe-to-run"
 
-[[exemptions.cbor-smol]]
-version = "0.5.1"
-criteria = "safe-to-run"
-
 [[exemptions.cc]]
 version = "1.2.38"
 criteria = "safe-to-run"
@@ -320,10 +308,6 @@ criteria = "safe-to-run"
 version = "0.3.7"
 criteria = "safe-to-run"
 
-[[exemptions.cosey]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
 [[exemptions.cpufeatures]]
 version = "0.2.17"
 criteria = "safe-to-run"
@@ -356,18 +340,6 @@ criteria = "safe-to-run"
 version = "0.1.12"
 criteria = "safe-to-run"
 
-[[exemptions.ctap-types]]
-version = "0.6.0-rc.4"
-criteria = "safe-to-run"
-
-[[exemptions.ctaphid-app]]
-version = "0.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.ctaphid-dispatch]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
 [[exemptions.ctr]]
 version = "0.9.2"
 criteria = "safe-to-run"
@@ -382,10 +354,6 @@ criteria = "safe-to-run"
 
 [[exemptions.dbl]]
 version = "0.3.2"
-criteria = "safe-to-run"
-
-[[exemptions.delog]]
-version = "0.1.8"
 criteria = "safe-to-run"
 
 [[exemptions.der]]
@@ -472,24 +440,12 @@ criteria = "safe-to-run"
 version = "0.13.1"
 criteria = "safe-to-run"
 
-[[exemptions.fido-authenticator]]
-version = "0.4.0-rc.3"
-criteria = "safe-to-run"
-
 [[exemptions.find-msvc-tools]]
 version = "0.1.2"
 criteria = "safe-to-run"
 
 [[exemptions.fixed]]
 version = "1.29.0"
-criteria = "safe-to-run"
-
-[[exemptions.flexiber]]
-version = "0.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.flexiber_derive]]
-version = "0.1.3"
 criteria = "safe-to-run"
 
 [[exemptions.form_urlencoded]]
@@ -608,10 +564,6 @@ criteria = "safe-to-run"
 version = "0.9.1"
 criteria = "safe-to-run"
 
-[[exemptions.heapless-bytes]]
-version = "0.5.0"
-criteria = "safe-to-run"
-
 [[exemptions.heck]]
 version = "0.4.1"
 criteria = "safe-to-run"
@@ -708,20 +660,12 @@ criteria = "safe-to-run"
 version = "0.1.4"
 criteria = "safe-to-run"
 
-[[exemptions.interchange]]
-version = "0.3.2"
-criteria = "safe-to-run"
-
 [[exemptions.is-terminal]]
 version = "0.4.16"
 criteria = "safe-to-run"
 
 [[exemptions.is_terminal_polyfill]]
 version = "1.70.1"
-criteria = "safe-to-run"
-
-[[exemptions.iso7816]]
-version = "0.2.0"
 criteria = "safe-to-run"
 
 [[exemptions.itertools]]
@@ -764,18 +708,6 @@ criteria = "safe-to-run"
 version = "0.8.0"
 criteria = "safe-to-run"
 
-[[exemptions.littlefs2]]
-version = "0.7.0"
-criteria = "safe-to-run"
-
-[[exemptions.littlefs2-core]]
-version = "0.1.2"
-criteria = "safe-to-run"
-
-[[exemptions.littlefs2-sys]]
-version = "0.3.2"
-criteria = "safe-to-run"
-
 [[exemptions.lock_api]]
 version = "0.4.13"
 criteria = "safe-to-run"
@@ -786,10 +718,6 @@ criteria = "safe-to-run"
 
 [[exemptions.loom]]
 version = "0.5.6"
-criteria = "safe-to-run"
-
-[[exemptions.lpc55-hal]]
-version = "0.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.lpc55-pac]]
@@ -1072,10 +1000,6 @@ criteria = "safe-to-run"
 version = "1.2.0"
 criteria = "safe-to-run"
 
-[[exemptions.se05x]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
 [[exemptions.sec1]]
 version = "0.7.3"
 criteria = "safe-to-run"
@@ -1098,10 +1022,6 @@ criteria = "safe-to-run"
 
 [[exemptions.serde-byte-array]]
 version = "0.1.2"
-criteria = "safe-to-run"
-
-[[exemptions.serde-indexed]]
-version = "0.1.1"
 criteria = "safe-to-run"
 
 [[exemptions.serde-untagged]]
@@ -1320,68 +1240,8 @@ criteria = "safe-to-run"
 version = "0.3.20"
 criteria = "safe-to-run"
 
-[[exemptions.trussed]]
-version = "0.2.0-rc.1"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-auth]]
-version = "0.5.0"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-auth-backend]]
-version = "0.2.0-rc.1"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-chunked]]
-version = "0.3.0"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-core]]
-version = "0.2.2"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-fs-info]]
-version = "0.3.0"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-hkdf]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-hpke]]
-version = "0.3.0"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-manage]]
-version = "0.3.0"
-criteria = "safe-to-run"
-
 [[exemptions.trussed-rsa-alloc]]
 version = "0.5.0-rc.1"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-rsa-types]]
-version = "0.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-se050-backend]]
-version = "0.8.0-rc.1"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-se050-manage]]
-version = "0.3.0"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-staging]]
-version = "0.5.0-rc.1"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-usbip]]
-version = "0.1.0-rc.1"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-wrap-key-to-file]]
-version = "0.3.0"
 criteria = "safe-to-run"
 
 [[exemptions.typed-builder]]
@@ -1434,14 +1294,6 @@ criteria = "safe-to-run"
 
 [[exemptions.usb-device]]
 version = "0.2.9"
-criteria = "safe-to-run"
-
-[[exemptions.usbd-ccid]]
-version = "0.4.0"
-criteria = "safe-to-run"
-
-[[exemptions.usbd-ctaphid]]
-version = "0.4.0"
 criteria = "safe-to-run"
 
 [[exemptions.usbip-device]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -4,6 +4,15 @@
 [cargo-vet]
 version = "0.10"
 
+[imports.bytecode-alliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[imports.google]
+url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
+
+[imports.mozilla]
+url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
+
 [policy.admin-app]
 audit-as-crates-io = false
 notes = "pinned to a reviewed revision"
@@ -48,14 +57,6 @@ criteria = "safe-to-run"
 version = "0.10.3"
 criteria = "safe-to-run"
 
-[[exemptions.aho-corasick]]
-version = "1.1.3"
-criteria = "safe-to-run"
-
-[[exemptions.android_system_properties]]
-version = "0.1.5"
-criteria = "safe-to-run"
-
 [[exemptions.anstream]]
 version = "0.6.20"
 criteria = "safe-to-run"
@@ -80,22 +81,6 @@ criteria = "safe-to-run"
 version = "1.0.100"
 criteria = "safe-to-run"
 
-[[exemptions.askama]]
-version = "0.14.0"
-criteria = "safe-to-run"
-
-[[exemptions.askama_derive]]
-version = "0.14.0"
-criteria = "safe-to-run"
-
-[[exemptions.askama_parser]]
-version = "0.14.0"
-criteria = "safe-to-run"
-
-[[exemptions.atomic-polyfill]]
-version = "1.0.3"
-criteria = "safe-to-run"
-
 [[exemptions.autocfg]]
 version = "1.5.0"
 criteria = "safe-to-run"
@@ -104,20 +89,8 @@ criteria = "safe-to-run"
 version = "1.2.1"
 criteria = "safe-to-run"
 
-[[exemptions.bare-metal]]
-version = "0.2.5"
-criteria = "safe-to-run"
-
-[[exemptions.bare-metal]]
-version = "1.0.0"
-criteria = "safe-to-run"
-
 [[exemptions.base16ct]]
 version = "0.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.base64]]
-version = "0.13.1"
 criteria = "safe-to-run"
 
 [[exemptions.base64ct]]
@@ -128,40 +101,12 @@ criteria = "safe-to-run"
 version = "0.1.10"
 criteria = "safe-to-run"
 
-[[exemptions.bindgen]]
-version = "0.70.1"
-criteria = "safe-to-run"
-
-[[exemptions.bitfield]]
-version = "0.13.2"
-criteria = "safe-to-run"
-
-[[exemptions.bitflags]]
-version = "1.3.2"
-criteria = "safe-to-run"
-
-[[exemptions.bitflags]]
-version = "2.9.4"
-criteria = "safe-to-run"
-
-[[exemptions.block-buffer]]
-version = "0.10.4"
-criteria = "safe-to-run"
-
 [[exemptions.block-padding]]
 version = "0.3.3"
 criteria = "safe-to-run"
 
-[[exemptions.bumpalo]]
-version = "3.19.0"
-criteria = "safe-to-run"
-
 [[exemptions.bytemuck]]
 version = "1.23.2"
-criteria = "safe-to-run"
-
-[[exemptions.byteorder]]
-version = "1.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.camino]]
@@ -196,20 +141,12 @@ criteria = "safe-to-run"
 version = "0.21.0"
 criteria = "safe-to-run"
 
-[[exemptions.cast]]
-version = "0.3.0"
-criteria = "safe-to-run"
-
 [[exemptions.cbc]]
 version = "0.1.2"
 criteria = "safe-to-run"
 
 [[exemptions.cc]]
 version = "1.2.38"
-criteria = "safe-to-run"
-
-[[exemptions.cexpr]]
-version = "0.6.0"
 criteria = "safe-to-run"
 
 [[exemptions.cfg-if]]
@@ -226,10 +163,6 @@ criteria = "safe-to-run"
 
 [[exemptions.chrono]]
 version = "0.4.42"
-criteria = "safe-to-run"
-
-[[exemptions.cipher]]
-version = "0.4.4"
 criteria = "safe-to-run"
 
 [[exemptions.clang-sys]]
@@ -260,10 +193,6 @@ criteria = "safe-to-run"
 version = "0.7.2"
 criteria = "safe-to-run"
 
-[[exemptions.cobs]]
-version = "0.3.0"
-criteria = "safe-to-run"
-
 [[exemptions.colorchoice]]
 version = "1.0.4"
 criteria = "safe-to-run"
@@ -280,28 +209,12 @@ criteria = "safe-to-run"
 version = "0.9.6"
 criteria = "safe-to-run"
 
-[[exemptions.core-foundation-sys]]
-version = "0.8.7"
-criteria = "safe-to-run"
-
-[[exemptions.cortex-m]]
-version = "0.7.7"
-criteria = "safe-to-run"
-
 [[exemptions.cortex-m-rt]]
 version = "0.7.5"
 criteria = "safe-to-run"
 
 [[exemptions.cortex-m-rt-macros]]
 version = "0.7.5"
-criteria = "safe-to-run"
-
-[[exemptions.cortex-m-rtic]]
-version = "1.1.4"
-criteria = "safe-to-run"
-
-[[exemptions.cortex-m-rtic-macros]]
-version = "1.1.6"
 criteria = "safe-to-run"
 
 [[exemptions.cortex-m-semihosting]]
@@ -316,20 +229,12 @@ criteria = "safe-to-run"
 version = "0.4.0"
 criteria = "safe-to-run"
 
-[[exemptions.critical-section]]
-version = "1.2.0"
-criteria = "safe-to-run"
-
 [[exemptions.crunchy]]
 version = "0.2.4"
 criteria = "safe-to-run"
 
 [[exemptions.crypto-bigint]]
 version = "0.5.5"
-criteria = "safe-to-run"
-
-[[exemptions.crypto-common]]
-version = "0.1.6"
 criteria = "safe-to-run"
 
 [[exemptions.csv]]
@@ -344,20 +249,12 @@ criteria = "safe-to-run"
 version = "0.9.2"
 criteria = "safe-to-run"
 
-[[exemptions.cty]]
-version = "0.2.2"
-criteria = "safe-to-run"
-
 [[exemptions.dashmap]]
 version = "5.5.3"
 criteria = "safe-to-run"
 
 [[exemptions.dbl]]
 version = "0.3.2"
-criteria = "safe-to-run"
-
-[[exemptions.der]]
-version = "0.7.10"
 criteria = "safe-to-run"
 
 [[exemptions.der_derive]]
@@ -376,20 +273,12 @@ criteria = "safe-to-run"
 version = "0.10.7"
 criteria = "safe-to-run"
 
-[[exemptions.displaydoc]]
-version = "0.2.5"
-criteria = "safe-to-run"
-
 [[exemptions.ecdsa]]
 version = "0.16.9"
 criteria = "safe-to-run"
 
 [[exemptions.ed25519]]
 version = "2.2.3"
-criteria = "safe-to-run"
-
-[[exemptions.either]]
-version = "1.15.0"
 criteria = "safe-to-run"
 
 [[exemptions.elliptic-curve]]
@@ -421,15 +310,7 @@ version = "1.0.0"
 criteria = "safe-to-run"
 
 [[exemptions.env_logger]]
-version = "0.8.4"
-criteria = "safe-to-run"
-
-[[exemptions.env_logger]]
 version = "0.10.2"
-criteria = "safe-to-run"
-
-[[exemptions.equivalent]]
-version = "1.0.2"
 criteria = "safe-to-run"
 
 [[exemptions.erased-serde]]
@@ -448,44 +329,8 @@ criteria = "safe-to-run"
 version = "1.29.0"
 criteria = "safe-to-run"
 
-[[exemptions.form_urlencoded]]
-version = "1.2.2"
-criteria = "safe-to-run"
-
 [[exemptions.fugit]]
 version = "0.3.7"
-criteria = "safe-to-run"
-
-[[exemptions.futures]]
-version = "0.3.31"
-criteria = "safe-to-run"
-
-[[exemptions.futures-channel]]
-version = "0.3.31"
-criteria = "safe-to-run"
-
-[[exemptions.futures-core]]
-version = "0.3.31"
-criteria = "safe-to-run"
-
-[[exemptions.futures-executor]]
-version = "0.3.31"
-criteria = "safe-to-run"
-
-[[exemptions.futures-io]]
-version = "0.3.31"
-criteria = "safe-to-run"
-
-[[exemptions.futures-sink]]
-version = "0.3.31"
-criteria = "safe-to-run"
-
-[[exemptions.futures-task]]
-version = "0.3.31"
-criteria = "safe-to-run"
-
-[[exemptions.futures-util]]
-version = "0.3.31"
 criteria = "safe-to-run"
 
 [[exemptions.gcd]]
@@ -494,10 +339,6 @@ criteria = "safe-to-run"
 
 [[exemptions.generator]]
 version = "0.7.5"
-criteria = "safe-to-run"
-
-[[exemptions.generic-array]]
-version = "0.14.7"
 criteria = "safe-to-run"
 
 [[exemptions.generic-array]]
@@ -545,47 +386,19 @@ version = "0.3.1"
 criteria = "safe-to-run"
 
 [[exemptions.hashbrown]]
-version = "0.12.3"
-criteria = "safe-to-run"
-
-[[exemptions.hashbrown]]
 version = "0.14.5"
-criteria = "safe-to-run"
-
-[[exemptions.hashbrown]]
-version = "0.16.0"
-criteria = "safe-to-run"
-
-[[exemptions.heapless]]
-version = "0.7.17"
 criteria = "safe-to-run"
 
 [[exemptions.heapless]]
 version = "0.9.1"
 criteria = "safe-to-run"
 
-[[exemptions.heck]]
-version = "0.4.1"
-criteria = "safe-to-run"
-
-[[exemptions.heck]]
-version = "0.5.0"
-criteria = "safe-to-run"
-
 [[exemptions.hermit-abi]]
 version = "0.5.2"
 criteria = "safe-to-run"
 
-[[exemptions.hex]]
-version = "0.4.3"
-criteria = "safe-to-run"
-
 [[exemptions.hex-literal]]
 version = "0.3.4"
-criteria = "safe-to-run"
-
-[[exemptions.hex-literal]]
-version = "0.4.1"
 criteria = "safe-to-run"
 
 [[exemptions.hkdf]]
@@ -600,60 +413,8 @@ criteria = "safe-to-run"
 version = "2.3.0"
 criteria = "safe-to-run"
 
-[[exemptions.iana-time-zone]]
-version = "0.1.64"
-criteria = "safe-to-run"
-
-[[exemptions.iana-time-zone-haiku]]
-version = "0.1.2"
-criteria = "safe-to-run"
-
-[[exemptions.icu_collections]]
-version = "2.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.icu_locale_core]]
-version = "2.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.icu_normalizer]]
-version = "2.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.icu_normalizer_data]]
-version = "2.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.icu_properties]]
-version = "2.0.1"
-criteria = "safe-to-run"
-
-[[exemptions.icu_properties_data]]
-version = "2.0.1"
-criteria = "safe-to-run"
-
-[[exemptions.icu_provider]]
-version = "2.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.idna]]
-version = "1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.idna_adapter]]
-version = "1.2.1"
-criteria = "safe-to-run"
-
 [[exemptions.if_chain]]
 version = "1.0.3"
-criteria = "safe-to-run"
-
-[[exemptions.indexmap]]
-version = "1.9.3"
-criteria = "safe-to-run"
-
-[[exemptions.indexmap]]
-version = "2.11.4"
 criteria = "safe-to-run"
 
 [[exemptions.inout]]
@@ -672,24 +433,8 @@ criteria = "safe-to-run"
 version = "0.13.0"
 criteria = "safe-to-run"
 
-[[exemptions.itertools]]
-version = "0.14.0"
-criteria = "safe-to-run"
-
-[[exemptions.itoa]]
-version = "1.0.15"
-criteria = "safe-to-run"
-
 [[exemptions.js-sys]]
 version = "0.3.81"
-criteria = "safe-to-run"
-
-[[exemptions.lazy_static]]
-version = "1.5.0"
-criteria = "safe-to-run"
-
-[[exemptions.libc]]
-version = "0.2.176"
 criteria = "safe-to-run"
 
 [[exemptions.libloading]]
@@ -704,16 +449,8 @@ criteria = "safe-to-run"
 version = "0.10.5"
 criteria = "safe-to-run"
 
-[[exemptions.litemap]]
-version = "0.8.0"
-criteria = "safe-to-run"
-
 [[exemptions.lock_api]]
 version = "0.4.13"
-criteria = "safe-to-run"
-
-[[exemptions.log]]
-version = "0.4.28"
 criteria = "safe-to-run"
 
 [[exemptions.loom]]
@@ -724,28 +461,12 @@ criteria = "safe-to-run"
 version = "0.5.0"
 criteria = "safe-to-run"
 
-[[exemptions.matchers]]
-version = "0.2.0"
-criteria = "safe-to-run"
-
 [[exemptions.memchr]]
 version = "2.7.5"
 criteria = "safe-to-run"
 
 [[exemptions.minimal-lexical]]
 version = "0.2.1"
-criteria = "safe-to-run"
-
-[[exemptions.nb]]
-version = "0.1.3"
-criteria = "safe-to-run"
-
-[[exemptions.nb]]
-version = "1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.nom]]
-version = "7.1.3"
 criteria = "safe-to-run"
 
 [[exemptions.nrf-hal-common]]
@@ -764,10 +485,6 @@ criteria = "safe-to-run"
 version = "0.11.0"
 criteria = "safe-to-run"
 
-[[exemptions.nu-ansi-term]]
-version = "0.50.1"
-criteria = "safe-to-run"
-
 [[exemptions.num]]
 version = "0.3.1"
 criteria = "safe-to-run"
@@ -780,20 +497,12 @@ criteria = "safe-to-run"
 version = "0.3.1"
 criteria = "safe-to-run"
 
-[[exemptions.num-integer]]
-version = "0.1.46"
-criteria = "safe-to-run"
-
 [[exemptions.num-iter]]
 version = "0.1.45"
 criteria = "safe-to-run"
 
 [[exemptions.num-rational]]
 version = "0.3.2"
-criteria = "safe-to-run"
-
-[[exemptions.num-traits]]
-version = "0.2.19"
 criteria = "safe-to-run"
 
 [[exemptions.once_cell]]
@@ -828,18 +537,6 @@ criteria = "safe-to-run"
 version = "0.9.11"
 criteria = "safe-to-run"
 
-[[exemptions.percent-encoding]]
-version = "2.3.2"
-criteria = "safe-to-run"
-
-[[exemptions.pin-project-lite]]
-version = "0.2.16"
-criteria = "safe-to-run"
-
-[[exemptions.pin-utils]]
-version = "0.1.0"
-criteria = "safe-to-run"
-
 [[exemptions.pkcs1]]
 version = "0.7.5"
 criteria = "safe-to-run"
@@ -860,20 +557,12 @@ criteria = "safe-to-run"
 version = "0.7.3"
 criteria = "safe-to-run"
 
-[[exemptions.postcard]]
-version = "1.1.3"
-criteria = "safe-to-run"
-
 [[exemptions.postcard-cobs]]
 version = "0.1.5-pre"
 criteria = "safe-to-run"
 
 [[exemptions.potential_utf]]
 version = "0.1.3"
-criteria = "safe-to-run"
-
-[[exemptions.ppv-lite86]]
-version = "0.2.21"
 criteria = "safe-to-run"
 
 [[exemptions.pretty_env_logger]]
@@ -884,36 +573,12 @@ criteria = "safe-to-run"
 version = "0.13.6"
 criteria = "safe-to-run"
 
-[[exemptions.proc-macro-error]]
-version = "1.0.4"
-criteria = "safe-to-run"
-
-[[exemptions.proc-macro-error-attr]]
-version = "1.0.4"
-criteria = "safe-to-run"
-
 [[exemptions.proc-macro2]]
 version = "1.0.101"
 criteria = "safe-to-run"
 
 [[exemptions.quickcheck]]
 version = "1.0.3"
-criteria = "safe-to-run"
-
-[[exemptions.quote]]
-version = "1.0.40"
-criteria = "safe-to-run"
-
-[[exemptions.rand]]
-version = "0.8.6"
-criteria = "safe-to-run"
-
-[[exemptions.rand_chacha]]
-version = "0.3.1"
-criteria = "safe-to-run"
-
-[[exemptions.rand_core]]
-version = "0.6.4"
 criteria = "safe-to-run"
 
 [[exemptions.redox_syscall]]
@@ -948,38 +613,6 @@ criteria = "safe-to-run"
 version = "0.9.10"
 criteria = "safe-to-run"
 
-[[exemptions.rtic-core]]
-version = "1.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.rtic-monotonic]]
-version = "1.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.rtic-syntax]]
-version = "1.0.3"
-criteria = "safe-to-run"
-
-[[exemptions.rtt-target]]
-version = "0.3.1"
-criteria = "safe-to-run"
-
-[[exemptions.rustc-hash]]
-version = "1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.rustc-hash]]
-version = "2.1.1"
-criteria = "safe-to-run"
-
-[[exemptions.rustc_version]]
-version = "0.2.3"
-criteria = "safe-to-run"
-
-[[exemptions.rustc_version]]
-version = "0.4.1"
-criteria = "safe-to-run"
-
 [[exemptions.rustversion]]
 version = "1.0.22"
 criteria = "safe-to-run"
@@ -992,10 +625,6 @@ criteria = "safe-to-run"
 version = "0.3.0"
 criteria = "safe-to-run"
 
-[[exemptions.scoped-tls]]
-version = "1.0.1"
-criteria = "safe-to-run"
-
 [[exemptions.scopeguard]]
 version = "1.2.0"
 criteria = "safe-to-run"
@@ -1005,15 +634,7 @@ version = "0.7.3"
 criteria = "safe-to-run"
 
 [[exemptions.semver]]
-version = "0.9.0"
-criteria = "safe-to-run"
-
-[[exemptions.semver]]
 version = "1.0.27"
-criteria = "safe-to-run"
-
-[[exemptions.semver-parser]]
-version = "0.7.0"
 criteria = "safe-to-run"
 
 [[exemptions.serde]]
@@ -1026,10 +647,6 @@ criteria = "safe-to-run"
 
 [[exemptions.serde-untagged]]
 version = "0.1.9"
-criteria = "safe-to-run"
-
-[[exemptions.serde-value]]
-version = "0.7.0"
 criteria = "safe-to-run"
 
 [[exemptions.serde_bytes]]
@@ -1076,18 +693,6 @@ criteria = "safe-to-run"
 version = "0.10.9"
 criteria = "safe-to-run"
 
-[[exemptions.sharded-slab]]
-version = "0.1.7"
-criteria = "safe-to-run"
-
-[[exemptions.shell-words]]
-version = "1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.shlex]]
-version = "1.3.0"
-criteria = "safe-to-run"
-
 [[exemptions.signal-hook]]
 version = "0.3.18"
 criteria = "safe-to-run"
@@ -1104,10 +709,6 @@ criteria = "safe-to-run"
 version = "0.4.11"
 criteria = "safe-to-run"
 
-[[exemptions.smallvec]]
-version = "1.15.1"
-criteria = "safe-to-run"
-
 [[exemptions.spdx]]
 version = "0.10.9"
 criteria = "safe-to-run"
@@ -1116,24 +717,8 @@ criteria = "safe-to-run"
 version = "0.2.0"
 criteria = "safe-to-run"
 
-[[exemptions.spin]]
-version = "0.9.8"
-criteria = "safe-to-run"
-
 [[exemptions.spki]]
 version = "0.7.3"
-criteria = "safe-to-run"
-
-[[exemptions.stable_deref_trait]]
-version = "1.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.strsim]]
-version = "0.11.1"
-criteria = "safe-to-run"
-
-[[exemptions.strum_macros]]
-version = "0.25.3"
 criteria = "safe-to-run"
 
 [[exemptions.subtle]]
@@ -1145,23 +730,11 @@ version = "0.3.0"
 criteria = "safe-to-run"
 
 [[exemptions.syn]]
-version = "1.0.109"
-criteria = "safe-to-run"
-
-[[exemptions.syn]]
 version = "2.0.106"
-criteria = "safe-to-run"
-
-[[exemptions.synstructure]]
-version = "0.13.2"
 criteria = "safe-to-run"
 
 [[exemptions.systick-monotonic]]
 version = "1.0.1"
-criteria = "safe-to-run"
-
-[[exemptions.termcolor]]
-version = "1.4.1"
 criteria = "safe-to-run"
 
 [[exemptions.thiserror]]
@@ -1182,10 +755,6 @@ criteria = "safe-to-run"
 
 [[exemptions.thread_local]]
 version = "1.1.9"
-criteria = "safe-to-run"
-
-[[exemptions.tinystr]]
-version = "0.8.1"
 criteria = "safe-to-run"
 
 [[exemptions.toml]]
@@ -1220,26 +789,6 @@ criteria = "safe-to-run"
 version = "1.0.3"
 criteria = "safe-to-run"
 
-[[exemptions.tracing]]
-version = "0.1.41"
-criteria = "safe-to-run"
-
-[[exemptions.tracing-attributes]]
-version = "0.1.30"
-criteria = "safe-to-run"
-
-[[exemptions.tracing-core]]
-version = "0.1.34"
-criteria = "safe-to-run"
-
-[[exemptions.tracing-log]]
-version = "0.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.tracing-subscriber]]
-version = "0.3.20"
-criteria = "safe-to-run"
-
 [[exemptions.trussed-rsa-alloc]]
 version = "0.5.0-rc.1"
 criteria = "safe-to-run"
@@ -1260,24 +809,8 @@ criteria = "safe-to-run"
 version = "1.18.0"
 criteria = "safe-to-run"
 
-[[exemptions.ufmt-write]]
-version = "0.1.0"
-criteria = "safe-to-run"
-
 [[exemptions.unicode-ident]]
 version = "1.0.19"
-criteria = "safe-to-run"
-
-[[exemptions.unicode-width]]
-version = "0.1.14"
-criteria = "safe-to-run"
-
-[[exemptions.unicode-width]]
-version = "0.2.1"
-criteria = "safe-to-run"
-
-[[exemptions.unicode-xid]]
-version = "0.2.6"
 criteria = "safe-to-run"
 
 [[exemptions.universal-hash]]
@@ -1288,10 +821,6 @@ criteria = "safe-to-run"
 version = "0.9.0"
 criteria = "safe-to-run"
 
-[[exemptions.url]]
-version = "2.5.7"
-criteria = "safe-to-run"
-
 [[exemptions.usb-device]]
 version = "0.2.9"
 criteria = "safe-to-run"
@@ -1300,28 +829,12 @@ criteria = "safe-to-run"
 version = "0.1.5"
 criteria = "safe-to-run"
 
-[[exemptions.utf8_iter]]
-version = "1.0.4"
-criteria = "safe-to-run"
-
-[[exemptions.utf8parse]]
-version = "0.2.2"
-criteria = "safe-to-run"
-
 [[exemptions.valuable]]
 version = "0.1.1"
 criteria = "safe-to-run"
 
-[[exemptions.vcell]]
-version = "0.1.3"
-criteria = "safe-to-run"
-
 [[exemptions.version_check]]
 version = "0.9.5"
-criteria = "safe-to-run"
-
-[[exemptions.void]]
-version = "1.0.2"
 criteria = "safe-to-run"
 
 [[exemptions.volatile-register]]
@@ -1374,10 +887,6 @@ criteria = "safe-to-run"
 
 [[exemptions.windows-link]]
 version = "0.1.3"
-criteria = "safe-to-run"
-
-[[exemptions.windows-link]]
-version = "0.2.0"
 criteria = "safe-to-run"
 
 [[exemptions.windows-result]]
@@ -1510,52 +1019,4 @@ criteria = "safe-to-run"
 
 [[exemptions.winnow]]
 version = "0.7.13"
-criteria = "safe-to-run"
-
-[[exemptions.writeable]]
-version = "0.6.1"
-criteria = "safe-to-run"
-
-[[exemptions.yoke]]
-version = "0.8.0"
-criteria = "safe-to-run"
-
-[[exemptions.yoke-derive]]
-version = "0.8.0"
-criteria = "safe-to-run"
-
-[[exemptions.zerocopy]]
-version = "0.8.27"
-criteria = "safe-to-run"
-
-[[exemptions.zerocopy-derive]]
-version = "0.8.27"
-criteria = "safe-to-run"
-
-[[exemptions.zerofrom]]
-version = "0.1.6"
-criteria = "safe-to-run"
-
-[[exemptions.zerofrom-derive]]
-version = "0.1.6"
-criteria = "safe-to-run"
-
-[[exemptions.zeroize]]
-version = "1.8.1"
-criteria = "safe-to-run"
-
-[[exemptions.zeroize_derive]]
-version = "1.4.2"
-criteria = "safe-to-run"
-
-[[exemptions.zerotrie]]
-version = "0.2.2"
-criteria = "safe-to-run"
-
-[[exemptions.zerovec]]
-version = "0.11.4"
-criteria = "safe-to-run"
-
-[[exemptions.zerovec-derive]]
-version = "0.11.1"
 criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -185,10 +185,6 @@ criteria = "safe-to-run"
 version = "4.5.47"
 criteria = "safe-to-run"
 
-[[exemptions.clap_lex]]
-version = "0.7.5"
-criteria = "safe-to-run"
-
 [[exemptions.cmac]]
 version = "0.7.2"
 criteria = "safe-to-run"
@@ -227,10 +223,6 @@ criteria = "safe-to-run"
 
 [[exemptions.crc16]]
 version = "0.4.0"
-criteria = "safe-to-run"
-
-[[exemptions.crunchy]]
-version = "0.2.4"
 criteria = "safe-to-run"
 
 [[exemptions.crypto-bigint]]
@@ -417,10 +409,6 @@ criteria = "safe-to-run"
 version = "1.0.3"
 criteria = "safe-to-run"
 
-[[exemptions.inout]]
-version = "0.1.4"
-criteria = "safe-to-run"
-
 [[exemptions.is-terminal]]
 version = "0.4.16"
 criteria = "safe-to-run"
@@ -483,10 +471,6 @@ criteria = "safe-to-run"
 
 [[exemptions.nrf52840-pac]]
 version = "0.11.0"
-criteria = "safe-to-run"
-
-[[exemptions.num]]
-version = "0.3.1"
 criteria = "safe-to-run"
 
 [[exemptions.num-bigint-dig]]
@@ -559,10 +543,6 @@ criteria = "safe-to-run"
 
 [[exemptions.postcard-cobs]]
 version = "0.1.5-pre"
-criteria = "safe-to-run"
-
-[[exemptions.potential_utf]]
-version = "0.1.3"
 criteria = "safe-to-run"
 
 [[exemptions.pretty_env_logger]]
@@ -673,14 +653,6 @@ criteria = "safe-to-run"
 version = "0.6.9"
 criteria = "safe-to-run"
 
-[[exemptions.serde_spanned]]
-version = "1.0.2"
-criteria = "safe-to-run"
-
-[[exemptions.serial_test]]
-version = "1.0.0"
-criteria = "safe-to-run"
-
 [[exemptions.serial_test_derive]]
 version = "1.0.0"
 criteria = "safe-to-run"
@@ -785,10 +757,6 @@ criteria = "safe-to-run"
 version = "0.1.2"
 criteria = "safe-to-run"
 
-[[exemptions.toml_writer]]
-version = "1.0.3"
-criteria = "safe-to-run"
-
 [[exemptions.trussed-rsa-alloc]]
 version = "0.5.0-rc.1"
 criteria = "safe-to-run"
@@ -865,10 +833,6 @@ criteria = "safe-to-run"
 version = "0.2.104"
 criteria = "safe-to-run"
 
-[[exemptions.winapi-util]]
-version = "0.1.11"
-criteria = "safe-to-run"
-
 [[exemptions.windows]]
 version = "0.48.0"
 criteria = "safe-to-run"
@@ -883,10 +847,6 @@ criteria = "safe-to-run"
 
 [[exemptions.windows-interface]]
 version = "0.59.1"
-criteria = "safe-to-run"
-
-[[exemptions.windows-link]]
-version = "0.1.3"
 criteria = "safe-to-run"
 
 [[exemptions.windows-result]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,0 +1,2 @@
+
+# cargo-vet imports lock

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,2 +1,127 @@
 
 # cargo-vet imports lock
+
+[[publisher.apdu-app]]
+version = "0.2.0"
+when = "2026-03-25"
+trusted-publisher = "github:trussed-dev/apdu-dispatch"
+
+[[publisher.apdu-dispatch]]
+version = "0.4.0"
+when = "2026-03-25"
+trusted-publisher = "github:trussed-dev/apdu-dispatch"
+
+[[publisher.ctap-types]]
+version = "0.6.0-rc.4"
+when = "2026-06-01"
+trusted-publisher = "github:trussed-dev/ctap-types"
+
+[[publisher.ctaphid-app]]
+version = "0.2.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/ctaphid-dispatch"
+
+[[publisher.ctaphid-dispatch]]
+version = "0.4.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/ctaphid-dispatch"
+
+[[publisher.fido-authenticator]]
+version = "0.4.0-rc.3"
+when = "2026-06-01"
+trusted-publisher = "github:trussed-dev/fido-authenticator"
+
+[[publisher.heapless-bytes]]
+version = "0.5.0"
+when = "2025-09-18"
+trusted-publisher = "github:trussed-dev/heapless-bytes"
+
+[[publisher.iso7816]]
+version = "0.2.0"
+when = "2025-09-25"
+trusted-publisher = "github:trussed-dev/iso7816"
+
+[[publisher.littlefs2]]
+version = "0.7.0"
+when = "2026-03-09"
+trusted-publisher = "github:trussed-dev/littlefs2"
+
+[[publisher.littlefs2-core]]
+version = "0.1.2"
+when = "2025-10-16"
+trusted-publisher = "github:trussed-dev/littlefs2"
+
+[[publisher.littlefs2-sys]]
+version = "0.3.2"
+when = "2026-03-03"
+trusted-publisher = "github:trussed-dev/littlefs2-sys"
+
+[[publisher.lpc55-hal]]
+version = "0.5.0"
+when = "2026-03-20"
+trusted-publisher = "github:lpc55/lpc55-hal"
+
+[[publisher.se05x]]
+version = "0.4.0"
+when = "2026-03-31"
+trusted-publisher = "github:Nitrokey/se05x"
+
+[[publisher.trussed-auth]]
+version = "0.5.0"
+when = "2026-03-25"
+trusted-publisher = "github:trussed-dev/trussed-auth"
+
+[[publisher.trussed-chunked]]
+version = "0.3.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+
+[[publisher.trussed-core]]
+version = "0.2.2"
+when = "2026-06-01"
+trusted-publisher = "github:trussed-dev/trussed"
+
+[[publisher.trussed-fs-info]]
+version = "0.3.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+
+[[publisher.trussed-hkdf]]
+version = "0.4.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+
+[[publisher.trussed-hpke]]
+version = "0.3.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+
+[[publisher.trussed-manage]]
+version = "0.3.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+
+[[publisher.trussed-rsa-types]]
+version = "0.2.0"
+when = "2026-03-25"
+trusted-publisher = "github:trussed-dev/trussed-rsa-backend"
+
+[[publisher.trussed-se050-manage]]
+version = "0.3.0"
+when = "2026-03-25"
+trusted-publisher = "github:Nitrokey/trussed-se050-backend"
+
+[[publisher.trussed-wrap-key-to-file]]
+version = "0.3.0"
+when = "2026-03-23"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+
+[[publisher.usbd-ccid]]
+version = "0.4.0"
+when = "2026-03-25"
+trusted-publisher = "github:trussed-dev/usbd-ccid"
+
+[[publisher.usbd-ctaphid]]
+version = "0.4.0"
+when = "2026-03-25"
+trusted-publisher = "github:trussed-dev/usbd-ctaphid"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -230,6 +230,12 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 version = "0.1.2"
 
+[[audits.bytecode-alliance.audits.inout]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = "A part of RustCrypto/utils, this crate is designed to handle unsafe buffers and carefully documents the safety concerns throughout. Older versions of this tally up to ~130k daily downloads."
+
 [[audits.bytecode-alliance.audits.itertools]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
@@ -440,6 +446,37 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "0.3.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.clap_lex]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "0.7.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.clap_lex]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.7.0 -> 0.7.1"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.clap_lex]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.7.1 -> 0.7.2"
+notes = "No `.rs` changes in the delta."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.clap_lex]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.7.2 -> 0.7.3"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.clap_lex]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.7.3 -> 0.7.4"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.core-foundation-sys]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -977,6 +1014,20 @@ criteria = "safe-to-run"
 version = "0.1.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.potential_utf]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "Contains a handful of lines of from-UTF8 unsafety and some `repr(transparent)` casting unsafety. Reasonably well commented, could do with listing invariants explicitly."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.potential_utf]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.2"
+notes = "Addition of safe comparison APIs since last audit"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.ppv-lite86]]
 who = "danakj@chromium.org"
 criteria = "safe-to-run"
@@ -1146,6 +1197,12 @@ criteria = "safe-to-run"
 version = "0.7.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.serial_test]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "2.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.shell-words]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -1258,6 +1315,30 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "0.1.3"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.winapi-util]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.1.6"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.winapi-util]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.1.6 -> 0.1.8"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.winapi-util]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.1.8 -> 0.1.9"
+notes = "The delta only changes Cargo.toml."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.writeable]]
 who = "Manish Goregaokar <manishearth@google.com>"
@@ -1476,6 +1557,12 @@ criteria = "safe-to-deploy"
 delta = "2.6.0 -> 2.7.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.crunchy]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.crypto-common]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1679,6 +1766,13 @@ criteria = "safe-to-deploy"
 delta = "0.7.5 -> 0.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.percent-encoding]]
 who = "edgul <ed.guloien@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1737,6 +1831,13 @@ criteria = "safe-to-deploy"
 version = "0.7.0"
 notes = "Basic implementation of a serde value type. No use of unsafe code."
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde_spanned]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.0.3"
+notes = "Relatively simple Serde trait implementations.  No IO or unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.sharded-slab]]
 who = "Mark Hammond <mhammond@skippinet.com.au>"
@@ -1809,6 +1910,12 @@ who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
 delta = "0.7.6 -> 0.8.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml_writer]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.0.6+spec-1.1.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.tracing]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -11,6 +11,20 @@ version = "0.4.0"
 when = "2026-03-25"
 trusted-publisher = "github:trussed-dev/apdu-dispatch"
 
+[[publisher.bumpalo]]
+version = "3.19.0"
+when = "2025-06-24"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.cexpr]]
+version = "0.6.0"
+when = "2021-10-11"
+user-id = 3788
+user-login = "emilio"
+user-name = "Emilio Cobos Álvarez"
+
 [[publisher.ctap-types]]
 version = "0.6.0-rc.4"
 when = "2026-06-01"
@@ -116,6 +130,27 @@ version = "0.3.0"
 when = "2026-03-23"
 trusted-publisher = "github:trussed-dev/trussed-staging"
 
+[[publisher.unicode-width]]
+version = "0.1.14"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-width]]
+version = "0.2.1"
+when = "2025-06-09"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-xid]]
+version = "0.2.6"
+when = "2024-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
 [[publisher.usbd-ccid]]
 version = "0.4.0"
 when = "2026-03-25"
@@ -125,3 +160,1904 @@ trusted-publisher = "github:trussed-dev/usbd-ccid"
 version = "0.4.0"
 when = "2026-03-25"
 trusted-publisher = "github:trussed-dev/usbd-ctaphid"
+
+[[publisher.utf8_iter]]
+version = "1.0.4"
+when = "2023-12-01"
+user-id = 4484
+user-login = "hsivonen"
+user-name = "Henri Sivonen"
+
+[[audits.bytecode-alliance.wildcard-audits.bumpalo]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2019-03-16"
+end = "2026-08-21"
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.7.0 -> 2.9.4"
+notes = "Tweaks to the macro, nothing out of order."
+
+[[audits.bytecode-alliance.audits.cipher]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "0.4.4"
+notes = "Most unsafe is hidden by `inout` dependency; only remaining unsafe is raw-splitting a slice and an unreachable hint. Older versions of this regularly reach ~150k daily downloads."
+
+[[audits.bytecode-alliance.audits.cobs]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.2.3"
+notes = "No `unsafe` code in the crate and no usage of `std`"
+
+[[audits.bytecode-alliance.audits.cobs]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.3 -> 0.3.0"
+notes = "Nothing out of the ordinary, virtually no unsafe code."
+
+[[audits.bytecode-alliance.audits.crypto-common]]
+who = "Benjamin Bouvier <public@benj.me>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+
+[[audits.bytecode-alliance.audits.der]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "0.7.10"
+notes = "No unsafe code aside from transmutes for transparent newtypes."
+
+[[audits.bytecode-alliance.audits.futures]]
+who = "Joel Dice <joel.dice@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.31"
+
+[[audits.bytecode-alliance.audits.futures-executor]]
+who = "Joel Dice <joel.dice@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.31"
+
+[[audits.bytecode-alliance.audits.hashbrown]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.14.5 -> 0.15.2"
+
+[[audits.bytecode-alliance.audits.iana-time-zone-haiku]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
+[[audits.bytecode-alliance.audits.itertools]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.5 -> 0.12.1"
+notes = """
+Minimal `unsafe` usage. Few blocks that existed looked reasonable. Does what it
+says on the tin: lots of iterators.
+"""
+
+[[audits.bytecode-alliance.audits.itertools]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.12.1 -> 0.14.0"
+notes = """
+Lots of new iterators and shuffling some things around. Some new unsafe code but
+it's well-documented and well-tested. Nothing suspicious.
+"""
+
+[[audits.bytecode-alliance.audits.libc]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.146 -> 0.2.147"
+notes = "Only new type definitions and updating others for some platforms, no major changes"
+
+[[audits.bytecode-alliance.audits.libc]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.153 -> 0.2.158"
+notes = "More platforms, more definitions, more headers, it's still just `libc`"
+
+[[audits.bytecode-alliance.audits.libc]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+delta = "0.2.158 -> 0.2.161"
+
+[[audits.bytecode-alliance.audits.libc]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.161 -> 0.2.171"
+notes = """
+Lots of unsafe, but that's par for the course with libc, it's all FFI type
+definitions updates/adjustments/etc.
+"""
+
+[[audits.bytecode-alliance.audits.log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.22 -> 0.4.27"
+notes = "Lots of minor updates to macros and such, nothing touching `unsafe`"
+
+[[audits.bytecode-alliance.audits.log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.27 -> 0.4.28"
+notes = "Minor doc updates and lots new tests, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Some unsafe code, but not more than before. Nothing awry."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.46.0"
+notes = "one use of unsafe to call windows specific api to get console handle."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.46.0 -> 0.50.1"
+notes = "Lots of stylistic/rust-related changes, plus new features, but nothing out of the ordrinary."
+
+[[audits.bytecode-alliance.audits.postcard]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.8"
+notes = """
+I've audited the unsafe code to do what it looks like it's doing. Otherwise the
+crate is a standard serializer/deserializer crate.
+"""
+
+[[audits.bytecode-alliance.audits.postcard]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.8 -> 1.1.3"
+notes = "Substantial updates, but nothing out of the ordinary one would expect from a serialization crate. Minor `unsafe` updates, but nothing major from what was already there."
+
+[[audits.bytecode-alliance.audits.sharded-slab]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = "I always really enjoy reading eliza's code, she left perfect comments at every use of unsafe."
+
+[[audits.bytecode-alliance.audits.tracing-attributes]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.28 -> 0.1.30"
+notes = "Few code changes, a pretty minor update."
+
+[[audits.bytecode-alliance.audits.tracing-core]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.33 -> 0.1.34"
+notes = "Mostly just an update with Rust stylistic conventions changing. Nothing awry."
+
+[[audits.bytecode-alliance.audits.tracing-log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = """
+This is a standard adapter between the `log` ecosystem and the `tracing`
+ecosystem. There's one `unsafe` block in this crate and it's well-scoped.
+"""
+
+[[audits.bytecode-alliance.audits.tracing-log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.2.0"
+notes = "Nothing out of the ordinary, a typical major version update and nothing awry."
+
+[[audits.bytecode-alliance.audits.tracing-subscriber]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.17"
+
+[[audits.google.audits.aho-corasick]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "1.1.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.atomic-polyfill]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "0.1.11"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.atomic-polyfill]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.1.11 -> 1.0.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.bare-metal]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.2.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.bare-metal]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.2.5 -> 1.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.base64]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.13.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.bindgen]]
+who = "Justin Green <greenjustin@google.com>"
+criteria = "safe-to-run"
+version = "0.70.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitfield]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.13.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.3.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.bitflags]]
+who = "Justin Green <greenjustin@google.com>"
+criteria = "safe-to-run"
+version = "2.6.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.block-buffer]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.10.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.byteorder]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.5.0"
+notes = "Unsafe review in https://crrev.com/c/5838022"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.cast]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.core-foundation-sys]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.8.7"
+notes = "OSX system APIs"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.cortex-m]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.7.7"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.cortex-m-rtic]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.1.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.cortex-m-rtic-macros]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.1.6"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.critical-section]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "1.1.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.critical-section]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "1.1.1 -> 1.1.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.critical-section]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "1.1.2 -> 1.2.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.cty]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "0.2.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.displaydoc]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.2.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.env_logger]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.9.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.env_logger]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.9.3 -> 0.8.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "Jonathan Hao <phao@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.0.2"
+notes = "No changes to any .rs files or Rust code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-channel]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.28"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-channel]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.3.28 -> 0.3.31"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-core]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.28"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-core]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.3.28 -> 0.3.31"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-io]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.28"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-io]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.3.28 -> 0.3.31"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-sink]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.28"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-sink]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.3.28 -> 0.3.31"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-task]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.28"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-task]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.3.28 -> 0.3.31"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-util]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.28"
+notes = """
+There's a custom xorshift-based `random::shuffle` implementation in
+src/async_await/random.rs. This is `doc(hidden)` and seems to exist just so
+that `futures-macro::select` can be unbiased. Sicne xorshift is explicitly not
+intended to be a cryptographically secure algorithm, it is not considered
+crypto.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures-util]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.3.28 -> 0.3.31"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.generic-array]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.14.7"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.heapless]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.7.17"
+notes = """
+does-not-implement-crypto: Hashing containers (e.g., IndexMap) defer to other
+machinery like the hash32 crate for hashing.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.heck]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
+and there were no hits.
+
+`heck` (version `0.3.3`) has been added to Chromium in
+https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.heck]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "0.5.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.hex-literal]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.4.1"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.iana-time-zone]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.61"
+notes = "Some unsafe: interfacing with system timezone APIs"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_collections]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0-beta1"
+notes = """
+Two instances of unsafe :
+ - Non-safety related unsafe API that imposes additional invariants
+ - `from_utf8` for known-UTF8 integer
+
+Comments added/improved in https://github.com/unicode-org/icu4x/pull/6056.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_collections]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta1 -> 2.0.0-beta2"
+notes = "from_utf8 unsafe removed. no new unsafe added"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_locale_core]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0-beta2"
+notes = """
+All unsafe code commented (and improved from prior version):
+  - A checklisted ULE impl
+  - from-utf8 code on known-ASCII
+  - Some unchecked indexing around maintained invariants
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_normalizer]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0-beta2"
+notes = """
+All unsafe is unchecked `char` and `str` conversion, mostly well-commented.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_normalizer_data]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0-beta1"
+notes = "Contains codegenned unsafe only, using safe Bake impls from zerovec/zerotrie"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_normalizer_data]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta1 -> 2.0.0-beta2"
+notes = "Contains codegenned unsafe only, using safe Bake impls from zerovec/zerotrie"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_properties]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0-beta2"
+notes = "All unsafe was removed"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_properties_data]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0-beta1"
+notes = "Contains codegenned unsafe only, using safe Bake impls from zerovec/zerotrie"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_properties_data]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta1 -> 2.0.0-beta2"
+notes = "Contains codegenned unsafe only, using safe Bake impls from zerovec/zerotrie"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_provider]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "2.0.0-beta1"
+notes = """
+All unsafe code commented:
+  - Minor unsafe transmutes between types which are identical but not type-system-provably so.
+  - One unsafe EqULE impl
+  - Some repr(transparent) transmutes
+  - A from_utf8_unchecked for an ascii-validated string
+
+Comment improvements can be found in https://github.com/unicode-org/icu4x/pull/6056
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.icu_provider]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta1 -> 2.0.0-beta2"
+notes = "from_utf8_unchecked unsafe remove, all other unsafe not meaningfully changed"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.idna]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.idna]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.3.0 -> 1.0.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.9.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.7.1"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`
+and there were no hits.
+
+There is a little bit of `unsafe` Rust code - the audit can be found at
+https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.7.1 -> 2.8.0"
+notes = """
+No `unsafe` introduced or affected in:
+* `indexmap_with_default!` and `indexset_with_default!` macros
+* New `PartialEq` implementations
+* `fn slice_eq` in `util.rs`
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.itertools]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "0.10.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.itoa]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.10"
+notes = '''
+I grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits.
+
+There are a few places where `unsafe` is used.  Unsafe review notes can be found
+in https://crrev.com/c/5350697.
+
+Version 1.0.1 of this crate has been added to Chromium in
+https://crrev.com/c/3321896.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.itoa]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.10 -> 1.0.11"
+notes = """
+Straightforward diff between 1.0.10 and 1.0.11 - only 3 commits:
+
+* Bumping up the version
+* A touch up of comments
+* And my own PR to make `unsafe` blocks more granular:
+  https://github.com/dtolnay/itoa/pull/42
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.itoa]]
+who = "Liza Burakova <liza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.11 -> 1.0.14"
+notes = """
+Unsafe review at https://crrev.com/c/6051067
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.itoa]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.14 -> 1.0.15"
+notes = "Only minor rustdoc changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "1.4.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+notes = "Unsafe review notes: https://crrev.com/c/5650836"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.libc]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.2.146"
+notes = """
+Much like the getrandom crate, this exports interfaces to APIs which perform
+crypto, but does not implement any crypto itself.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.libc]]
+who = "Daniel Verkamp <dverkamp@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.2.147 -> 0.2.153"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.litemap]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.7.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.litemap]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.4 -> 0.7.5"
+notes = "Delta implements the entry API but doesn't add or change any unsafe code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.22"
+notes = """
+Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO4CwN5noMFXnqyDIM/edit?usp=sharing
+
+Unsafety is generally very well-documented, with one exception, which we
+describe in the review doc.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.nb]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.nb]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 0.1.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.nb]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 1.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.nom]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "7.1.3"
+notes = """
+Reviewed in https://chromium-review.googlesource.com/c/chromium/src/+/5046153
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.num-integer]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.46"
+notes = "Contains no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.num-traits]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.19"
+notes = "Contains a single line of float-to-int unsafe with decent safety comments"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.percent-encoding]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "2.2.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.percent-encoding]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "2.2.0 -> 2.3.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.percent-encoding]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "2.3.0 -> 2.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.pin-project-lite]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "0.2.9"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.pin-project-lite]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.9 -> 0.2.13"
+notes = "Audited at https://fxrev.dev/946396"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.pin-utils]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "0.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.ppv-lite86]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.2.17"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.ppv-lite86]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.2.17 -> 0.2.20"
+notes = "Using zerocopy to reduce unsafe usage."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.ppv-lite86]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.2.20 -> 0.2.21"
+notes = """
+The delta mostly corresponds to @joshlf's
+https://github.com/cryptocorrosion/cryptocorrosion/pull/85 which started
+using an undocumented API that `zerocopy` has provided specifically for
+`ppv-lite86` in https://github.com/google/zerocopy/pull/2418.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro-error]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.0.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro-error-attr]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "1.0.36"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.36 -> 1.0.37"
+notes = """
+The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
+`primitive!` macro and 2) adds `impl ToTokens` for `CStr` and `CString`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.37 -> 1.0.38"
+notes = "Still no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.38 -> 1.0.39"
+notes = "Only minor changes for clippy lints and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.39 -> 1.0.40"
+notes = """
+The delta is just a simplification of how `tokens.extend(...)` call is made.
+Still no `unsafe` anywhere.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.8.5"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_chacha]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "0.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_core]]
+who = "Android Legacy"
+criteria = "safe-to-run"
+version = "0.6.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rtic-core]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rtic-monotonic]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rtic-syntax]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.0.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rtt-target]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustc_version]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.2.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustc_version]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.4.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rustc_version]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.4.0 -> 0.4.1"
+notes = "No unsafe, net or fs."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.scoped-tls]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.semver]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.9.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.semver-parser]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.7.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.shell-words]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.shlex]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.shlex]]
+who = "Daniel Verkamp <dverkamp@chromium.org>"
+criteria = "safe-to-run"
+delta = "1.1.0 -> 1.3.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.smallvec]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.2"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.smallvec]]
+who = "Jonathan Hao <phao@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.13.2 -> 1.14.0"
+notes = """
+WARNING: This certification is a result of a **partial** audit. The
+`malloc_size_of` feature has **not** been audited. This feature does
+not explicitly document its safety requirements.
+See also https://chromium-review.googlesource.com/c/chromium/src/+/6275133/comment/ea0d7a93_98051a2e/
+and https://github.com/servo/malloc_size_of/issues/8.
+This feature is banned in gnrt_config.toml.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.spin]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.9.8"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.stable_deref_trait]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "1.2.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.strsim]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "0.11.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.strum_macros]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.syn]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "1.0.109"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.termcolor]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "1.4.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.termcolor]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-run"
+delta = "1.4.0 -> 1.4.1"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.ufmt-write]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.utf8parse]]
+who = "Ying Hsu <yinghsu@chromium.org>"
+criteria = "safe-to-run"
+version = "0.2.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.vcell]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.1.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.writeable]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.6.0"
+notes = "Contains three lines of unsafe, thoroughly commented: one is for from-UTF8 on ASCII, the other two are for from-UTF8 on a datastructure that keeps track of a buffer with partial UTF8 validation. Relatively straigtforward."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.writeable]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.6.0 -> 0.6.1"
+notes = "Minor comment/documentation updates and switch to a non-panicking alternative to split_at()."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.7.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.8.0"
+notes = """
+Cleaning up a previous hack for adding trait bounds to yoke objects. Unsafe changes:
+- deleting the hack itself removes a lot of unsafe use required in the hack's implementation
+- changes another unsafe use to remove the use of the hack, now that it's no longer needed
+
+
+See https://crrev.com/c/6323349 for more audit notes.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke-derive]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.7.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.yoke-derive]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.8.0"
+notes = "No code changes: only incrementing the version."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.1.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.1.6"
+notes = "Only minor cfg tweaks."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom-derive]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.1.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerofrom-derive]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.1.6"
+notes = "Only a minor clippy adjustment."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerotrie]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = "Minor repr(transparent) unsafe code. Improved comments in https://github.com/unicode-org/icu4x/pull/6054"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.zerotrie]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = """
+Changes in unsafe blocks are wrapping direct calls to `core::mem::transmute` with the `transparent_ref_from_store` wrapper.
+No safety guarantees change, but providing the `transparent_ref_from_store` as a wrapper provides a convenient marker that this transmute operation is actually sound.
+
+See https://crrev.com/c/6323349 for more audit notes.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.mozilla.wildcard-audits.cexpr]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+user-id = 3788 # Emilio Cobos Álvarez (emilio)
+start = "2021-06-21"
+end = "2024-04-21"
+notes = "No unsafe code, rather straight-forward parser."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-width]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-12-05"
+end = "2026-02-01"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-xid]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-07-25"
+end = "2027-04-23"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.utf8_iter]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+user-id = 4484 # Henri Sivonen (hsivonen)
+start = "2022-04-19"
+end = "2024-06-16"
+notes = "Maintained by Henri Sivonen who works at Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+notes = "I wrote this crate, reviewed by jimb. It is mostly a Rust port of some C++ code we already ship."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.13.1"
+notes = """
+Template crate.  This is only used to generate the Rust/JS code for UniFFI.
+
+We used to use askama, then we switched to rinja which was a fork.  Now rinja and
+askama have merged again.
+
+The differences from askama 0.12, are pretty straightforward and don't seem risky to me.  There's
+some unsafe code and macros, but nothing that complicated.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.14.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_derive]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.13.1"
+notes = """
+Template crate.  This is only used to generate the Rust/JS code for UniFFI.
+
+We used to use askama, then we switched to rinja which was a fork.  Now rinja and
+askama have merged again.
+
+I did a quick scan of the current code and couldn't find any issues.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_derive]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.14.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_parser]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.13.0"
+notes = """
+Template crate.  This is only used to generate the Rust/JS code for UniFFI.
+
+We used to use askama, then we switched to rinja which was a fork.  Now rinja and
+askama have merged again.
+
+I did a quick scan of the current code and couldn't find any issues.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.askama_parser]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.0 -> 0.14.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = [
+    "Teodor Tanasoaia <ttanasoaia@mozilla.com>",
+    "Erich Gubler <erichdongubler@gmail.com>",
+]
+criteria = "safe-to-deploy"
+delta = "2.6.0 -> 2.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crypto-common]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.1.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "1.6.1"
+notes = """
+Straightforward crate providing the Either enum and trait implementations with
+no unsafe code.
+"""
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.6.1 -> 1.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 1.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.8.0 -> 1.8.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.8.1 -> 1.9.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 1.10.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.10.0 -> 1.12.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.12.0 -> 1.13.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.13.0 -> 1.14.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.1 -> 1.2.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+version = "0.12.3"
+notes = "This version is used in rust's libstd, so effectively we're already trusting it"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.2 -> 0.15.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.5 -> 0.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.iana-time-zone]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.1.61 -> 0.1.63"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.iana-time-zone]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.63 -> 0.1.64"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_collections]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta2 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locale_core]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta2 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_normalizer]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta2 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_normalizer_data]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta2 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_properties]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta2 -> 2.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_properties_data]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta2 -> 2.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_provider]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "2.0.0-beta2 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna_adapter]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna_adapter]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.11.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.libc]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.171 -> 0.2.176"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.litemap]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.1 -> 2.3.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.pin-project-lite]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.13 -> 0.2.14"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.pin-project-lite]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.14 -> 0.2.16"
+notes = """
+Only functional change is to work around a bug in the negative_impls feature
+(https://github.com/taiki-e/pin-project/issues/340#issuecomment-2432146009)
+"""
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rand]]
+who = "Henrik Skupin <mail@hskupin.info>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.8.6"
+notes = """
+Fixes RUSTSEC-2026-0097 by removing `log` dependency. Removes `simd_support`
+feature. No new dependencies or unsafe code.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rustc-hash]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Straightforward crate with no unsafe code, does what it says on the tin."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rustc-hash]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.1.0 -> 2.1.1"
+notes = "Simple hashing crate, no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.scoped-tls]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-run"
+delta = "1.0.0 -> 1.0.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.serde-value]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "Basic implementation of a serde value type. No use of unsafe code."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.sharded-slab]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.7"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.12.6"
+notes = """
+I am the primary author of the `synstructure` crate, and its current
+maintainer. The one use of `unsafe` is unnecessary, but documented and
+harmless. It will be removed in the next version.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.12.6 -> 0.13.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.13.0 -> 0.13.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.synstructure]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.13.1 -> 0.13.2"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "One of original auther was Zibi Braniecki who worked at Mozilla and maintained by ICU4X developers (Google and Mozilla). I've vetted the one instance of unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.7.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.7.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.4 -> 0.7.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.6 -> 0.8.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.37"
+notes = """
+There's only one unsafe impl, and its purpose is to ensure correct behavior by
+creating a non-Send marker type (it has nothing to do with soundness). All
+dependencies make sense, and no side-effectful std functions are used.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.1.37 -> 0.1.41"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-attributes]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.24"
+notes = "No unsafe code, macros extensively tested and produce reasonable code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-attributes]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.1.24 -> 0.1.28"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.30"
+notes = """
+Most unsafe code is in implementing non-std sync primitives. Unsafe impls are
+logically correct and justified in comments, and unsafe code is sound and
+justified in comments.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-core]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.1.30 -> 0.1.33"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-subscriber]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.3.17 -> 0.3.19"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tracing-subscriber]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.3.19 -> 0.3.20"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.0 -> 2.4.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.1 -> 2.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+delta = "2.5.0 -> 2.5.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.5.1 -> 2.5.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "edgul <ed.guloien@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.5.4 -> 2.5.7"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.utf8parse]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.void]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.2"
+notes = "Very small crate, just hosts the Void type for easier cross-crate interfacing."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.windows-link]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "A microsoft crate allowing unsafe calls to windows apis."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.windows-link]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.32"
+notes = """
+This crate is `no_std` so doesn't use any side-effectful std functions. It
+contains quite a lot of `unsafe` code, however. I verified portions of this. It
+also has a large, thorough test suite. The project claims to run tests with
+Miri to have stronger soundness checks, and also claims to use formal
+verification tools to prove correctness.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.32 -> 0.8.27"
+notes = """
+These changes are enormous, however unsafe code is kept somewhat minimal in
+comparison. The safety properties of unsafe code blocks, traits, and other
+types are thoroughly documented. The new build script is safe. All code is very
+thoroughly tested. I expect their test coverage is quite high.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy-derive]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.32"
+notes = "Clean, safe macros for zerocopy."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy-derive]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.32 -> 0.8.27"
+notes = """
+There are a lot of changes here, however they look reasonable. Unsafe code is
+heavily documented, and there are extensive tests for the changes.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zeroize]]
+who = "Benjamin Beurdouche <beurdouche@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.8.1"
+notes = """
+This code DOES contain unsafe code required to internally call volatiles
+for deleting data. This is expected and documented behavior.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zeroize_derive]]
+who = "Benjamin Beurdouche <beurdouche@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.4.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerotrie]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.9.4"
+notes = "This crate is zero-copy data structure implmentation. Although this uses unsafe block in several code, it requires for zero-copy. And this has a comment in code why this uses unsafe and I audited code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.10.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.10.1 -> 0.10.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.2 -> 0.10.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.10.4 -> 0.11.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.11.2 -> 0.11.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.11.3 -> 0.11.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec-derive]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.10.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec-derive]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.10.1 -> 0.10.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec-derive]]
+who = "Max Inden <mail@max-inden.de>"
+criteria = "safe-to-deploy"
+delta = "0.10.2 -> 0.10.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec-derive]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.10.3 -> 0.11.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"


### PR DESCRIPTION
This configuration requires `safe-to-run` for all dependencies, imports audits from the Bytecode Alliance, Google and Mozilla, adds audits for our own crates (wildcard audits for crates using trusted publishing, manual audits otherwise) and adds cargo vet to the CI.