### PR TITLE
modify sh files to use nitropy instead of nrfutil

### DIFF
--- a/utils/nrf-bootloader/generate_key.sh
+++ b/utils/nrf-bootloader/generate_key.sh
@@ -26,11 +26,13 @@ if [ -r "${privkey}" ] | [ -r "${pubkey}" ]; then
 fi
 
 # Generate a private key
-nrfutil keys generate ${privkey}
-
+#nrfutil keys generate ${privkey}
+nitropy-nrf keys generate ${privkey}
 # Generate C source file containing the public key
-nrfutil keys display --key pk --format code ${privkey} --out_file ${pubkey}
-nrfutil keys display --key pk --format pem ${privkey} --out_file ${pubkey_pem}
+#nrfutil keys display --key pk --format code ${privkey} --out_file ${pubkey}
+#nrfutil keys display --key pk --format pem ${privkey} --out_file ${pubkey_pem}
+nitropy-nrf keys display --format code --key-file ${privkey} --out-file ${pubkey}
+nitropy-nrf keys display --format pem --key-file ${privkey} --out-file ${pubkey_pem}
 
 stat ${pubkey}
 stat ${privkey}

--- a/utils/nrf-bootloader/sign-bootloader.sh
+++ b/utils/nrf-bootloader/sign-bootloader.sh
@@ -32,4 +32,5 @@ HW_VERSION=52
 SD_VERSION=0x0
 
 # Create an update package signed with the private key
-nrfutil pkg generate --hw-version $HW_VERSION --bootloader-version $BOOTLOADER_VERSION --bootloader $BOOTLOADER_HEX_FILE --sd-req $SD_VERSION --key-file $KEY_PATH  $OUTPUT_FILE
+#nrfutil pkg generate --hw-version $HW_VERSION --bootloader-version $BOOTLOADER_VERSION --bootloader $BOOTLOADER_HEX_FILE --sd-req $SD_VERSION --key-file $KEY_PATH  $OUTPUT_FILE
+nitropy-nrf pkg generate --hw-version $HW_VERSION --bootloader-version $BOOTLOADER_VERSION --bootloader $BOOTLOADER_HEX_FILE --sd-req $SD_VERSION --key-file $KEY_PATH $OUTPUT_FILE

--- a/utils/nrf-bootloader/sign.sh
+++ b/utils/nrf-bootloader/sign.sh
@@ -32,4 +32,5 @@ HW_VERSION=52
 SD_VERSION=0x0
 
 # Create an update package signed with the private key
-nrfutil pkg generate --hw-version $HW_VERSION --application-version $APP_VERSION --application $APP_HEX_FILE --sd-req $SD_VERSION --key-file $KEY_PATH --app-boot-validation VALIDATE_ECDSA_P256_SHA256 $OUTPUT_FILE
+#nrfutil pkg generate --hw-version $HW_VERSION --application-version $APP_VERSION --application $APP_HEX_FILE --sd-req $SD_VERSION --key-file $KEY_PATH --app-boot-validation VALIDATE_ECDSA_P256_SHA256 $OUTPUT_FILE
+nitropy-nrf pkg generate --hw-version $HW_VERSION --application-version $APP_VERSION --application $APP_HEX_FILE --sd-req $SD_VERSION --key-file $KEY_PATH --app-boot-validation $OUTPUT_FILE

--- a/utils/nrf-bootloader/upload.sh
+++ b/utils/nrf-bootloader/upload.sh
@@ -10,4 +10,5 @@ fi
 UPDATE_FILENAME=$1
 SERIAL_PORT=$2
 
-nrfutil dfu usb-serial -pkg $UPDATE_FILENAME -p $SERIAL_PORT
+#nrfutil dfu usb-serial -pkg $UPDATE_FILENAME -p $SERIAL_PORT
+nitropy-nrf dfu usb-serial --package $UPDATE_FILENAME --port $SERIAL_PORT


### PR DESCRIPTION
Use nitropy changes instead of nrfutils. Will remove the nrfutil installer in the docker files later after tests