### PR TITLE
Add SoloKeys Solo2 support (board-solo2)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,23 @@ check-components:
   script:
     - make check-components
 
+# Community-maintained SoloKeys Solo2 support (see docs/solo2.md).
+# Non-blocking (allow_failure): a Solo2 breakage must never block a Nitrokey
+# device release. It only surfaces as a warning for the Solo2 code owners.
+build-solo2:
+  image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+  tags:
+    - docker
+  stage: build
+  allow_failure: true
+  script:
+    - rustup target add thumbv8m.main-none-eabi
+    - make -C runners/embedded build-solo2
+    - make -C runners/embedded build-solo2 FEATURES=develop
+
 lint:
   image: registry.git.nitrokey.com/nitrokey/nitrokey-3-firmware/nitrokey3:latest
   rules:

--- a/components/apps/src/lib.rs
+++ b/components/apps/src/lib.rs
@@ -498,10 +498,11 @@ const fn validate_mechanisms() {
         if contains(trussed_se050_backend::MECHANISMS, mechanism) {
             continue;
         }
-        // The usbip runner does not have the mechanisms normally provided by the se050 backend.
+        // Some targets do not have the se050 backend that normally provides these mechanisms:
+        // the usbip runner, and hardware without an SE050 secure element (e.g. the Solo2).
         // Until there is a backend implementing them in software, we ignore them and return an
         // error at runtime.
-        #[cfg(feature = "trussed-usbip")]
+        #[cfg(any(feature = "trussed-usbip", not(feature = "se050")))]
         if contains(
             &[
                 Mechanism::BrainpoolP256R1,
@@ -516,6 +517,11 @@ const fn validate_mechanisms() {
                 Mechanism::P521Prehashed,
                 Mechanism::Secp256k1,
                 Mechanism::Secp256k1Prehashed,
+                // Raw RSA is only provided by the se050 backend (or the usbip runner's
+                // `trussed-rsa-alloc/raw`); PKCS#1 v1.5 RSA remains covered by backend-rsa.
+                Mechanism::Rsa2048Raw,
+                Mechanism::Rsa3072Raw,
+                Mechanism::Rsa4096Raw,
             ],
             mechanism,
         ) {

--- a/components/boards/Cargo.toml
+++ b/components/boards/Cargo.toml
@@ -62,6 +62,9 @@ littlefs2-core = { version = "0.1", features = ["debug-error"] }
 [features]
 board-nk3am = ["soc-nrf52", "lfs-backup", "se05x/embedded-hal-v0.2.7"]
 board-nk3xn = ["soc-lpc55", "fm11nc08", "utils/storage", "se05x/embedded-hal-v0.2.7"]
+# SoloKeys Solo2: reuses the LPC55 (nk3xn) board but with capacitive touch
+# buttons and without the SE050 secure element (no `se050`, no `se05x`).
+board-solo2 = ["soc-lpc55", "fm11nc08", "utils/storage"]
 board-nkpk = ["board-nk3am", "utils/storage"]
 
 soc-lpc55 = ["lpc55-hal", "lpc55-pac", "se05x?/lpc55-v0.6", "systick-monotonic"]

--- a/components/boards/src/flash.rs
+++ b/components/boards/src/flash.rs
@@ -16,6 +16,19 @@ const FLASH_PROPERTIES: FlashProperties = FlashProperties {
     _cont: 0, /* should be 6, but device doesn't report those */
 };
 
+/// External-flash JEDEC IDs (manufacturer code + 2-byte device id) accepted by
+/// the firmware. All are 2 MB SPI-NOR parts with a compatible command set.
+const ACCEPTED_JEDEC: &[[u8; 3]] = &[
+    // GigaDevice GD25Q16 (Nitrokey 3).
+    FLASH_PROPERTIES.jedec,
+    // The Solo2 additionally ships pin- and command-compatible Winbond W25Q16JV
+    // parts (manufacturer 0xEF), which the Nitrokey 3 does not.
+    #[cfg(feature = "board-solo2")]
+    [0xef, 0x40, 0x15], // Winbond W25Q16JV
+    #[cfg(feature = "board-solo2")]
+    [0xef, 0x70, 0x15], // Winbond W25Q16JV-DTR
+];
+
 // defines how much space we leave untouched at the end
 pub const SPARE_LEN: usize = 4096 * 32; // 128kb
 
@@ -112,9 +125,9 @@ where
         let mut flash = spi_memory::series25::Flash::init(spim, cs).ok()?;
         let jedec_id = flash.read_jedec_id().ok()?;
         info!("Ext. Flash: {:?}", jedec_id);
-        if jedec_id.mfr_code() != FLASH_PROPERTIES.jedec[0]
-            || jedec_id.device_id() != &FLASH_PROPERTIES.jedec[1..]
-        {
+        let device_id = jedec_id.device_id();
+        let id = [jedec_id.mfr_code(), device_id[0], device_id[1]];
+        if !ACCEPTED_JEDEC.contains(&id) {
             error_now!("Unknown Ext. Flash: {:?}", jedec_id);
             None
         } else {

--- a/components/boards/src/lib.rs
+++ b/components/boards/src/lib.rs
@@ -14,7 +14,9 @@ pub mod ui;
 
 #[cfg(feature = "board-nk3am")]
 pub mod nk3am;
-#[cfg(feature = "board-nk3xn")]
+// The Solo2 reuses the LPC55 board implementation of the Nitrokey 3 (`nk3xn`),
+// so the module is compiled for both targets.
+#[cfg(any(feature = "board-nk3xn", feature = "board-solo2"))]
 pub mod nk3xn;
 #[cfg(feature = "board-nkpk")]
 pub mod nkpk;

--- a/components/boards/src/nk3xn.rs
+++ b/components/boards/src/nk3xn.rs
@@ -25,6 +25,10 @@ use utils::OptionalStorage;
 use crate::{flash::ExtFlashStorage, soc::lpc55::Lpc55, Board};
 
 pub mod button;
+/// Capacitive touch buttons, used by the `board-solo2` target instead of the
+/// single-GPIO [`button`] used by the Nitrokey 3.
+#[cfg(feature = "board-solo2")]
+pub mod button_touch;
 pub mod led;
 pub mod nfc;
 pub mod prince;
@@ -61,7 +65,10 @@ impl Board for NK3xN {
     type Resources = ();
 
     type NfcDevice = NfcChip;
+    #[cfg(not(feature = "board-solo2"))]
     type Buttons = button::ThreeButtons;
+    #[cfg(feature = "board-solo2")]
+    type Buttons = button_touch::ThreeButtons;
     type Led = led::RgbLed;
 
     type InternalStorage = InternalFlashStorage;
@@ -76,9 +83,19 @@ impl Board for NK3xN {
     #[cfg(not(feature = "se050"))]
     type Se050Timer = ();
 
+    #[cfg(not(feature = "board-solo2"))]
     const BOARD_NAME: &'static str = "nk3xn";
+    #[cfg(feature = "board-solo2")]
+    const BOARD_NAME: &'static str = "solo2";
     const HAS_NFC: bool = true;
 }
+
+/// The SoloKeys Solo2 shares the LPC55 board implementation with the Nitrokey 3
+/// (`NK3xN`), differing only in the button hardware (capacitive touch instead of
+/// a single GPIO) and the absence of the SE050 secure element.  Both are
+/// selected at compile time via the `board-nk3xn` / `board-solo2` features.
+#[cfg(feature = "board-solo2")]
+pub use NK3xN as Solo2;
 
 pub type InternalFlashStorage = InternalFilesystem;
 pub type ExternalFlashStorage = OptionalStorage<ExtFlashStorage<Spi, FlashCs>>;

--- a/components/boards/src/nk3xn/button_touch.rs
+++ b/components/boards/src/nk3xn/button_touch.rs
@@ -1,0 +1,182 @@
+//! Capacitive touch buttons for the SoloKeys Solo2.
+//!
+//! The Solo2 uses three capacitive touch pads driven by the LPC55 ADC together
+//! with a DMA channel and two timers, unlike the Nitrokey 3 which uses a single
+//! GPIO button (see [`super::button`]).  This is a port of the `solo2` board
+//! driver from the upstream `solokeys/solo2` repository, adapted to this repo's
+//! [`crate::ui::buttons`] traits.
+use core::convert::Infallible;
+
+use lpc55_hal::{
+    drivers::{
+        pins,
+        touch::{ButtonPins, Compare, Edge as TouchEdge, TouchSensor, TouchSensorChannel},
+    },
+    peripherals::{adc, ctimer, dma},
+    typestates::{pin::PinId, ClocksSupportTouchToken},
+    Enabled, Gpio, Iocon,
+};
+use trussed_core::types::consent;
+
+use crate::ui::buttons::{Button, Edge, Press, UserPresence};
+
+pub type ChargeMatchPin = pins::Pio1_16;
+pub type ButtonTopPin = pins::Pio0_23;
+pub type ButtonBotPin = pins::Pio0_31;
+pub type ButtonMidPin = pins::Pio0_15;
+
+type Adc = adc::Adc<Enabled>;
+type Dma = dma::Dma<Enabled>;
+
+type AdcTimer = ctimer::Ctimer1<Enabled>;
+type SampleTimer = ctimer::Ctimer2<Enabled>;
+
+pub type ThreeButtons = SoloThreeTouchButtons<ButtonTopPin, ButtonBotPin, ButtonMidPin>;
+
+pub struct SoloThreeTouchButtons<P1, P2, P3>
+where
+    P1: PinId,
+    P2: PinId,
+    P3: PinId,
+{
+    touch_sensor: TouchSensor<P1, P2, P3>,
+}
+
+impl SoloThreeTouchButtons<ButtonTopPin, ButtonBotPin, ButtonMidPin> {
+    pub fn new(
+        adc: Adc,
+        adc_timer: AdcTimer,
+        sample_timer: SampleTimer,
+        dma: &mut Dma,
+        token: ClocksSupportTouchToken,
+        gpio: &mut Gpio<Enabled>,
+        iocon: &mut Iocon<Enabled>,
+    ) -> SoloThreeTouchButtons<ButtonTopPin, ButtonBotPin, ButtonMidPin> {
+        let top = ButtonTopPin::take().unwrap().into_analog_input(iocon, gpio);
+        let mid = ButtonMidPin::take().unwrap().into_analog_input(iocon, gpio);
+        let bot = ButtonBotPin::take().unwrap().into_analog_input(iocon, gpio);
+        let charge_match = ChargeMatchPin::take().unwrap().into_match_output(iocon);
+        let button_pins = ButtonPins(top, bot, mid);
+        let touch_sensor = TouchSensor::new(
+            [12_000, 12_000, 12_000],
+            5,
+            adc,
+            adc_timer,
+            sample_timer,
+            charge_match,
+            button_pins,
+        );
+        let touch_sensor = touch_sensor.enabled(dma, token);
+        Self { touch_sensor }
+    }
+
+    /// Map a [`Button`] to its touch channel and read the debounced state.
+    fn button_get_state(&self, button: Button, ctype: Compare) -> bool {
+        let channel = match button {
+            Button::A => TouchSensorChannel::Channel1,
+            Button::B => TouchSensorChannel::Channel2,
+            Button::Middle => TouchSensorChannel::Channel3,
+        };
+        self.touch_sensor.get_state(channel, ctype).is_active
+    }
+
+    fn button_has_edge(&self, button: Button, edge_type: TouchEdge) -> bool {
+        let channel = match button {
+            Button::A => TouchSensorChannel::Channel1,
+            Button::B => TouchSensorChannel::Channel2,
+            Button::Middle => TouchSensorChannel::Channel3,
+        };
+        self.touch_sensor.has_edge(channel, edge_type)
+    }
+
+    fn button_reset_state(&self, button: Button, offset: i32) {
+        let channel = match button {
+            Button::A => TouchSensorChannel::Channel1,
+            Button::B => TouchSensorChannel::Channel2,
+            Button::Middle => TouchSensorChannel::Channel3,
+        };
+        self.touch_sensor.reset_results(channel, offset);
+    }
+}
+
+impl Press for SoloThreeTouchButtons<ButtonTopPin, ButtonBotPin, ButtonMidPin> {
+    fn is_pressed(&mut self, button: Button) -> bool {
+        self.button_get_state(button, Compare::BelowThreshold)
+    }
+
+    fn is_released(&mut self, button: Button) -> bool {
+        self.button_get_state(button, Compare::AboveThreshold)
+    }
+}
+
+impl Edge for SoloThreeTouchButtons<ButtonTopPin, ButtonBotPin, ButtonMidPin> {
+    fn wait_for_new_press(&mut self, button: Button) -> nb::Result<(), Infallible> {
+        if self.button_has_edge(button, TouchEdge::Falling) {
+            // Erase edge with pressed status.
+            self.button_reset_state(button, -1);
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    fn wait_for_new_release(&mut self, button: Button) -> nb::Result<(), Infallible> {
+        if self.button_has_edge(button, TouchEdge::Rising) {
+            self.button_reset_state(button, 1);
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    fn wait_for_any_new_press(&mut self) -> nb::Result<Button, Infallible> {
+        if self.wait_for_new_press(Button::A).is_ok() {
+            Ok(Button::A)
+        } else if self.wait_for_new_press(Button::B).is_ok() {
+            Ok(Button::B)
+        } else if self.wait_for_new_press(Button::Middle).is_ok() {
+            Ok(Button::Middle)
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    fn wait_for_any_new_release(&mut self) -> nb::Result<Button, Infallible> {
+        if self.wait_for_new_release(Button::A).is_ok() {
+            Ok(Button::A)
+        } else if self.wait_for_new_release(Button::B).is_ok() {
+            Ok(Button::B)
+        } else if self.wait_for_new_release(Button::Middle).is_ok() {
+            Ok(Button::Middle)
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    fn wait_for_new_squeeze(&mut self) -> nb::Result<(), Infallible> {
+        let a = self.button_has_edge(Button::A, TouchEdge::Falling);
+        let b = self.button_has_edge(Button::B, TouchEdge::Falling);
+        if a && b {
+            self.button_reset_state(Button::A, -1);
+            self.button_reset_state(Button::B, -1);
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+}
+
+impl UserPresence for SoloThreeTouchButtons<ButtonTopPin, ButtonBotPin, ButtonMidPin> {
+    fn check_user_presence(&mut self) -> consent::Level {
+        let state = self.state();
+        if self.wait_for_any_new_press().is_ok() {
+            if state.a && state.b {
+                consent::Level::Strong
+            } else {
+                consent::Level::Normal
+            }
+        } else {
+            consent::Level::None
+        }
+    }
+}

--- a/docs/solo2.md
+++ b/docs/solo2.md
@@ -1,0 +1,172 @@
+# Running the firmware on a SoloKeys Solo2
+
+This document describes the `board-solo2` target, which builds this firmware for
+the [SoloKeys Solo2][solo2].  It is **experimental** and **not an official
+Nitrokey product configuration**.
+
+[solo2]: https://github.com/solokeys/solo2
+
+## Why this works
+
+The Solo2 and the LPC55 variant of the Nitrokey 3 (`nk3xn`) are built around the
+**same NXP LPC55S69 microcontroller**, and this firmware descends from the same
+[`solokeys/solo2`][solo2] code base.  The two boards differ in only two places:
+
+| Subsystem      | Nitrokey 3 (`nk3xn`)              | Solo2 (`board-solo2`)                    |
+| -------------- | -------------------------------- | ---------------------------------------- |
+| Buttons        | single GPIO (`Pio0_31`)          | three capacitive touch pads (ADC + DMA)  |
+| Secure element | SE050 (I2C5)                     | **none**                                 |
+| RGB LED        | `Pio0_5` / `Pio1_21` / `Pio1_19` | identical                                |
+| NFC            | FM11NC08 (SPI, CS `Pio1_20`)     | identical                                |
+| External flash | SPI (`Pio0_28/24/25`, CS `Pio0_13`) | identical                             |
+
+Therefore `board-solo2` reuses the entire `nk3xn` board implementation and only:
+
+* selects the capacitive touch button driver
+  ([`boards::nk3xn::button_touch`](../components/boards/src/nk3xn/button_touch.rs),
+  ported from the upstream `solo2` board), and
+* disables the `se050` feature (there is no secure element to talk to).
+
+The touch buttons use `Ctimer1` (charge/sample trigger), `Ctimer2` (sample
+correlation), the ADC and one DMA channel.  On the Nitrokey 3 `Ctimer2` drives
+the SE050 delay timer; on the Solo2 it is free because there is no SE050.
+
+## Identity
+
+The device keeps the **Nitrokey 3 USB identity** (VID `0x20A0`, PID `0x42B2`),
+so it is managed with `nitropy nk3` and the standard tooling, not the SoloKeys
+`solo2` CLI.
+
+## Building
+
+```
+$ rustup target add thumbv8m.main-none-eabi
+$ make -C runners/embedded build-solo2
+```
+
+The artifacts land in `runners/embedded/artifacts/runner-lpc55-solo2.{elf,bin}`.
+
+A development build (no encrypted storage / secure boot, useful for first
+bring-up) is:
+
+```
+$ make -C runners/embedded build-solo2 FEATURES=develop
+```
+
+## Flashing (development)
+
+Flashing unsigned firmware requires the LPC55 ROM bootloader (ISP mode) and a
+device whose **CMPA is not sealed**.
+
+> **Warning — sealed devices.** A production Solo2 provisioned with secure boot
+> and a sealed CMPA will refuse foreign firmware, and CMPA sealing is
+> irreversible.  Only devices with an open/unsealed CMPA (e.g. a Solo2 "Hacker"
+> or a self-provisioned unit) can be reflashed.
+
+> **Secure boot must be disabled (or you must self-sign).** A Solo2 ships with
+> `secure-boot-enabled` set to the SoloKeys root of trust, and it *is* enforced
+> even when the CMPA is unsealed: an unsigned build like this one will not boot.
+> On a Hacker (unsealed) you can turn it off — write a CMPA with
+> `secure-boot-enabled: false` via `lpc55 configure factory-settings` — flash,
+> and turn it back on later; this is reversible while `seal` stays `false`.
+> To keep secure boot *on* with this firmware you must run your own root of
+> trust: generate your keys, sign the image (NXP `spsdk`/`nxpimage`), and write
+> your ROTKH into the CMPA — optionally keeping the SoloKeys root in a spare RoT
+> slot so official releases still boot.  The LPC55 firmware version is also an
+> anti-rollback monotonic counter, so a signed image must declare a version at
+> least as high as the one currently recorded.
+
+1. Put the Solo2 into LPC55 ROM bootloader mode (`solo2 program bootloader`, or
+   the physical bootloader-pin method while plugging in).
+2. Confirm it is visible: `lpc55 ls`.
+3. Flash the firmware you built. Write the artifact directly:
+
+   ```
+   $ lpc55 write-flash runners/embedded/artifacts/runner-lpc55-solo2.bin
+   $ lpc55 reboot
+   ```
+
+   > **Do not use `make -C utils/lpc55-builder bl-flash` to flash a build with
+   > uncommitted changes.** That target has a `build:` prerequisite that
+   > recompiles the firmware from the committed tree first, silently
+   > overwriting your `.bin`. Flash the artifact directly with `lpc55
+   > write-flash` (or commit your changes first).
+
+## Production provisioning (secure boot + encrypted storage + attestation)
+
+This mirrors the Nitrokey 3 flow in
+[`docs/lpc55-quickstart.md`](./lpc55-quickstart.md) and
+[`utils/lpc55-builder`](../utils/lpc55-builder); nothing here is Solo2-specific
+except the firmware binary/features you build.  These steps require the physical
+device, `lpc55` + `nitropy`, and your own signing material; the CMPA seal is
+**not reversible**.
+
+1. **Reset / open the device** and apply the development CMPA:
+   `make -C utils/lpc55-builder reset`.
+2. **Provision the keystore** (PRINCE region-2 key for encrypted internal
+   storage) using a provisioner build:
+   `make -C utils/lpc55-builder bl-provision-keystore`.
+3. **Apply the CMPA** (`bl-config-cmpa-develop`, and for a true release build a
+   secure-boot CMPA signed with your ROT keys — see the `# TODO: add secure
+   boot` marker in the builder Makefile, which is not yet implemented upstream).
+4. **Flash a provisioner firmware** and **provision the FIDO attestation key +
+   certificate** and the Trussed device key/cert
+   (`make -C utils/lpc55-builder fw-provision-certs`).  You need access to real
+   FIDO2 batch keys/certs for attestation to validate; without them
+   `nitropy nk3 test` reports an expected FIDO cert-hash mismatch.
+5. **Flash the final firmware**:
+   `make -C utils/lpc55-builder flash OUTPUT_BIN=.../runner-lpc55-solo2.bin`.
+6. **Seal the CMPA** to enforce secure boot (irreversible) — only once every
+   previous step is verified.
+
+Build the provisioner/final firmware for the Solo2 by passing the board target,
+e.g.:
+
+```
+$ make -C runners/embedded build-solo2 FEATURES=provisioner
+```
+
+## Status and caveats
+
+* **Verified on real Solo2 hardware** (a "Solo 2 Security Key" Hacker).  Both the
+  default **PRINCE-encrypted** build and the `develop` build boot with
+  `init_status 0` and the internal and external filesystems available; the
+  encrypted build is the correct one for a factory PRINCE-provisioned key (see
+  the storage note below).  Confirmed working end-to-end:
+  * USB enumerates as a Nitrokey 3; the **capacitive touch button** registers
+    user presence in real use.
+  * **FIDO2** advertises the full feature set (FIDO 2.0/2.1, `es256` + `eddsa`,
+    `hmac-secret`, resident keys, USB + NFC transports).
+  * **OATH/TOTP** works: an added credential survives a replug and generates
+    codes that match an independent TOTP implementation bit-for-bit.
+  * SE050 is correctly skipped; the only `nitropy nk3 test` failure is FIDO2
+    attestation (`x5c`), which needs provisioning — see below.
+  * The capacitive-touch thresholds (`[12_000, 12_000, 12_000]`, confidence
+    `5`), pin assignment and channel mapping are copied verbatim from the
+    official `solokeys/solo2` firmware.
+  * The touch clock requires the CPU to run at ≥96 MHz; this holds in active
+    (USB) mode, where the buttons are initialised.  In passive NFC mode the
+    buttons are not built (the ADC drives the clock controller), exactly as on
+    the Nitrokey 3.
+* **Storage mode: match the build to the key.**  A Solo2 that ships
+  PRINCE-provisioned needs the default **encrypted** build (`make build-solo2`,
+  `require_prince = true`).  The `develop` build adds `no-encrypted-storage`
+  (`require_prince = false`) and is for quick bring-up only — flashing the wrong
+  mode for the key's keystore is unsupported.  The encrypted build was verified
+  on a provisioned key: the internal filesystem is PRINCE-encrypted and the
+  `key_provisioned(PrinceRegion2)` assertion passes.
+* **External flash.**  The Solo2 ships Winbond W25Q16JV parts (JEDEC
+  manufacturer `0xEF`) rather than the GigaDevice GD25Q16 (`0xC8`) used by the
+  Nitrokey 3; both are accepted (see `components/boards/src/flash.rs`).
+* **FIDO2 requires provisioning.**  On an unprovisioned development build the
+  FIDO2 test fails with an `x5c` / certificate error because no attestation key
+  and certificate have been written.  This is expected; provision them via the
+  production flow above with real batch keys.
+* **No SE050 means no secure element and no SE050-only mechanisms.**  The
+  curves normally provided by the SE050 backend — P384, P521, the Brainpool
+  P256/P384/P512 family and Secp256k1 — are unavailable and return an error at
+  runtime (the same situation as the `usbip` runner).  The common mechanisms
+  used by FIDO2, PIV and OpenPGP (P256, Ed25519, X25519, RSA via
+  `backend-rsa`, AES, ChaCha8Poly1305, HMAC-SHA256, SHA256) are implemented by
+  Trussed itself and are unaffected.  Secrets that would normally be wrapped by
+  the SE050 are instead protected only by the PRINCE-encrypted internal flash.

--- a/docs/solo2.md
+++ b/docs/solo2.md
@@ -126,6 +126,122 @@ e.g.:
 $ make -C runners/embedded build-solo2 FEATURES=provisioner
 ```
 
+## Self-signed secure boot
+
+The `utils/lpc55-builder` flow above still carries a `# TODO: add secure boot`.
+If you want secure boot **now**, with your own root of trust, you can sign the
+firmware yourself using NXP's [spsdk](https://github.com/nxp-mcuxpresso/spsdk)
+(`nxpimage`/`nxpcrypto`, tested with 3.10) and turn it on via the CMPA.  This was
+verified end-to-end on a Solo2 Hacker.  The `lpc55 configure`/`lpc55 write-flash`
+steps need the device in the LPC55 ROM ISP (`nitropy nk3 reboot --bootloader`
+once a correctly signed image is installed, or the ROM's automatic fallback when
+no bootable image is present).
+
+**1. Build** `runners/embedded/artifacts/runner-lpc55-solo2.bin`:
+
+```
+$ make -C runners/embedded build-solo2
+```
+
+**2. Root key + a non-CA certificate** (the LPC55 rejects a CA cert as the last
+link of the signing chain):
+
+```
+$ nxpcrypto key generate -k rsa4096 -o root_key.pem
+$ openssl req -x509 -new -key root_key.pem -sha256 -days 3650 \
+      -outform DER -out root_cert.der \
+      -subj "/O=you/CN=Solo2 Secure Boot Root" \
+      -addext "basicConstraints=critical,CA:FALSE"
+```
+
+**3. Certificate block → RKTH.**  The LPC55 stores a hash of the 4-slot
+root-key table (the "RKTH") in the CMPA; with a single root that is the hash of
+your key:
+
+```
+$ cat > cert_block.yaml <<EOF
+family: lpc55s69
+revision: latest
+rootCertificate0File: root_cert.der
+mainRootCertId: 0
+containerOutputFile: cert_block.bin
+EOF
+$ nxpimage cert-block export -c cert_block.yaml   # prints "RKTH: <64 hex>"
+```
+
+There is **no multi-root shortcut**: the image embeds the whole root-key table
+and the CMPA stores its hash, so adding your key changes the RKTH and SoloKeys'
+pre-signed firmware no longer validates.  Single root = your key only.
+
+**4. Sign the firmware — TrustZone must stay enabled:**
+
+```
+$ cat > mbi.yaml <<EOF
+family: lpc55s69
+revision: latest
+outputImageExecutionTarget: xip
+outputImageAuthenticationType: signed
+outputImageExecutionAddress: 0
+inputImageFile: runners/embedded/artifacts/runner-lpc55-solo2.bin
+masterBootOutputFile: runner-lpc55-solo2.signed.bin
+enableTrustZone: true
+certBlock: cert_block.bin
+signer: type=file;file_path=root_key.pem
+EOF
+$ nxpimage mbi export -c mbi.yaml
+```
+
+> **`enableTrustZone: true` is mandatory.**  With `false`, the signed image marks
+> TrustZone-M as *disabled*; then "reboot to bootloader" (`boot_to_bootrom`, used
+> by `nitropy nk3 reboot --bootloader`) warm-jumps into the *secure* boot ROM at
+> `0x03000000`, which is unreachable while TrustZone is disabled — USB ISP never
+> enumerates and the device looks dead until a destructive recovery.  `true`
+> selects "TrustZone enabled, default settings" (no preset file), matching the
+> plain-image state, so the firmware is unchanged and reboot-to-bootloader keeps
+> working.  A plain unsigned `.bin` never disables TrustZone, which is why it
+> reboots fine.
+
+**5. Enable secure boot in the CMPA (reversible until sealed).**  Dump the
+factory CMPA first and edit only what you must, so every other field (including
+`customer-data`) keeps its factory value:
+
+```
+$ lpc55 pfr native > cmpa.yaml     # then edit the factory-settings block:
+#   secure-boot-configuration.secure-boot-enabled: true
+#   secure-boot-configuration.use-rsa4096-keys:    true
+#   rot-fingerprint: <RKTH from step 3>
+#   (leave `seal` unset so it stays reversible)
+$ lpc55 configure factory-settings -vvv cmpa.yaml
+```
+
+**6. Flash the signed image** (from now on, only `*.signed.bin`, never the raw
+`.bin`):
+
+```
+$ lpc55 write-flash runner-lpc55-solo2.signed.bin
+$ lpc55 reboot
+```
+
+The device now boots only firmware signed by your key, and
+`nitropy nk3 reboot --bootloader` re-enters the ROM normally.
+
+### Sealing (irreversible)
+
+Secure boot is enforced **whether or not the CMPA is sealed** — sealing only
+prevents *rewriting* the CMPA, i.e. it removes the escape hatch.  While unsealed
+you can always recover: re-enter the ROM ISP and write a CMPA with
+`secure-boot-enabled: false`, then flash the plain `.bin`.  Seal only after a
+signed image is confirmed booting and you no longer need reversibility:
+
+```
+$ lpc55 configure factory-settings -vvv cmpa.yaml   # with `seal: true` added
+```
+
+Once sealed, the CMPA can never change: a lost signing key, or an image whose
+build number is below the CFPA anti-rollback counter (`secure_firmware_version`,
+readable via `lpc55 pfr native`), bricks the device permanently.  **Do not seal a
+development key.**
+
 ## Status and caveats
 
 * **Verified on real Solo2 hardware** (a "Solo 2 Security Key" Hacker).  Both the

--- a/runners/embedded/Cargo.toml
+++ b/runners/embedded/Cargo.toml
@@ -83,6 +83,8 @@ alloc = ["embedded-alloc"]
 
 board-nk3am = ["boards/board-nk3am", "soc-nrf52", "se050"]
 board-nk3xn = ["boards/board-nk3xn", "soc-lpc55", "se050"]
+# SoloKeys Solo2: LPC55 board without the SE050 secure element (no `se050`).
+board-solo2 = ["boards/board-solo2", "soc-lpc55"]
 
 soc-nrf52 = ["nrf52840-hal", "nrf52840-pac"]
 soc-lpc55 = ["lpc55-hal", "lpc55-pac", "nb", "systick-monotonic"]

--- a/runners/embedded/Makefile
+++ b/runners/embedded/Makefile
@@ -9,6 +9,10 @@ else ifeq ($(BOARD), nk3xn)
   SOC := lpc55
   TARGET := thumbv8m.main-none-eabi
   LEGACY_BUILD_PROFILE := lpc55
+else ifeq ($(BOARD), solo2)
+  SOC := lpc55
+  TARGET := thumbv8m.main-none-eabi
+  LEGACY_BUILD_PROFILE := lpc55
 else ifneq ($(BOARD), )
   $(error Unsupported board $(BOARD))
 endif
@@ -81,6 +85,8 @@ GET_TARGET = $(shell echo $(@) | cut -d '-' -f 1)
 	$(MAKE) $(GET_TARGET) BOARD=nk3am FEATURES=$(FEATURES)
 %-nk3xn: $(ARTIFACTS)
 	$(MAKE) $(GET_TARGET) BOARD=nk3xn FEATURES=$(FEATURES)
+%-solo2: $(ARTIFACTS)
+	$(MAKE) $(GET_TARGET) BOARD=solo2 FEATURES=$(FEATURES)
 
 check-var-%:
 	@if [ -z '${${*}}' ]; then echo 'FAIL: var: $* required!!!' && exit 1; fi

--- a/runners/embedded/build.rs
+++ b/runners/embedded/build.rs
@@ -5,6 +5,9 @@ use utils::Soc;
 
 #[cfg(feature = "board-nk3xn")]
 const MEMORY_REGIONS: &MemoryRegions = &MemoryRegions::NK3XN;
+// The Solo2 uses the same LPC55S69 flash layout as the Nitrokey 3 (nk3xn).
+#[cfg(feature = "board-solo2")]
+const MEMORY_REGIONS: &MemoryRegions = &MemoryRegions::NK3XN;
 #[cfg(feature = "board-nk3am")]
 const MEMORY_REGIONS: &MemoryRegions = &MemoryRegions::NK3AM;
 

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -41,7 +41,10 @@ pub fn init_usb_nfc<B: Board>(
     nfc: Option<Iso14443<B::NfcDevice>>,
     nfc_rp: CcidResponder<'static>,
 ) -> UsbNfc<B> {
+    #[cfg(not(feature = "board-solo2"))]
     const USB_PRODUCT: &str = "Nitrokey 3";
+    #[cfg(feature = "board-solo2")]
+    const USB_PRODUCT: &str = "Nitrokey 3 (Solo2)";
     const USB_PRODUCT_ID: u16 = 0x42B2;
     boards::init::init_usb_nfc(
         resources,

--- a/runners/embedded/src/lib.rs
+++ b/runners/embedded/src/lib.rs
@@ -13,7 +13,8 @@ use utils::Version;
 
 delog::generate_macros!();
 
-#[cfg(feature = "board-nk3xn")]
+// Shared LPC55 runner glue, used by both the Nitrokey 3 (nk3xn) and the Solo2.
+#[cfg(any(feature = "board-nk3xn", feature = "board-solo2"))]
 pub mod nk3xn;
 
 #[cfg(not(any(feature = "soc-lpc55", feature = "soc-nrf52")))]

--- a/runners/embedded/src/nk3xn.rs
+++ b/runners/embedded/src/nk3xn.rs
@@ -29,6 +29,7 @@ pub fn init(
             hal.ctimer.2,
             hal.ctimer.3,
             hal.ctimer.4,
+            hal.dma,
             hal.pfr,
             secure_firmware_version,
             require_prince,

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -66,6 +66,11 @@ use utils::OptionalStorage;
 #[cfg(feature = "se050")]
 use {boards::nk3xn::TimerDelay, se05x::embedded_hal::Hal027};
 
+// Buttons differ per board: the Nitrokey 3 (nk3xn) uses a single GPIO button,
+// the Solo2 uses three capacitive touch pads.
+#[cfg(feature = "board-solo2")]
+use boards::nk3xn::button_touch::ThreeButtons;
+#[cfg(not(feature = "board-solo2"))]
 use boards::nk3xn::{button::ThreeButtons, ButtonsTimer};
 // The SE050 I2C bus only exists when the secure element is present.
 #[cfg(feature = "se050")]
@@ -256,24 +261,55 @@ impl Stage1 {
     }
 
     fn init_rgb(&mut self, ctimer: PwmTimer) -> RgbLed {
-        #[cfg(feature = "board-nk3xn")]
-        {
-            RgbLed::new(
-                hal::drivers::Pwm::new(ctimer.enabled(
-                    &mut self.peripherals.syscon,
-                    self.clocks.clocks.support_1mhz_fro_token().unwrap(),
-                )),
-                &mut self.clocks.iocon,
-            )
-        }
+        // The RGB LED is wired identically on the Nitrokey 3 and the Solo2.
+        RgbLed::new(
+            hal::drivers::Pwm::new(ctimer.enabled(
+                &mut self.peripherals.syscon,
+                self.clocks.clocks.support_1mhz_fro_token().unwrap(),
+            )),
+            &mut self.clocks.iocon,
+        )
     }
 
+    // The Nitrokey 3 single-GPIO button.
+    #[cfg(not(feature = "board-solo2"))]
     fn init_buttons(&mut self, ctimer: ButtonsTimer) -> ThreeButtons {
         ThreeButtons::new(
             Timer::new(ctimer.enabled(
                 &mut self.peripherals.syscon,
                 self.clocks.clocks.support_1mhz_fro_token().unwrap(),
             )),
+            &mut self.clocks.gpio,
+            &mut self.clocks.iocon,
+        )
+    }
+
+    // The Solo2's three capacitive touch pads, driven by the ADC, one DMA
+    // channel, Ctimer1 (charge/sample trigger) and Ctimer2 (sample correlation).
+    #[cfg(feature = "board-solo2")]
+    fn init_touch_buttons(
+        &mut self,
+        adc: hal::Adc<Enabled>,
+        adc_timer: ctimer::Ctimer1,
+        sample_timer: ctimer::Ctimer2,
+        dma: hal::Dma<Unknown>,
+    ) -> ThreeButtons {
+        let touch_token = self.clocks.clocks.support_touch_token().unwrap();
+        let adc_timer = adc_timer.enabled(
+            &mut self.peripherals.syscon,
+            self.clocks.clocks.support_1mhz_fro_token().unwrap(),
+        );
+        let sample_timer = sample_timer.enabled(
+            &mut self.peripherals.syscon,
+            self.clocks.clocks.support_1mhz_fro_token().unwrap(),
+        );
+        let mut dma = dma.enabled(&mut self.peripherals.syscon);
+        ThreeButtons::new(
+            adc,
+            adc_timer,
+            sample_timer,
+            &mut dma,
+            touch_token,
             &mut self.clocks.gpio,
             &mut self.clocks.iocon,
         )
@@ -289,6 +325,8 @@ impl Stage1 {
         ctimer2: ctimer::Ctimer2,
         ctimer3: ctimer::Ctimer3,
         perf_timer: ctimer::Ctimer4,
+        // Only the Solo2 touch buttons use DMA; unused on the Nitrokey 3.
+        #[allow(unused_variables)] dma: hal::Dma<Unknown>,
         pfr: Pfr<Unknown>,
         secure_firmware_version: Option<u32>,
         require_prince: bool,
@@ -324,8 +362,19 @@ impl Stage1 {
 
         let mut rgb = self.init_rgb(ctimer3);
 
+        // Nitrokey 3: single GPIO button.
+        #[cfg(not(feature = "board-solo2"))]
         let mut three_buttons = if !self.clocks.is_nfc_passive {
             Some(self.init_buttons(ctimer1))
+        } else {
+            None
+        };
+        // Solo2: three capacitive touch pads (see `init_touch_buttons`). Only
+        // built in active (USB) mode; in passive NFC mode the ADC drives the
+        // clock controller instead, exactly as on the Nitrokey 3.
+        #[cfg(feature = "board-solo2")]
+        let mut three_buttons = if !self.clocks.is_nfc_passive {
+            Some(self.init_touch_buttons(adc.take().unwrap(), ctimer1, ctimer2, dma))
         } else {
             None
         };

--- a/runners/embedded/src/nk3xn/init.rs
+++ b/runners/embedded/src/nk3xn/init.rs
@@ -6,12 +6,11 @@ use boards::{
     flash::ExtFlashStorage,
     init::{self, UsbNfc, UsbResources},
     nk3xn::{
-        button::ThreeButtons,
         led::RgbLed,
         nfc::{self, NfcChip},
         prince,
         spi::{self, FlashCs, FlashCsPin, Spi, SpiConfig},
-        ButtonsTimer, InternalFlashStorage, NK3xN, PwmTimer, I2C,
+        InternalFlashStorage, NK3xN, PwmTimer,
     },
     soc::{
         lpc55::{clock_controller::DynamicClockController, Lpc55},
@@ -25,10 +24,10 @@ use boards::{
     },
     Apps, Trussed,
 };
-use embedded_hal::{
-    blocking::i2c::{Read, Write},
-    timer::{Cancel, CountDown},
-};
+// The blocking I2C traits are only used to talk to the SE050 secure element.
+#[cfg(feature = "se050")]
+use embedded_hal::blocking::i2c::{Read, Write};
+use embedded_hal::timer::{Cancel, CountDown};
 use hal::{
     drivers::{
         clocks,
@@ -66,6 +65,11 @@ use trussed_core::types::Location;
 use utils::OptionalStorage;
 #[cfg(feature = "se050")]
 use {boards::nk3xn::TimerDelay, se05x::embedded_hal::Hal027};
+
+use boards::nk3xn::{button::ThreeButtons, ButtonsTimer};
+// The SE050 I2C bus only exists when the secure element is present.
+#[cfg(feature = "se050")]
+use boards::nk3xn::I2C;
 
 use crate::{VERSION, VERSION_STRING};
 
@@ -265,17 +269,14 @@ impl Stage1 {
     }
 
     fn init_buttons(&mut self, ctimer: ButtonsTimer) -> ThreeButtons {
-        #[cfg(feature = "board-nk3xn")]
-        {
-            ThreeButtons::new(
-                Timer::new(ctimer.enabled(
-                    &mut self.peripherals.syscon,
-                    self.clocks.clocks.support_1mhz_fro_token().unwrap(),
-                )),
-                &mut self.clocks.gpio,
-                &mut self.clocks.iocon,
-            )
-        }
+        ThreeButtons::new(
+            Timer::new(ctimer.enabled(
+                &mut self.peripherals.syscon,
+                self.clocks.clocks.support_1mhz_fro_token().unwrap(),
+            )),
+            &mut self.clocks.gpio,
+            &mut self.clocks.iocon,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -309,6 +310,10 @@ impl Stage1 {
         let mut delay_timer = Timer::new(
             delay_timer.enabled(syscon, self.clocks.clocks.support_1mhz_fro_token().unwrap()),
         );
+        // The SE050 timer and the Solo2 touch sample timer both need Ctimer2, so
+        // only one of them is built. On the Solo2 (no SE050) Ctimer2 is consumed
+        // by the touch buttons below instead.
+        #[cfg(feature = "se050")]
         let se050_timer = Timer::new(
             ctimer2.enabled(syscon, self.clocks.clocks.support_1mhz_fro_token().unwrap()),
         );
@@ -355,6 +360,7 @@ impl Stage1 {
             status: self.status,
             peripherals: self.peripherals,
             clocks: self.clocks,
+            #[cfg(feature = "se050")]
             se050_timer,
             basic,
             wwdt: self.wwdt,
@@ -367,6 +373,7 @@ pub struct Stage2 {
     peripherals: Peripherals,
     clocks: Clocks,
     basic: Basic,
+    #[cfg(feature = "se050")]
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
     wwdt: EnabledWwdt,
 }
@@ -413,6 +420,7 @@ impl Stage2 {
         Some(iso14443)
     }
 
+    #[cfg(feature = "se050")]
     fn get_se050_i2c(&mut self, flexcomm5: Flexcomm5<Unknown>) -> I2C {
         // SE050 check
         let _enabled = pins::Pio1_26::take()
@@ -473,7 +481,11 @@ impl Stage2 {
         static NFC_CHANNEL: CcidChannel = Channel::new();
         let (nfc_rq, nfc_rp) = NFC_CHANNEL.split().unwrap();
 
+        #[cfg(feature = "se050")]
         let se050_i2c = (!self.clocks.is_nfc_passive).then(|| self.get_se050_i2c(flexcomm5));
+        // The Solo2 has no SE050; Flexcomm5 (the SE050 I2C bus) is unused.
+        #[cfg(not(feature = "se050"))]
+        let _ = flexcomm5;
 
         let use_nfc = nfc_enabled && (cfg!(feature = "provisioner") || self.clocks.is_nfc_passive);
         let (nfc, spi) = if use_nfc {
@@ -493,7 +505,9 @@ impl Stage2 {
             nfc,
             nfc_rp,
             spi,
+            #[cfg(feature = "se050")]
             se050_timer: self.se050_timer,
+            #[cfg(feature = "se050")]
             se050_i2c,
             wwdt: self.wwdt,
         }
@@ -508,7 +522,9 @@ pub struct Stage3 {
     nfc: Option<Iso14443<NfcChip>>,
     nfc_rp: CcidResponder<'static>,
     spi: Option<Spi>,
+    #[cfg(feature = "se050")]
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
+    #[cfg(feature = "se050")]
     se050_i2c: Option<I2C>,
     wwdt: EnabledWwdt,
 }
@@ -545,7 +561,9 @@ impl Stage3 {
             nfc: self.nfc,
             nfc_rp: self.nfc_rp,
             spi: self.spi,
+            #[cfg(feature = "se050")]
             se050_timer: self.se050_timer,
+            #[cfg(feature = "se050")]
             se050_i2c: self.se050_i2c,
             flash,
             wwdt: self.wwdt,
@@ -562,7 +580,9 @@ pub struct Stage4 {
     nfc_rp: CcidResponder<'static>,
     spi: Option<Spi>,
     flash: Flash,
+    #[cfg(feature = "se050")]
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
+    #[cfg(feature = "se050")]
     se050_i2c: Option<I2C>,
     wwdt: EnabledWwdt,
 }
@@ -666,7 +686,9 @@ impl Stage4 {
             rng: self.flash.rng,
             nfc: self.nfc,
             nfc_rp: self.nfc_rp,
+            #[cfg(feature = "se050")]
             se050_timer: self.se050_timer,
+            #[cfg(feature = "se050")]
             se050_i2c: self.se050_i2c,
             store,
             wwdt: self.wwdt,
@@ -717,7 +739,9 @@ pub struct Stage5 {
     nfc_rp: CcidResponder<'static>,
     rng: Rng<Enabled>,
     store: RunnerStore<NK3xN>,
+    #[cfg(feature = "se050")]
     se050_timer: Timer<ctimer::Ctimer2<Enabled>>,
+    #[cfg(feature = "se050")]
     se050_i2c: Option<I2C>,
     wwdt: EnabledWwdt,
 }
@@ -752,12 +776,6 @@ impl Stage5 {
             self.se050_i2c
                 .map(|i2c| (Hal027(i2c), Hal027(TimerDelay(self.se050_timer)))),
         );
-
-        #[cfg(not(feature = "se050"))]
-        {
-            let _ = self.se050_timer;
-            let _ = self.se050_i2c;
-        }
 
         Stage6 {
             status: self.status,


### PR DESCRIPTION
## Summary

Adds a `board-solo2` target that runs the Nitrokey 3 LPC55 firmware on the SoloKeys Solo2 — same LPC55S69 SoC, capacitive touch buttons instead of the GPIO button, and no SE050. Verified end-to-end on real Solo2 hardware. The Solo2 keeps the Nitrokey 3 USB identity (VID/PID `0x20A0`/`0x42B2`), so `nitropy` and Nitrokey App detect it normally.

## How it's structured

Split so the shared-code changes stand on their own as general improvements, with everything Solo2-specific isolated behind the `board-solo2` feature:

- **apps: allow builds without the se050 backend** — the release `validate_mechanisms` check assumed the SE050 is always present on LPC55; this makes it hold for a backend-less build (also relevant to `trussed-usbip`). *No Solo2 references.*
- **runners/embedded: make the LPC55 init build without SE050** — gates the SE050 timer/I²C wiring behind `#[cfg(se050)]`. *No Solo2 references.*
- **boards: add board-solo2 with capacitive touch buttons** — new `button_touch.rs`, a port of the upstream `solokeys/solo2` touch driver adapted to this repo's `ui::buttons` traits; selected by cfg on the existing `NK3xN` board type.
- **runners/embedded: wire up the board-solo2 build target** — `board-solo2` feature (no `se050`), Makefile target, memory regions.
- **boards: accept Winbond external flash on the Solo2** — the Solo2 ships Winbond W25Q16JV (JEDEC `0xEF`) rather than GigaDevice `0xC8`; both are now accepted.
- **ci: build board-solo2 as a non-blocking job** — `allow_failure` job so the target keeps building without gating CI.
- **docs** — `docs/solo2.md` (build/flash, hardware notes, self-signed secure boot, caveats) + the USB product-string labelling.

## Verified on hardware (Solo 2 "Security Key" Hacker)

`nitropy nk3 test` → `init_status 0`; FIDO2 (USB + NFC), OATH/TOTP (codes match an independent implementation), capacitive-touch user presence, and the internal (PRINCE-encrypted) + external filesystems all work. Regression: `board-nk3xn` still builds unchanged.

## Caveats

- **No SE050** → SE050-only mechanisms (P384, P521, Brainpool, Secp256k1) are unavailable and error at runtime, same as the `usbip` runner. Everything used by FIDO2 / PIV / OpenPGP (P256, Ed25519, X25519, RSA via `backend-rsa`, …) is unaffected.
- **Secure boot** is user-managed (self-signed with your own root, documented in `docs/solo2.md`); it is not provisioned with Nitrokey keys.

## Note to maintainers

I realise the Solo2 isn't a Nitrokey product and you may not want to carry support for hardware you don't ship — no hard feelings if it isn't a fit. It's kept deliberately non-invasive (cfg-gated; the shared changes are general improvements) so it rebases cleanly and is easy to maintain as a fork tracking `main` if you'd rather not merge. Happy to split further or drop the CI/docs commits if that helps.