### PR TITLE
docker-Makefile cross platform

### DIFF
--- a/docker-Makefile
+++ b/docker-Makefile
@@ -12,4 +12,4 @@ build:
 
 .PHONY: docker-build
 docker-build:
-	docker run --interactive --rm --volume $(PWD):/app $(TAG) make -C $(RUNNER)
+	docker run --interactive --rm --volume "$(CURDIR)":/app $(TAG) make -C $(RUNNER)


### PR DESCRIPTION
Changing `$(PWD)` to `"$(CURDIR)"` to ensure it works on both linux and windows.