### PR TITLE
Update dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Copyright (C) Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+* @Nitrokey/rust-reviewers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - fido-authenticator: Implement the largeBlobKey extension and the largeBlobs command ([fido-authenticator#38][])
+- Update applications (maintenance only):
+  - admin-app v0.2.0
+  - opcard v1.8.0
 
 ## v1.9.0-rc.1 (2026-06-01)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 4
 
 [[package]]
 name = "admin-app"
-version = "0.1.0"
-source = "git+https://github.com/Nitrokey/admin-app.git?tag=v0.1.0-nitrokey.22#70086d9d99868def0a022c29c03b3270a4436385"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b02a99bf03dced64b9b0bc9b2f101987e5676fba19fc76580702c8ba32bd7c"
 dependencies = [
  "apdu-app",
  "cbor-smol",
@@ -1979,9 +1980,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "littlefs2"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09962f5a4debc842f60156499ba53364cff174f4afb0ac210156d114d843cc4d"
+checksum = "3e00aee790b8914c83815e9f6952731f4ddd9965c160aa66fe2a89abeb5c406a"
 dependencies = [
  "bitflags 2.9.4",
  "delog",
@@ -2004,12 +2005,13 @@ dependencies = [
 
 [[package]]
 name = "littlefs2-sys"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae112b732df34c1420471e1ff21c562dfdf81219efb5960dd15b3947097e784a"
+checksum = "999d08bb7fae46d63ecb98d2474d28f7af1a6c928a51b4dfe5f1804abf9afc46"
 dependencies = [
  "bindgen",
  "cc",
+ "tinyrlibc",
 ]
 
 [[package]]
@@ -2043,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "lpc55-hal"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e86e4e491dd3f8e07e7ba6de4aace716459ddefebd05743b2cb67b6a566d3c"
+checksum = "1b5eeac224f2ed643cdd682ad20ed018af5c08963a5667906d658eb18f3b8c44"
 dependencies = [
  "block-buffer",
  "cipher",
@@ -2149,6 +2151,7 @@ dependencies = [
  "ctaphid-dispatch",
  "delog",
  "interchange",
+ "littlefs2-sys",
  "memory-regions",
  "nrf52840-hal",
  "nrf52840-pac",
@@ -2326,8 +2329,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opcard"
-version = "1.7.0"
-source = "git+https://github.com/Nitrokey/opcard-rs?tag=v1.7.0#2b94d6aa0d1d533e01997b61332b229247e41c49"
+version = "1.8.0"
+source = "git+https://github.com/Nitrokey/opcard-rs?tag=v1.8.0#2cf214a95ccbdd8c1f5dbdd286f5381526c68ee2"
 dependencies = [
  "admin-app",
  "apdu-app",
@@ -2862,9 +2865,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "se05x"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577dd859bde220795c4afca496d850c62c794e72b49c475d3febceca329c718a"
+checksum = "d33abe6f15b9695e82eef4d45391dd476d1011b54914fa314e3d27c68a59e79a"
 dependencies = [
  "aes",
  "bitflags 2.9.4",
@@ -3362,6 +3365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyrlibc"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af8adde15cc59c61328c5d709b41b8464522a733033584d33def687b26bd009"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,9 +3526,9 @@ dependencies = [
 
 [[package]]
 name = "trussed"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400475917c40f07716c84b201a363012f6c9b1acdb4b38a5ed05e227539cd05c"
+checksum = "7b5782830442198b88886b5e165b61b4626cda85316b7912e563950e65fa5e20"
 dependencies = [
  "aead",
  "aes",
@@ -3559,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "trussed-auth-backend"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddba6d39b34a5732dbc1b8938eff7a4e95e1a1ac2e28a91bcdac6d20af682fd6"
+checksum = "32af78560d0e3e415b86b34bfdf7abdfc00e0117f401e2f5f5048f58d6f95540"
 dependencies = [
  "cbor-smol",
  "chacha20poly1305",
@@ -3648,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "trussed-rsa-alloc"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959e4ed92c9a39f3af0e41605422574deb067a4b52c2d0b3ec651a7769909e1b"
+checksum = "7aacf018840cb3ad6cb18ab3fbf9dc56e686e2c00e46fabccc4bc6436ce19374"
 dependencies = [
  "delog",
  "heapless-bytes",
@@ -3675,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "trussed-se050-backend"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8883814fc9e3a7b5ab94548fd26bc33ca0aeebbedc6c13f66849aa15dc187188"
+checksum = "75b9f1a4147d9a0b674a7121bccfb871c7538fe85416212fab21de92af72ce49"
 dependencies = [
  "bitflags 2.9.4",
  "cbor-smol",
@@ -3726,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "trussed-staging"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e6deeae8561b46439244e293ca8b280e803a6c0ba37bdd6716ce5fb7a1afa4"
+checksum = "267ecfbae9d6f86498ea3a9635a6b3d3897d2591efa7f398cabd21390cf5535d"
 dependencies = [
  "aead",
  "chacha20poly1305",
@@ -3756,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "trussed-usbip"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f180e84c51b87ea68e90ad7c13703f80b9f099e293e008c075a46ae823e227cc"
+checksum = "f097fde89905249b0530e502b90e3b83392eb6c909bb5b4a60b9718d1bda536a"
 dependencies = [
  "apdu-dispatch",
  "ctaphid-dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ resolver = "2"
 version = "1.9.0-rc.1"
 
 [workspace.dependencies]
-littlefs2 = "0.7"
-trussed = { version = "=0.2.0-rc.1", default-features = false }
+littlefs2 = "0.8"
+trussed = { version = "0.2", default-features = false }
 trussed-core = "0.2"
 
 [patch.crates-io]
@@ -25,8 +25,7 @@ memory-regions = { path = "components/memory-regions" }
 p256-cortex-m4  = { git = "https://github.com/ycrypto/p256-cortex-m4.git", rev = "cdb31e12594b4dc1f045b860a885fdc94d96aee2" }
 
 # applications
-admin-app = { git = "https://github.com/Nitrokey/admin-app.git", tag = "v0.1.0-nitrokey.22" }
-opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.7.0" }
+opcard = { git = "https://github.com/Nitrokey/opcard-rs", tag = "v1.8.0" }
 piv-authenticator = { git = "https://github.com/trussed-dev/piv-authenticator.git", tag = "v0.6.0" }
 secrets-app = { git = "https://github.com/Nitrokey/trussed-secrets-app", tag = "v0.15.0" }
 

--- a/components/apps/Cargo.toml
+++ b/components/apps/Cargo.toml
@@ -16,17 +16,17 @@ se05x = { version = "0.4", optional = true}
 serde = { version = "1.0.180", default-features = false }
 trussed = { workspace = true, features = ["crypto-client", "filesystem-client", "management-client", "serde-extensions", "ui-client"] }
 trussed-core.workspace = true
-trussed-usbip = { version = "=0.1.0-rc.1", default-features = false, features = ["ctaphid"], optional = true }
+trussed-usbip = { version = "0.1", default-features = false, features = ["ctaphid"], optional = true }
 usbd-ctaphid = { version = "0.4", optional = true }
 utils = { path = "../utils" }
 if_chain = "1.0.2"
 littlefs2-core = "0.1"
 
 # Backends
-trussed-auth-backend = { version = "=0.2.0-rc.1", optional = true }
-trussed-rsa-alloc = { version = "=0.5.0-rc.1", optional = true }
-trussed-se050-backend = { version = "=0.8.0-rc.1", optional = true }
-trussed-staging = { version = "=0.5.0-rc.1", features = ["wrap-key-to-file", "chunked", "hkdf", "manage", "fs-info"] }
+trussed-auth-backend = { version = "0.2", optional = true }
+trussed-rsa-alloc = { version = "0.5", optional = true }
+trussed-se050-backend = { version = "0.8", optional = true }
+trussed-staging = { version = "0.5", features = ["wrap-key-to-file", "chunked", "hkdf", "manage", "fs-info"] }
 
 # Extensions
 trussed-auth = { version = "0.5", optional = true }
@@ -39,7 +39,7 @@ trussed-fs-info = "0.3.0"
 trussed-hpke = "0.3.0"
 
 # apps
-admin-app = "0.1.0"
+admin-app = "0.2"
 fido-authenticator = { version = "=0.4.0-rc.3", features = ["chunked", "dispatch", "credential-id-format-v2"], optional = true }
 ndef-app = { path = "../ndef-app", optional = true }
 secrets-app = { version = "0.15", features = ["apdu-dispatch", "ctaphid"], optional = true }

--- a/components/boards/Cargo.toml
+++ b/components/boards/Cargo.toml
@@ -15,8 +15,8 @@ embedded-hal = "0.2.3"
 embedded-time = "0.12"
 generic-array = "0.14"
 interchange = "0.3"
-littlefs2 = { version = "=0.7.0", features = ["c-stubs", "unstable-littlefs-patched"] }
-littlefs2-sys = "=0.3.2"
+littlefs2 = { version = "=0.8.0", features = ["c-stubs", "unstable-littlefs-patched"] }
+littlefs2-sys = "=0.4.0"
 memory-regions = { path = "../memory-regions" }
 nb = "1"
 nfc-device = { path = "../nfc-device" }
@@ -32,7 +32,7 @@ usbd-ctaphid = "0.4"
 utils = { path = "../utils" }
 
 # soc-lpc55
-lpc55-hal = { version = "0.5", optional = true }
+lpc55-hal = { version = "0.6", optional = true }
 lpc55-pac = { version = "0.5", optional = true }
 systick-monotonic = { version = "1.0.0", optional = true }
 
@@ -52,7 +52,7 @@ cortex-m-semihosting = { version = "0.3.5", optional = true }
 rtt-target = { version = "0.3", features = ["cortex-m"], optional = true }
 
 # se050
-se05x = { version = "0.4", optional = true }
+se05x = { version = "0.4.1", optional = true }
 
 trussed-manage = "0.3.0"
 
@@ -64,7 +64,7 @@ board-nk3am = ["soc-nrf52", "lfs-backup", "se05x/embedded-hal-v0.2.7"]
 board-nk3xn = ["soc-lpc55", "fm11nc08", "utils/storage", "se05x/embedded-hal-v0.2.7"]
 board-nkpk = ["board-nk3am", "utils/storage"]
 
-soc-lpc55 = ["lpc55-hal", "lpc55-pac", "se05x?/lpc55-v0.5", "systick-monotonic"]
+soc-lpc55 = ["lpc55-hal", "lpc55-pac", "se05x?/lpc55-v0.6", "systick-monotonic"]
 soc-nrf52 = ["embedded-storage", "nrf52840-hal", "nrf52840-pac", "se05x?/nrf"]
 
 log-all = []
@@ -80,7 +80,7 @@ log-semihosting = ["cortex-m-semihosting"]
 
 no-buttons = []
 no-delog = []
-no-encrypted-storage = ["lpc55-hal?/littlefs"]
+no-encrypted-storage = ["lpc55-hal?/littlefs2-v0.8"]
 format-filesystem = []
 provisioner = ["apps/provisioner-app"]
 se050 = ["se05x", "apps/se050"]

--- a/components/boards/src/store.rs
+++ b/components/boards/src/store.rs
@@ -24,8 +24,6 @@ const_ram_storage!(
     block_size = 256,
     block_count = 2 * 8192 / 256,
     lookahead_size_ty = littlefs2::consts::U1,
-    filename_max_plus_one_ty = littlefs2::consts::U256,
-    path_max_plus_one_ty = littlefs2::consts::U256,
 );
 
 pub struct StoreResources<B: Board> {
@@ -137,6 +135,8 @@ impl<B: Board> Store for RunnerStore<B> {
         unsafe { Self::pointers().vfs.assume_init() }
     }
 }
+
+unsafe impl<B> Send for RunnerStore<B> {}
 
 pub fn init_store<B: Board>(
     resources: &'static mut StoreResources<B>,
@@ -455,8 +455,6 @@ mod tests {
         block_size = 4096,
         block_count = FULL_EXTERNAL_STORAGE_BLOCK_COUNT,
         lookahead_size_ty = littlefs2::consts::U1,
-        filename_max_plus_one_ty = littlefs2::consts::U1,
-        path_max_plus_one_ty = littlefs2::consts::U2,
     );
 
     const_ram_storage!(
@@ -468,8 +466,6 @@ mod tests {
         block_size = 4096,
         block_count = CROPPED_EXTERNAL_STORAGE_BLOCK_COUNT,
         lookahead_size_ty = littlefs2::consts::U1,
-        filename_max_plus_one_ty = littlefs2::consts::U1,
-        path_max_plus_one_ty = littlefs2::consts::U2,
     );
 
     const_ram_storage!(
@@ -481,8 +477,6 @@ mod tests {
         block_size = 4096,
         block_count = 0x20_0000 / 4096,
         lookahead_size_ty = littlefs2::consts::U1,
-        filename_max_plus_one_ty = littlefs2::consts::U1,
-        path_max_plus_one_ty = littlefs2::consts::U2,
     );
 
     impl<EfsStorage: Storage + 'static> Board for TestBoard<EfsStorage> {

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -38,7 +38,7 @@ nrf52840-hal = { version = "0.15.1", optional = true }
 nrf52840-pac = { version = "0.11", optional = true }
 
 ### LPC55 specific dependencies
-lpc55-hal = { version = "0.5", optional = true }
+lpc55-hal = { version = "0.6", optional = true }
 lpc55-pac = { version = "0.5", optional = true }
 nb = { version = "1", optional = true }
 systick-monotonic = { version = "1.0.0", optional = true }
@@ -47,7 +47,7 @@ systick-monotonic = { version = "1.0.0", optional = true }
 embedded-alloc = { version = "0.6.0", optional = true }
 
 # littlefs2-sys for intrinsics feature
-littlefs2-sys = { version = "0.3", optional = true }
+littlefs2-sys = { version = "0.4", features = ["tinyrlibc"] }
 
 [build-dependencies]
 memory-regions = "1"

--- a/runners/nkpk/Cargo.toml
+++ b/runners/nkpk/Cargo.toml
@@ -14,6 +14,7 @@ cortex-m-rtic = "1.0"
 ctaphid-dispatch = "0.4"
 delog = "0.1"
 interchange = "0.3"
+littlefs2-sys = { version = "0.4", features = ["tinyrlibc"] }
 nrf52840-hal = "0.15.1"
 nrf52840-pac = "0.11"
 utils = { path = "../../components/utils", features = ["storage"] }

--- a/runners/usbip/Cargo.toml
+++ b/runners/usbip/Cargo.toml
@@ -19,7 +19,7 @@ rand_core = { version = "0.6.4", features = ["getrandom"] }
 signal-hook = { version = "0.3.17", default-features = false }
 trussed.workspace = true
 trussed-core.workspace = true
-trussed-usbip = { version = "=0.1.0-rc.1", default-features = false, features = ["ctaphid"] }
+trussed-usbip = { version = "0.1", default-features = false, features = ["ctaphid"] }
 utils = { path = "../../components/utils", features = ["log-all"] }
 
 [build-dependencies]

--- a/runners/usbip/src/store.rs
+++ b/runners/usbip/src/store.rs
@@ -27,8 +27,6 @@ const_ram_storage!(
     block_size = 4096,
     block_count = 0x2_0000 / 4096,
     lookahead_size_ty = U1,
-    filename_max_plus_one_ty = U256,
-    path_max_plus_one_ty = U256,
 );
 const_ram_storage!(VolatileStorage, IFS_STORAGE_SIZE);
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -338,3 +338,45 @@ delta = "0.1.9 -> 0.1.11"
 who = "Robin Krahl <robin@nitrokey.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.1 -> 0.1.3"
+
+[[trusted.admin-app]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/admin-app"
+start = "2026-07-22"
+end = "2027-07-23"
+
+[[trusted.trussed]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed"
+start = "2026-07-22"
+end = "2027-07-23"
+
+[[trusted.trussed-auth-backend]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-auth"
+start = "2026-07-23"
+end = "2027-07-23"
+
+[[trusted.trussed-rsa-alloc]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-rsa-backend"
+start = "2026-07-23"
+end = "2027-07-23"
+
+[[trusted.trussed-se050-backend]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:Nitrokey/trussed-se050-backend"
+start = "2026-07-23"
+end = "2027-07-23"
+
+[[trusted.trussed-staging]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+start = "2026-07-23"
+end = "2027-07-23"
+
+[[trusted.trussed-usbip]]
+criteria = "safe-to-deploy"
+trusted-publisher = "github:trussed-dev/pc-usbip-runner"
+start = "2026-07-23"
+end = "2027-07-23"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -13,10 +13,6 @@ url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
-[policy.admin-app]
-audit-as-crates-io = false
-notes = "pinned to a reviewed revision"
-
 [policy.collect-license-info]
 criteria = "safe-to-run"
 notes = "relaxed to reduce initial efforts"
@@ -729,6 +725,10 @@ criteria = "safe-to-run"
 version = "1.1.9"
 criteria = "safe-to-run"
 
+[[exemptions.tinyrlibc]]
+version = "0.5.1"
+criteria = "safe-to-run"
+
 [[exemptions.toml]]
 version = "0.8.23"
 criteria = "safe-to-run"
@@ -755,10 +755,6 @@ criteria = "safe-to-run"
 
 [[exemptions.toml_write]]
 version = "0.1.2"
-criteria = "safe-to-run"
-
-[[exemptions.trussed-rsa-alloc]]
-version = "0.5.0-rc.1"
 criteria = "safe-to-run"
 
 [[exemptions.typed-builder]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,11 @@
 
 # cargo-vet imports lock
 
+[[publisher.admin-app]]
+version = "0.2.0"
+when = "2026-07-22"
+trusted-publisher = "github:trussed-dev/admin-app"
+
 [[publisher.apdu-app]]
 version = "0.2.0"
 when = "2026-03-25"
@@ -56,8 +61,8 @@ when = "2025-09-25"
 trusted-publisher = "github:trussed-dev/iso7816"
 
 [[publisher.littlefs2]]
-version = "0.7.0"
-when = "2026-03-09"
+version = "0.8.0"
+when = "2026-06-23"
 trusted-publisher = "github:trussed-dev/littlefs2"
 
 [[publisher.littlefs2-core]]
@@ -66,23 +71,33 @@ when = "2025-10-16"
 trusted-publisher = "github:trussed-dev/littlefs2"
 
 [[publisher.littlefs2-sys]]
-version = "0.3.2"
-when = "2026-03-03"
+version = "0.4.0"
+when = "2026-06-22"
 trusted-publisher = "github:trussed-dev/littlefs2-sys"
 
 [[publisher.lpc55-hal]]
-version = "0.5.0"
-when = "2026-03-20"
+version = "0.6.0"
+when = "2026-07-15"
 trusted-publisher = "github:lpc55/lpc55-hal"
 
 [[publisher.se05x]]
-version = "0.4.0"
-when = "2026-03-31"
+version = "0.4.1"
+when = "2026-07-23"
 trusted-publisher = "github:Nitrokey/se05x"
+
+[[publisher.trussed]]
+version = "0.2.0"
+when = "2026-07-22"
+trusted-publisher = "github:trussed-dev/trussed"
 
 [[publisher.trussed-auth]]
 version = "0.5.0"
 when = "2026-03-25"
+trusted-publisher = "github:trussed-dev/trussed-auth"
+
+[[publisher.trussed-auth-backend]]
+version = "0.2.0"
+when = "2026-07-23"
 trusted-publisher = "github:trussed-dev/trussed-auth"
 
 [[publisher.trussed-chunked]]
@@ -115,15 +130,35 @@ version = "0.3.0"
 when = "2026-03-23"
 trusted-publisher = "github:trussed-dev/trussed-staging"
 
+[[publisher.trussed-rsa-alloc]]
+version = "0.5.0"
+when = "2026-07-23"
+trusted-publisher = "github:trussed-dev/trussed-rsa-backend"
+
 [[publisher.trussed-rsa-types]]
 version = "0.2.0"
 when = "2026-03-25"
 trusted-publisher = "github:trussed-dev/trussed-rsa-backend"
 
+[[publisher.trussed-se050-backend]]
+version = "0.8.0"
+when = "2026-07-23"
+trusted-publisher = "github:Nitrokey/trussed-se050-backend"
+
 [[publisher.trussed-se050-manage]]
 version = "0.3.0"
 when = "2026-03-25"
 trusted-publisher = "github:Nitrokey/trussed-se050-backend"
+
+[[publisher.trussed-staging]]
+version = "0.5.0"
+when = "2026-07-23"
+trusted-publisher = "github:trussed-dev/trussed-staging"
+
+[[publisher.trussed-usbip]]
+version = "0.1.0"
+when = "2026-07-23"
+trusted-publisher = "github:trussed-dev/pc-usbip-runner"
 
 [[publisher.trussed-wrap-key-to-file]]
 version = "0.3.0"

--- a/utils/fido2-mds/requirements.txt
+++ b/utils/fido2-mds/requirements.txt
@@ -4,19 +4,19 @@ cairocffi==1.7.1
     # via cairosvg
 cairosvg==2.9.0
     # via -r requirements.in
-cffi==2.0.0
+cffi==2.1.0
     # via
     #   cairocffi
     #   cryptography
-cryptography==48.0.0
+cryptography==49.0.0
     # via fido2
 cssselect2==0.9.0
     # via cairosvg
 defusedxml==0.7.1
     # via cairosvg
-fido2==2.2.0
+fido2==2.2.1
     # via -r requirements.in
-pillow==12.2.0
+pillow==12.3.0
     # via cairosvg
 pycparser==3.0
     # via cffi

--- a/utils/fido2-mds/uv.toml
+++ b/utils/fido2-mds/uv.toml
@@ -1,0 +1,1 @@
+exclude-newer = "7 days"


### PR DESCRIPTION
This PR updates the firmware to trussed v0.2 and updates the Python dependencies for `fido2-mds`.

Depends on:
- https://github.com/Nitrokey/opcard-rs/pull/230